### PR TITLE
Fixed wrong calculation of date in mock data

### DIFF
--- a/portal-api/api-tests/fixtures/deal-fully-completed-issued-and-unissued-facilities.js
+++ b/portal-api/api-tests/fixtures/deal-fully-completed-issued-and-unissued-facilities.js
@@ -1,8 +1,6 @@
 const moment = require('moment');
 const dealFullyCompleted = require('./deal-fully-completed');
 
-const now = moment();
-
 const deal = {
   ...dealFullyCompleted,
   mockFacilities: [

--- a/portal-api/api-tests/fixtures/deal-fully-completed.js
+++ b/portal-api/api-tests/fixtures/deal-fully-completed.js
@@ -1,7 +1,5 @@
 const moment = require('moment');
 
-const now = moment();
-
 const deal = {
   details: {
     bankSupplyContractName: 'mock name',
@@ -43,9 +41,9 @@ const deal = {
       facilityStage: 'Issued',
       ukefGuaranteeInMonths: '12',
       requestedCoverStartDate: moment().utc().valueOf(),
-      'coverEndDate-day': `${now.add(1, 'month').format('DD')}`,
-      'coverEndDate-month': `${now.add(1, 'month').format('MM')}`,
-      'coverEndDate-year': `${now.add(1, 'month').format('YYYY')}`,
+      'coverEndDate-day': `${moment().add(1, 'month').format('DD')}`,
+      'coverEndDate-month': `${moment().add(1, 'month').format('MM')}`,
+      'coverEndDate-year': `${moment().add(1, 'month').format('YYYY')}`,
       uniqueIdentificationNumber: '1234567890',
       bondBeneficiary: 'test',
       status: 'Completed',
@@ -75,9 +73,9 @@ const deal = {
       facilityStage: 'Issued',
       ukefGuaranteeInMonths: '12',
       requestedCoverStartDate: moment().utc().valueOf(),
-      'coverEndDate-day': `${now.add(1, 'month').format('DD')}`,
-      'coverEndDate-month': `${now.add(1, 'month').format('MM')}`,
-      'coverEndDate-year': `${now.add(1, 'month').format('YYYY')}`,
+      'coverEndDate-day': `${moment().add(1, 'month').format('DD')}`,
+      'coverEndDate-month': `${moment().add(1, 'month').format('MM')}`,
+      'coverEndDate-year': `${moment().add(1, 'month').format('YYYY')}`,
       uniqueIdentificationNumber: '1234567890',
       bondBeneficiary: 'test',
       status: 'Completed',
@@ -290,9 +288,9 @@ const deal = {
       facilityType: 'loan',
       facilityStage: 'Unconditional',
       requestedCoverStartDate: moment().utc().valueOf(),
-      'coverEndDate-day': `${now.add(1, 'month').format('DD')}`,
-      'coverEndDate-month': `${now.add(1, 'month').format('MM')}`,
-      'coverEndDate-year': `${now.add(1, 'month').format('YYYY')}`,
+      'coverEndDate-day': `${moment().add(1, 'month').format('DD')}`,
+      'coverEndDate-month': `${moment().add(1, 'month').format('MM')}`,
+      'coverEndDate-year': `${moment().add(1, 'month').format('YYYY')}`,
       bankReferenceNumber: '12345678',
       guaranteeFeePayableByBank: '10.8000',
       ukefExposure: '3,703,703.40',

--- a/portal-api/src/v1/controllers/integration/helpers/calculate-facility-conversion-date.js
+++ b/portal-api/src/v1/controllers/integration/helpers/calculate-facility-conversion-date.js
@@ -4,9 +4,6 @@ const calculateFacilityConversionDate = (facility, dealCurrency) => {
   if (facility.currencySameAsSupplyContractCurrency === 'true' || facility.currency.id === dealCurrency) {
     return '';
   }
-  console.log('CONVERSION',
-    facility['conversionRateDate-day'], facility['conversionRateDate-month'], facility['conversionRateDate-year'],
-    dateHelpers.formatDate(facility['conversionRateDate-day'], facility['conversionRateDate-month'], facility['conversionRateDate-year']));
 
   return dateHelpers.formatDate(facility['conversionRateDate-day'], facility['conversionRateDate-month'], facility['conversionRateDate-year']);
 };


### PR DESCRIPTION
There was an issue creating the requestedCoverEndDate so today it was calculating one of the facilities as having an endDate of 29/02/2022.

This was due to referencing the same now variable in several places as adding/subtracting days/months/years to calculate a date. Each respective add/subtract would use the value left from the previous one rather than based on todays date.

