### PR TITLE
DTFS2-4524 - add submission data to GEF deals & facilities

### DIFF
--- a/portal-api/api-tests/api.js
+++ b/portal-api/api-tests/api.js
@@ -54,9 +54,10 @@ module.exports = (app) => ({
         },
       }),
 
-      get: async (url) => request(app)
+      get: async (url, query = {}) => request(app)
         .get(url)
-        .set({ Authorization: token || '' }),
+        .set({ Authorization: token || '' })
+        .query(query),
 
       remove: async (url) => request(app)
         .delete(url)

--- a/portal-api/api-tests/fixtures/gef/application.js
+++ b/portal-api/api-tests/fixtures/gef/application.js
@@ -9,6 +9,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -20,6 +21,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -31,6 +33,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -42,6 +45,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -53,6 +57,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -64,6 +69,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -75,6 +81,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -86,6 +93,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -97,6 +105,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -108,6 +117,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -119,6 +129,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -130,6 +141,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -141,6 +153,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -152,6 +165,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }, {
   userId: null,
   bankId: null,
@@ -163,6 +177,7 @@ const APPLICATION = [{
   mandatoryVersionId: '123',
   status: 'IN_PROGRESS',
   updatedAt: null,
+  submissionCount: 0,
 }];
 
 module.exports = APPLICATION;

--- a/portal-api/api-tests/fixtures/gef/facilities.js
+++ b/portal-api/api-tests/fixtures/gef/facilities.js
@@ -1,6 +1,5 @@
 const FACILITIES = [
-  [{
-    applicationId: 'IGNORE_POST-POPULATED',
+  {
     type: 'CASH',
     hasBeenIssued: true,
     name: null,
@@ -16,7 +15,6 @@ const FACILITIES = [
     interestPercentage: null,
     paymentType: null,
   }, {
-    applicationId: 'IGNORE_POST-POPULATED',
     type: 'CASH',
     hasBeenIssued: false,
     name: null,
@@ -32,7 +30,6 @@ const FACILITIES = [
     interestPercentage: null,
     paymentType: null,
   }, {
-    applicationId: 'IGNORE_POST-POPULATED',
     type: 'CONTINGENT',
     hasBeenIssued: true,
     name: null,
@@ -47,7 +44,7 @@ const FACILITIES = [
     coverPercentage: null,
     interestPercentage: null,
     paymentType: null,
-  }],
+  },
 ];
 
 module.exports = FACILITIES;

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -243,7 +243,7 @@ describe(baseUrl, () => {
       expect(status).toEqual(200);
     });
 
-    it('returns a enum error if I send an incorrect status', async () => {
+    it('returns a enum error if an incorrect status is sent', async () => {
       const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
       const res = await as(aMaker).put({ status: 'NOT_A_STATUS' }).to(`${baseUrl}/status/${body._id}`);
       expect(res.status).toEqual(422);
@@ -254,9 +254,20 @@ describe(baseUrl, () => {
       }]);
     });
 
-    it('returns a 204 - "No Content" if there are no records', async () => {
+    describe('when new status is `SUBMITTED_TO_UKEF`', () => {
+      it('increases submissionCount', async () => {
+        const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+        expect(body.submissionCount).toEqual(0);
+
+        const putResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
+        expect(putResponse.status).toEqual(200);
+        expect(putResponse.body.submissionCount).toEqual(1);
+      });
+    });
+
+    it('returns a 404 when application does not exist', async () => {
       const { status } = await as(aMaker).put({ status: 'COMPLETED' }).to(`${baseUrl}/status/doesnotexist`);
-      expect(status).toEqual(204);
+      expect(status).toEqual(404);
     });
   });
 

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -10,8 +10,10 @@ const { expectMongoId } = require('../../expectMongoIds');
 
 const baseUrl = '/v1/gef/application';
 const collectionName = 'gef-application';
+const mockApplications = require('../../fixtures/gef/application');
 
-const allItems = require('../../fixtures/gef/application');
+const facilitiesUrl = '/v1/gef/facilities';
+const mockFacilities = require('../../fixtures/gef/facilities');
 
 describe(baseUrl, () => {
   // let noRoles;
@@ -38,26 +40,26 @@ describe(baseUrl, () => {
     });
 
     it('returns list of all items', async () => {
-      await as(aMaker).post(allItems[0]).to(baseUrl);
-      await as(aMaker).post(allItems[1]).to(baseUrl);
-      await as(aMaker).post(allItems[2]).to(baseUrl);
-      await as(aMaker).post(allItems[3]).to(baseUrl);
-      await as(aMaker).post(allItems[4]).to(baseUrl);
-      await as(aMaker).post(allItems[5]).to(baseUrl);
-      await as(aMaker).post(allItems[6]).to(baseUrl);
-      await as(aMaker).post(allItems[7]).to(baseUrl);
-      await as(aMaker).post(allItems[8]).to(baseUrl);
-      await as(aMaker).post(allItems[9]).to(baseUrl);
-      await as(aMaker).post(allItems[10]).to(baseUrl);
-      await as(aMaker).post(allItems[11]).to(baseUrl);
-      await as(aMaker).post(allItems[12]).to(baseUrl);
-      await as(aMaker).post(allItems[13]).to(baseUrl);
-      await as(aMaker).post(allItems[14]).to(baseUrl);
-      await as(aMaker).post(allItems[15]).to(baseUrl);
+      await as(aMaker).post(mockApplications[0]).to(baseUrl);
+      await as(aMaker).post(mockApplications[1]).to(baseUrl);
+      await as(aMaker).post(mockApplications[2]).to(baseUrl);
+      await as(aMaker).post(mockApplications[3]).to(baseUrl);
+      await as(aMaker).post(mockApplications[4]).to(baseUrl);
+      await as(aMaker).post(mockApplications[5]).to(baseUrl);
+      await as(aMaker).post(mockApplications[6]).to(baseUrl);
+      await as(aMaker).post(mockApplications[7]).to(baseUrl);
+      await as(aMaker).post(mockApplications[8]).to(baseUrl);
+      await as(aMaker).post(mockApplications[9]).to(baseUrl);
+      await as(aMaker).post(mockApplications[10]).to(baseUrl);
+      await as(aMaker).post(mockApplications[11]).to(baseUrl);
+      await as(aMaker).post(mockApplications[12]).to(baseUrl);
+      await as(aMaker).post(mockApplications[13]).to(baseUrl);
+      await as(aMaker).post(mockApplications[14]).to(baseUrl);
+      await as(aMaker).post(mockApplications[15]).to(baseUrl);
 
 
       // MW: couldn't get the promise.all running in sequential order
-      // await allItems.map(async (item) => {
+      // await mockApplications.map(async (item) => {
       //   return as(aMaker).post(item).to(baseUrl);
       // })
 
@@ -66,7 +68,7 @@ describe(baseUrl, () => {
       const { body, status } = await as(aChecker).get(baseUrl);
 
       const expected = {
-        items: allItems.map((item) => ({
+        items: mockApplications.map((item) => ({
           ...expectMongoId(item),
           exporterId: expect.any(String),
           coverTermsId: expect.any(String),
@@ -91,16 +93,16 @@ describe(baseUrl, () => {
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const item = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const item = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const { status } = await as(aMaker).get(`${baseUrl}/${item.body._id}`);
       expect(status).toEqual(200);
     });
 
     it('returns an individual item', async () => {
-      const item = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const item = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const { body } = await as(aMaker).get(`${baseUrl}/${item.body._id}`);
       const expected = {
-        ...allItems[0],
+        ...mockApplications[0],
         exporterId: expect.any(String),
         coverTermsId: expect.any(String),
         status: 'Draft',
@@ -126,13 +128,13 @@ describe(baseUrl, () => {
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const item = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const item = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const { status } = await as(aMaker).get(`${baseUrl}/status/${item.body._id}`);
       expect(status).toEqual(200);
     });
 
     it('returns a status', async () => {
-      const item = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const item = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const { body } = await as(aMaker).get(`${baseUrl}/status/${item.body._id}`);
       expect(body).toEqual({ status: 'Draft' });
     });
@@ -145,19 +147,19 @@ describe(baseUrl, () => {
 
   describe(`POST ${baseUrl}`, () => {
     it('rejects requests that do not present a valid Authorization token', async () => {
-      const { status } = await as().post(allItems[0]).to(baseUrl);
+      const { status } = await as().post(mockApplications[0]).to(baseUrl);
       expect(status).toEqual(401);
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const { status } = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const { status } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       expect(status).toEqual(201);
     });
 
     it('returns a new application upon creation', async () => {
-      const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const expected = {
-        ...allItems[0],
+        ...mockApplications[0],
         exporterId: expect.any(String),
         coverTermsId: expect.any(String),
         status: 'Draft',
@@ -171,8 +173,8 @@ describe(baseUrl, () => {
     });
 
     it('it returns a duplicate error in the system the item I created an application of the same reference', async () => {
-      await as(aMaker).post(allItems[0]).to(baseUrl); // 1st instance
-      const { status, body } = await as(aMaker).post(allItems[0]).to(baseUrl); // 2nd instance
+      await as(aMaker).post(mockApplications[0]).to(baseUrl); // 1st instance
+      const { status, body } = await as(aMaker).post(mockApplications[0]).to(baseUrl); // 2nd instance
       expect(body).toEqual([{
         errCode: 'ALREADY_EXISTS',
         errRef: 'bankInternalRefName',
@@ -183,7 +185,7 @@ describe(baseUrl, () => {
 
     it('it tells me the Bank Internal Ref Name is null', async () => {
       const removeName = {
-        ...allItems[0],
+        ...mockApplications[0],
         bankInternalRefName: null,
       };
       const { body, status } = await as(aMaker).post(removeName).to(baseUrl);
@@ -197,7 +199,7 @@ describe(baseUrl, () => {
 
     it('it tells me the Bank Internal Ref Name is an empty string', async () => {
       const removeName = {
-        ...allItems[0],
+        ...mockApplications[0],
         bankInternalRefName: '',
       };
       const { body, status } = await as(aMaker).post(removeName).to(baseUrl);
@@ -212,7 +214,7 @@ describe(baseUrl, () => {
 
   describe(`PUT ${baseUrl}/:id`, () => {
     const updated = {
-      ...allItems[0],
+      ...mockApplications[0],
       bankInternalRefName: 'Updated Ref Name (Unit Test)',
       submissionType: 'Automatic Inclusion Notice',
     };
@@ -223,7 +225,7 @@ describe(baseUrl, () => {
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const { status } = await as(aMaker).put(updated).to(`${baseUrl}/${body._id}`);
       expect(status).toEqual(200);
     });
@@ -241,13 +243,13 @@ describe(baseUrl, () => {
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const { status } = await as(aMaker).put({ status: 'COMPLETED' }).to(`${baseUrl}/status/${body._id}`);
       expect(status).toEqual(200);
     });
 
     it('returns a enum error if an incorrect status is sent', async () => {
-      const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+      const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
       const res = await as(aMaker).put({ status: 'NOT_A_STATUS' }).to(`${baseUrl}/status/${body._id}`);
       expect(res.status).toEqual(422);
       expect(res.body).toEqual([{
@@ -259,7 +261,7 @@ describe(baseUrl, () => {
 
     describe('when new status is `SUBMITTED_TO_UKEF`', () => {
       it('increases submissionCount', async () => {
-        const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+        const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
         expect(body.submissionCount).toEqual(0);
 
         const putResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
@@ -268,7 +270,7 @@ describe(baseUrl, () => {
       });
 
       it('adds submissionDate', async () => {
-        const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+        const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
 
         const putResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
         expect(putResponse.status).toEqual(200);
@@ -276,7 +278,7 @@ describe(baseUrl, () => {
       });
 
       it('does NOT add submissionDate if already exists', async () => {
-        const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+        const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
 
         const firstPutResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
         expect(firstPutResponse.status).toEqual(200);
@@ -284,10 +286,36 @@ describe(baseUrl, () => {
         const initialSubmissionDate = firstPutResponse.body.submissionDate;
         expect(firstPutResponse.body.submissionDate).toEqual(expect.any(String));
 
+        // submit again, check that the submissionDate has not changed.
         const secondPutResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
         expect(secondPutResponse.status).toEqual(200);
 
         expect(secondPutResponse.body.submissionDate).toEqual(initialSubmissionDate);
+      });
+
+      it('adds submittedAsIssuedDate to each issued facility associated with the application', async () => {
+        // create deal
+        const { body } = await as(aMaker).post(mockApplications[0]).to(baseUrl);
+        const applicationId = body._id;
+
+        // create issued facility that's associated with the deal
+        const issuedFacility = mockFacilities.find((f) => f.hasBeenIssued === true);
+        const createFacilityResponse = await as(aMaker).post({ applicationId, ...issuedFacility }).to(facilitiesUrl);
+        expect(createFacilityResponse.status).toEqual(201);
+
+        const facilityId = createFacilityResponse.body.details._id;
+
+        // check that the facility does not already have submittedAsIssuedDate
+        expect(createFacilityResponse.body.details.submittedAsIssuedDate).toEqual(null);
+
+        // change deal status to submitted
+        const putResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
+        expect(putResponse.status).toEqual(200);
+
+        // check that the facility has updated submittedAsIssuedDate
+        const getFacilityResponse = await as(aMaker).get(`${facilitiesUrl}/${facilityId}`);
+        expect(getFacilityResponse.status).toEqual(200);
+        expect(getFacilityResponse.body.details.submittedAsIssuedDate).toEqual(expect.any(String));
       });
     });
 
@@ -304,7 +332,7 @@ describe(baseUrl, () => {
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const { body } = await as(aMaker).post(allItems[0]).to(`${baseUrl}`);
+      const { body } = await as(aMaker).post(mockApplications[0]).to(`${baseUrl}`);
       const { status } = await as(aMaker).remove(`${baseUrl}/${String(body._id)}`);
       expect(status).toEqual(200);
       expect(body).not.toEqual({ success: false, msg: "you don't have the right role" });

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -73,8 +73,9 @@ describe(baseUrl, () => {
           createdAt: expect.any(Number),  
           status: 'Draft',
           dealType: 'GEF',
-          submissionCount: 0,
           submissionType: null,
+          submissionCount: 0,
+          submissionDate: null,
         })),
       };
 
@@ -105,8 +106,9 @@ describe(baseUrl, () => {
         status: 'Draft',
         createdAt: expect.any(Number),
         dealType: 'GEF',
-        submissionCount: 0,
         submissionType: null,
+        submissionCount: 0,
+        submissionDate: null,
       };
       expect(body).toEqual(expectMongoId(expected));
     });
@@ -152,7 +154,7 @@ describe(baseUrl, () => {
       expect(status).toEqual(201);
     });
 
-    it('returns me a new application upon creation', async () => {
+    it('returns a new application upon creation', async () => {
       const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
       const expected = {
         ...allItems[0],
@@ -161,8 +163,9 @@ describe(baseUrl, () => {
         status: 'Draft',
         createdAt: expect.any(Number),
         dealType: 'GEF',
-        submissionCount: 0,
         submissionType: null,
+        submissionCount: 0,
+        submissionDate: null,
       };
       expect(body).toEqual(expectMongoId(expected));
     });
@@ -262,6 +265,29 @@ describe(baseUrl, () => {
         const putResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
         expect(putResponse.status).toEqual(200);
         expect(putResponse.body.submissionCount).toEqual(1);
+      });
+
+      it('adds submissionDate', async () => {
+        const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+
+        const putResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
+        expect(putResponse.status).toEqual(200);
+        expect(putResponse.body.submissionDate).toEqual(expect.any(String));
+      });
+
+      it('does NOT add submissionDate if already exists', async () => {
+        const { body } = await as(aMaker).post(allItems[0]).to(baseUrl);
+
+        const firstPutResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
+        expect(firstPutResponse.status).toEqual(200);
+
+        const initialSubmissionDate = firstPutResponse.body.submissionDate;
+        expect(firstPutResponse.body.submissionDate).toEqual(expect.any(String));
+
+        const secondPutResponse = await as(aMaker).put({ status: 'SUBMITTED_TO_UKEF' }).to(`${baseUrl}/status/${body._id}`);
+        expect(secondPutResponse.status).toEqual(200);
+
+        expect(secondPutResponse.body.submissionDate).toEqual(initialSubmissionDate);
       });
     });
 

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -194,7 +194,7 @@ describe(baseUrl, () => {
       expect(status).toEqual(401);
     });
 
-    it('partially update a facility ', async () => {
+    it('partially updates a facility ', async () => {
       const { details } = newFacility;
       const update = {
         hasBeenIssued: false,

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -56,6 +56,7 @@ describe(baseUrl, () => {
         createdAt: expect.any(Number),
         updatedAt: expect.any(Number),
         ukefExposure: 0,
+        submittedAsIssuedDate: null,
       },
       validation: {
         required: ['name', 'monthsOfCover', 'details', 'currency', 'value', 'coverPercentage', 'interestPercentage'],
@@ -102,7 +103,9 @@ describe(baseUrl, () => {
         hasBeenIssued: false,
       }).to(baseUrl);
 
-      const { body, status } = await as(aChecker).get(baseUrl);
+      const mockQuery = { applicationId: applicationItem.body._id };
+
+      const { body, status } = await as(aChecker).get(baseUrl, mockQuery);
 
       expect(body).toEqual({ status: STATUS.IN_PROGRESS, items: [newFacility, newFacility] });
       expect(status).toEqual(200);
@@ -365,7 +368,10 @@ describe(baseUrl, () => {
       await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-      const { body, status } = await as(aMaker).get(baseUrl);
+
+      const mockQuery = { applicationId: applicationItem.body._id };
+      const { body, status } = await as(aMaker).get(baseUrl, mockQuery);
+
       expect(status).toEqual(200);
       expect(body.status).toEqual(STATUS.IN_PROGRESS);
       expect(body).not.toEqual({ success: false, msg: "you don't have the right role" });
@@ -376,7 +382,10 @@ describe(baseUrl, () => {
       const item3 = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       await as(aMaker).put({ name: 'test' }).to(`${baseUrl}/${item1.body.details._id}`);
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item3.body.details._id}`);
-      const { body, status } = await as(aMaker).get(baseUrl);
+
+      const mockQuery = { applicationId: applicationItem.body._id };
+      const { body, status } = await as(aMaker).get(baseUrl, mockQuery);
+
       expect(status).toEqual(200);
       expect(body.status).toEqual(STATUS.IN_PROGRESS);
       expect(body).not.toEqual({ success: false, msg: "you don't have the right role" });
@@ -389,7 +398,10 @@ describe(baseUrl, () => {
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item1.body.details._id}`);
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item2.body.details._id}`);
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item3.body.details._id}`);
-      const { body, status } = await as(aMaker).get(baseUrl);
+
+      const mockQuery = { applicationId: applicationItem.body._id };
+      const { body, status } = await as(aMaker).get(baseUrl, mockQuery);
+
       expect(status).toEqual(200);
       expect(body.status).toEqual(STATUS.COMPLETED);
       expect(body).not.toEqual({ success: false, msg: "you don't have the right role" });

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -11,11 +11,11 @@ const { as } = require('../../api')(app);
 
 const baseUrl = '/v1/gef/facilities';
 const collectionName = 'gef-facilities';
-const allItems = require('../../fixtures/gef/facilities');
+const mockFacilities = require('../../fixtures/gef/facilities');
 
 const applicationCollectionName = 'gef-application';
 const applicationBaseUrl = '/v1/gef/application';
-const applicationAllItems = require('../../fixtures/gef/application');
+const mockApplications = require('../../fixtures/gef/application');
 const { calculateUkefExposure } = require('../../../src/v1/gef/controllers/facilities.controller');
 
 describe(baseUrl, () => {
@@ -23,7 +23,7 @@ describe(baseUrl, () => {
   let aMaker;
   let aChecker;
   // let anEditor;
-  let applicationItem;
+  let mockApplication;
   let newFacility;
   let completeUpdate;
 
@@ -33,12 +33,12 @@ describe(baseUrl, () => {
     aMaker = testUsers().withRole('maker').one();
     aChecker = testUsers().withRole('checker').one();
     // anEditor = testUsers().withRole('editor').one();
-    applicationItem = await as(aMaker).post(applicationAllItems[0]).to(applicationBaseUrl);
+    mockApplication = await as(aMaker).post(mockApplications[0]).to(applicationBaseUrl);
     newFacility = {
       status: STATUS.IN_PROGRESS,
       details: {
         _id: expect.any(String),
-        applicationId: applicationItem.body._id,
+        applicationId: mockApplication.body._id,
         type: expect.any(String),
         hasBeenIssued: false,
         name: null,
@@ -92,18 +92,18 @@ describe(baseUrl, () => {
 
     it('returns list of all items', async () => {
       await as(aMaker).post({
-        applicationId: applicationItem.body._id,
+        applicationId: mockApplication.body._id,
         type: FACILITY_TYPE.CASH,
         hasBeenIssued: false,
       }).to(baseUrl);
 
       await as(aMaker).post({
-        applicationId: applicationItem.body._id,
+        applicationId: mockApplication.body._id,
         type: FACILITY_TYPE.CONTINGENT,
         hasBeenIssued: false,
       }).to(baseUrl);
 
-      const mockQuery = { applicationId: applicationItem.body._id };
+      const mockQuery = { applicationId: mockApplication.body._id };
 
       const { body, status } = await as(aChecker).get(baseUrl, mockQuery);
 
@@ -113,13 +113,13 @@ describe(baseUrl, () => {
 
     it('returns list of item from the given application ID', async () => {
       await as(aMaker).post({
-        applicationId: applicationItem.body._id,
+        applicationId: mockApplication.body._id,
         type: FACILITY_TYPE.CASH,
         hasBeenIssued: false,
       }).to(baseUrl);
 
       await as(aMaker).post({
-        applicationId: applicationItem.body._id,
+        applicationId: mockApplication.body._id,
         type: FACILITY_TYPE.CONTINGENT,
         hasBeenIssued: false,
       }).to(baseUrl);
@@ -130,7 +130,7 @@ describe(baseUrl, () => {
         hasBeenIssued: false,
       }).to(baseUrl);
 
-      const { body, status } = await as(aChecker).get(`${baseUrl}?applicationId=${applicationItem.body._id}`);
+      const { body, status } = await as(aChecker).get(`${baseUrl}?applicationId=${mockApplication.body._id}`);
 
       expect(body).toEqual({ status: STATUS.IN_PROGRESS, items: [newFacility, newFacility] });
       expect(status).toEqual(200);
@@ -152,13 +152,13 @@ describe(baseUrl, () => {
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const item = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       const { status } = await as(aMaker).get(`${baseUrl}/${item.body.details._id}`);
       expect(status).toEqual(200);
     });
 
     it('returns an individual item', async () => {
-      const item = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       const { body } = await as(aMaker).get(`${baseUrl}/${item.body.details._id}`);
       expect(body).toEqual(newFacility);
     });
@@ -171,17 +171,17 @@ describe(baseUrl, () => {
 
   describe(`POST ${baseUrl}`, () => {
     it('rejects requests that do not present a valid Authorization token', async () => {
-      const { status } = await as().post(allItems[0]).to(baseUrl);
+      const { status } = await as().post(mockFacilities[0]).to(baseUrl);
       expect(status).toEqual(401);
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const { status } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const { status } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       expect(status).toEqual(201);
     });
 
     it('returns me a new application upon creation', async () => {
-      const { body } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const { body } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       expect(body).toEqual(newFacility);
     });
   });
@@ -197,15 +197,17 @@ describe(baseUrl, () => {
       expect(status).toEqual(401);
     });
 
-    it('partially updates a facility ', async () => {
+    it('partially updates a facility', async () => {
       const { details } = newFacility;
       const update = {
         hasBeenIssued: false,
         name: 'Matt',
         currency: 'GBP',
       };
-      const item = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+
       const { status, body } = await as(aMaker).put(update).to(`${baseUrl}/${item.body.details._id}`);
+
       const expected = {
         status: STATUS.IN_PROGRESS,
         details: {
@@ -231,7 +233,7 @@ describe(baseUrl, () => {
       const secondUpdate = {
         shouldCoverStartOnSubmission: true,
       };
-      const item = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
 
       // first update - insert start date
       const res1 = await as(aMaker).put(firstUpdate).to(`${baseUrl}/${item.body.details._id}`);
@@ -265,7 +267,7 @@ describe(baseUrl, () => {
         interestPercentage: 40,
         paymentType: 'IN_ADVANCE_QUARTERLY',
       };
-      const item = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       const { status, body } = await as(aMaker).put(update).to(`${baseUrl}/${item.body.details._id}`);
       const expected = {
         status: STATUS.COMPLETED,
@@ -290,7 +292,7 @@ describe(baseUrl, () => {
       const update = {
         details: ['other'],
       };
-      const item = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       const { status, body } = await as(aMaker).put(update).to(`${baseUrl}/${item.body.details._id}`);
       const expected = {
         status: STATUS.IN_PROGRESS,
@@ -310,7 +312,7 @@ describe(baseUrl, () => {
 
     it('completely update a facility ', async () => {
       const { details } = newFacility;
-      const item = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       const { status, body } = await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item.body.details._id}`);
       const expected = {
         status: STATUS.COMPLETED,
@@ -344,15 +346,15 @@ describe(baseUrl, () => {
     });
 
     it('accepts requests that present a valid Authorization token with "maker" role', async () => {
-      const { body } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const { body } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       const { status } = await as(aMaker).remove(`${baseUrl}/${String(body.details._id)}`);
       expect(status).toEqual(200);
       expect(body).not.toEqual({ success: false, msg: "you don't have the right role" });
     });
 
     it('removes all items by application ID', async () => {
-      const { body } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-      const { status } = await as(aMaker).remove(`${baseUrl}?applicationId=${applicationItem.body._id}`);
+      const { body } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const { status } = await as(aMaker).remove(`${baseUrl}?applicationId=${mockApplication.body._id}`);
       expect(status).toEqual(200);
       expect(body).not.toEqual({ success: false, msg: "you don't have the right role" });
     });
@@ -365,11 +367,11 @@ describe(baseUrl, () => {
 
   describe(`Overall Status: ${baseUrl}`, () => {
     it(`overall status shows as "${STATUS.NOT_STARTED}" if all status is marked as "${STATUS.NOT_STARTED}"`, async () => {
-      await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-      await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-      await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
 
-      const mockQuery = { applicationId: applicationItem.body._id };
+      const mockQuery = { applicationId: mockApplication.body._id };
       const { body, status } = await as(aMaker).get(baseUrl, mockQuery);
 
       expect(status).toEqual(200);
@@ -378,12 +380,12 @@ describe(baseUrl, () => {
     });
 
     it(`overall status shows as "${STATUS.IN_PROGRESS}" if some status is marked as "${STATUS.IN_PROGRESS}"`, async () => {
-      const item1 = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-      const item3 = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item1 = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item3 = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       await as(aMaker).put({ name: 'test' }).to(`${baseUrl}/${item1.body.details._id}`);
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item3.body.details._id}`);
 
-      const mockQuery = { applicationId: applicationItem.body._id };
+      const mockQuery = { applicationId: mockApplication.body._id };
       const { body, status } = await as(aMaker).get(baseUrl, mockQuery);
 
       expect(status).toEqual(200);
@@ -392,14 +394,14 @@ describe(baseUrl, () => {
     });
 
     it(`overall status shows as "${STATUS.COMPLETED}" if all status is marked as "${STATUS.COMPLETED}"`, async () => {
-      const item1 = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-      const item2 = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-      const item3 = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item1 = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item2 = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const item3 = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item1.body.details._id}`);
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item2.body.details._id}`);
       await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item3.body.details._id}`);
 
-      const mockQuery = { applicationId: applicationItem.body._id };
+      const mockQuery = { applicationId: mockApplication.body._id };
       const { body, status } = await as(aMaker).get(baseUrl, mockQuery);
 
       expect(status).toEqual(200);
@@ -411,7 +413,7 @@ describe(baseUrl, () => {
   describe('ENUM errors', () => {
     describe('POST', () => {
       it('returns an enum error when putting the wrong type', async () => {
-        const { status, body } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: 'TEST' }).to(baseUrl);
+        const { status, body } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: 'TEST' }).to(baseUrl);
         expect(status).toEqual(422);
         expect(body).toEqual([{
           errCode: ERROR.ENUM_ERROR,
@@ -420,7 +422,7 @@ describe(baseUrl, () => {
         }]);
       });
       it('returns an enum error when putting the payment type', async () => {
-        const { status, body } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: 'CASH', paymentType: 'TEST' }).to(baseUrl);
+        const { status, body } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: 'CASH', paymentType: 'TEST' }).to(baseUrl);
         expect(status).toEqual(422);
         expect(body).toEqual([{
           errCode: ERROR.ENUM_ERROR,
@@ -431,7 +433,7 @@ describe(baseUrl, () => {
     });
     describe('PUT', () => {
       it('returns an enum error when putting the wrong type', async () => {
-        const { body } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+        const { body } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
         const res = await as(aMaker).put({ paymentType: 'TEST' }).to(`${baseUrl}/${body.details._id}`);
         expect(res.status).toEqual(422);
         expect(res.body).toEqual([{
@@ -441,7 +443,7 @@ describe(baseUrl, () => {
         }]);
       });
       it('returns an enum error when putting the payment type', async () => {
-        const { body } = await as(aMaker).post({ applicationId: applicationItem.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+        const { body } = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
         const res = await as(aMaker).put({ paymentType: 'TEST' }).to(`${baseUrl}/${body.details._id}`);
         expect(res.status).toEqual(422);
         expect(res.body).toEqual([{
@@ -463,7 +465,7 @@ describe(baseUrl, () => {
       }]);
     });
     it('returns an mandator error when facilty type is missing', async () => {
-      const { status, body } = await as(aMaker).post({ applicationId: applicationItem.body._id }).to(baseUrl);
+      const { status, body } = await as(aMaker).post({ applicationId: mockApplication.body._id }).to(baseUrl);
       expect(status).toEqual(422);
       expect(body).toEqual([{
         errCode: ERROR.MANDATORY_FIELD,

--- a/portal-api/src/v1/gef/controllers/application-submit.js
+++ b/portal-api/src/v1/gef/controllers/application-submit.js
@@ -1,0 +1,51 @@
+const now = require('../../../now');
+const {
+  getAllFacilitiesByApplicationId,
+  update: updateFacility,
+} = require('./facilities.controller');
+
+const generateSubmissionData = async (existingApplication) => {
+  const result = {
+    date: existingApplication.submissionDate,
+  };
+
+  result.count = existingApplication.submissionCount + 1;
+
+  if (!existingApplication.submissionDate) {
+    result.date = now();
+  }
+
+  return result;
+};
+
+const addSubmissionDateToIssuedFacilities = async (applicationId) => {
+  const facilities = await getAllFacilitiesByApplicationId(applicationId);
+
+  facilities.forEach(async (facility) => {
+    const { _id, hasBeenIssued } = facility;
+
+    if (hasBeenIssued) {
+      const update = {
+        submittedAsIssuedDate: now(),
+      };
+
+      await updateFacility(_id, update);
+    }
+  });
+
+  return facilities;
+};
+
+
+const addSubmissionData = async (applicationId, existingApplication) => {
+  const { count, date } = await generateSubmissionData(existingApplication);
+
+  await addSubmissionDateToIssuedFacilities(applicationId);
+
+  return {
+    submissionCount: count,
+    submissionDate: date,
+  };
+};
+
+module.exports = addSubmissionData;

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -9,6 +9,7 @@ const { Application } = require('../models/application');
 const { Exporter } = require('../models/exporter');
 const { CoverTerms } = require('../models/coverTerms');
 const { STATUS } = require('../enums');
+const now = require('../../../now');
 
 const applicationCollectionName = 'gef-application';
 const exporterCollectionName = 'gef-exporter';
@@ -122,6 +123,10 @@ exports.changeStatus = async (req, res) => {
   // TODO: protect so that only a user with checker role can submit to UKEF.
   if (status === STATUS.SUBMITTED_TO_UKEF) {
     update.submissionCount = existingApplication.submissionCount + 1;
+
+    if (!existingApplication.submissionDate) {
+      update.submissionDate = now();
+    }
   }
 
   const result = await collection.findOneAndUpdate(

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -52,13 +52,15 @@ exports.getAllGET = async (req, res) => {
 
   const facilities = [];
 
-  doc.forEach((item) => {
-    facilities.push({
-      status: facilitiesStatus(item),
-      details: item,
-      validation: facilitiesValidation(item),
+  if (doc && doc.length) {
+    doc.forEach((item) => {
+      facilities.push({
+        status: facilitiesStatus(item),
+        details: item,
+        validation: facilitiesValidation(item),
+      });
     });
-  });
+  }
 
   res.status(200).send({
     status: facilitiesOverallStatus(facilities),

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -29,15 +29,29 @@ exports.create = async (req, res) => {
   }
 };
 
-exports.getAll = async (req, res) => {
+const getAllFacilitiesByApplicationId = async (applicationId) => {
   const collection = await db.getCollection(collectionName);
   let find = {};
-  if (req.query && req.query.applicationId) {
-    find = { applicationId: String(req.query.applicationId) };
+
+  if (applicationId) {
+    find = { applicationId: String(applicationId) };
   }
+
   const doc = await collection.find(find).toArray();
 
+  return doc;
+};
+exports.getAllFacilitiesByApplicationId = getAllFacilitiesByApplicationId;
+
+exports.getAllGET = async (req, res) => {
+  let doc;
+
+  if (req.query && req.query.applicationId) {
+    doc = await getAllFacilitiesByApplicationId(req.query.applicationId);
+  }
+
   const facilities = [];
+
   doc.forEach((item) => {
     facilities.push({
       status: facilitiesStatus(item),
@@ -45,6 +59,7 @@ exports.getAll = async (req, res) => {
       validation: facilitiesValidation(item),
     });
   });
+
   res.status(200).send({
     status: facilitiesOverallStatus(facilities),
     items: facilities,
@@ -101,6 +116,7 @@ const update = async (id, updateBody) => {
 
   return result;
 };
+exports.update = update;
 
 exports.updatePUT = async (req, res) => {
   const enumValidationErr = facilitiesCheckEnums(req.body);

--- a/portal-api/src/v1/gef/models/application.js
+++ b/portal-api/src/v1/gef/models/application.js
@@ -14,13 +14,16 @@ class Application {
       this.mandatoryVersionId = req.mandatoryVersionId ? String(req.mandatoryVersionId) : null;
       this.createdAt = Date.now();
       this.updatedAt = null;
-      this.submissionCount = 0;
       this.submissionType = null;
+      this.submissionCount = 0;
+      this.submissionDate = null;
     } else {
       // Update
       this.updatedAt = Date.now();
       this.comments = req.comments;
       this.submissionType = req.submissionType;
+      this.submissionCount = req.submissionCount;
+      this.submissionDate = req.submissionDate;
     }
     this.additionalRefName = req.additionalRefName ? String(req.additionalRefName) : null;
   }

--- a/portal-api/src/v1/gef/models/facilities.js
+++ b/portal-api/src/v1/gef/models/facilities.js
@@ -51,6 +51,7 @@ class Facility {
       this.createdAt = Date.now();
       this.updatedAt = Date.now();
       this.ukefExposure = 0;
+      this.submittedAsIssuedDate = null;
     } else {
       // update application
       if (req.hasBeenIssued != null) {
@@ -109,6 +110,10 @@ class Facility {
 
       if (req.ukefExposure != null) {
         this.ukefExposure = req.ukefExposure;
+      }
+
+      if (req.submittedAsIssuedDate != null) {
+        this.submittedAsIssuedDate = req.submittedAsIssuedDate;
       }
 
       // nullify values based on previous questions

--- a/portal-api/src/v1/gef/models/facilities.js
+++ b/portal-api/src/v1/gef/models/facilities.js
@@ -50,6 +50,7 @@ class Facility {
       this.paymentType = null;
       this.createdAt = Date.now();
       this.updatedAt = Date.now();
+      this.ukefExposure = 0;
     } else {
       // update application
       if (req.hasBeenIssued != null) {
@@ -104,6 +105,10 @@ class Facility {
 
       if (req.paymentType != null) {
         this.paymentType = checkPaymentType(req.paymentType);
+      }
+
+      if (req.ukefExposure != null) {
+        this.ukefExposure = req.ukefExposure;
       }
 
       // nullify values based on previous questions

--- a/portal-api/src/v1/gef/routes.js
+++ b/portal-api/src/v1/gef/routes.js
@@ -37,7 +37,7 @@ router.route('/cover-terms/:id')
 
 // Facilities
 router.route('/facilities')
-  .get(validate({ role: ['maker', 'checker', 'data-admin'] }), facilities.getAll)
+  .get(validate({ role: ['maker', 'checker', 'data-admin'] }), facilities.getAllGET)
   .post(validate({ role: ['maker', 'data-admin'] }), facilities.create)
   .delete(validate({ role: ['maker', 'data-admin'] }), facilities.deleteByApplicationId);
 

--- a/portal-api/src/v1/gef/routes.js
+++ b/portal-api/src/v1/gef/routes.js
@@ -43,7 +43,7 @@ router.route('/facilities')
 
 router.route('/facilities/:id')
   .get(validate({ role: ['maker', 'checker', 'data-admin'] }), facilities.getById)
-  .put(validate({ role: ['maker', 'data-admin'] }), facilities.update)
+  .put(validate({ role: ['maker', 'data-admin'] }), facilities.updatePUT)
   .delete(validate({ role: ['maker', 'data-admin'] }), facilities.delete);
 
 // Eligibility Criteria


### PR DESCRIPTION
### Summary
- increase `submissionCount` when deal status changes to 'submitted'
- add `submissionDate` when deal status changes to 'submitted'
- add `submittedAsIssuedDate` to issued facilities when deal status changes to 'submitted'
- calculate `ukefExposure` when a facility is updated

### Non-data things
- seperate `update` and `getAllFacilitiesByApplicationId` functionality in facilities controller. Allows us to get & update facilities without req & res.
- improved facilities unit tests so that "get all" is actually tested when `req.query.applicationId` is passed.
- create `addSubmissionData` function for when a deal status changes to submit. Can be expanded to other things moving forwards.


~Need this PR merged first https://github.com/foundry4/dtfs2/pull/165~