### PR TITLE
DTFS2-4328: pad company no to always be 8 chars

### DIFF
--- a/reference-data-proxy/src/v1/controllers/companies-house.controller.js
+++ b/reference-data-proxy/src/v1/controllers/companies-house.controller.js
@@ -3,9 +3,11 @@ const axios = require('axios');
 exports.lookup = async (req, res) => {
   const { companyRegNo } = req.params;
 
+  const sanitisedRegNo = companyRegNo.padStart(8, '0');
+
   const response = await axios({
     method: 'get',
-    url: `${process.env.COMPANIES_HOUSE_API_URL}/company/${companyRegNo}`,
+    url: `${process.env.COMPANIES_HOUSE_API_URL}/company/${sanitisedRegNo}`,
     auth: {
       username: process.env.COMPANIES_HOUSE_API_KEY,
     },


### PR DESCRIPTION
https://ukef-dtfs.atlassian.net/browse/DTFS2-4328
Companies house api expects 8 char numbers. Anything less is led with 0. Added 0 pad if less than 8 chars.