### PR TITLE
DTFS2-4361 - central API exporter endpoints, TFM facility mappings for GEF

### DIFF
--- a/dtfs-central-api/api-tests/v1/gef-deals/gef-deal-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/gef-deals/gef-deal-get.api-test.js
@@ -8,13 +8,13 @@ const newDeal = {
   status: 'Draft',
 };
 
-describe('/v1/portal/gef/deal/:id', () => {
+describe('/v1/portal/gef/deals/:id', () => {
   beforeAll(async () => {
     await wipeDB.wipe(['gef-application']);
     await wipeDB.wipe(['gef-facilities']);
   });
 
-  describe('GET /v1/portal/gef/deal/:id', () => {
+  describe('GET /v1/portal/gef/deals/:id', () => {
     it('returns 404 when the deal is not found', async () => {
       const invalidDealId = '123456789f0ffe00219319c1';
 

--- a/dtfs-central-api/api-tests/v1/gef-exporter/gef-exporter-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/gef-exporter/gef-exporter-get.api-test.js
@@ -1,0 +1,29 @@
+const wipeDB = require('../../wipeDB');
+const app = require('../../../src/createApp');
+const api = require('../../api')(app);
+
+const newExporter = {
+  companyName: 'Testing',
+  companiesHouseRegistrationNumber: '12345678',
+};
+
+describe('/v1/portal/gef/exporter', () => {
+  beforeAll(async () => {
+    await wipeDB.wipe(['gef-exporter']);
+  });
+
+  describe('GET /v1/portal/gef/exporter', () => {
+    it('returns the created deal with correct fields', async () => {
+      const { body, status } = await api.post(newExporter).to('/v1/portal/gef/exporter');
+
+      expect(status).toEqual(200);
+
+      const expected = {
+        _id: expect.any(String),
+        ...newExporter,
+      };
+
+      expect(body).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/api-tests/v1/gef-exporter/gef-exporter-post.api-test.js
+++ b/dtfs-central-api/api-tests/v1/gef-exporter/gef-exporter-post.api-test.js
@@ -1,0 +1,29 @@
+const wipeDB = require('../../wipeDB');
+const app = require('../../../src/createApp');
+const api = require('../../api')(app);
+
+const newExporter = {
+  companyName: 'Testing',
+  companiesHouseRegistrationNumber: '12345678',
+};
+
+describe('/v1/portal/gef/exporter', () => {
+  beforeAll(async () => {
+    await wipeDB.wipe(['gef-exporter']);
+  });
+
+  describe('POST /v1/portal/gef/exporter', () => {
+    it('returns the created exporter ', async () => {
+      const { body, status } = await api.post(newExporter).to('/v1/portal/gef/exporter');
+
+      expect(status).toEqual(200);
+
+      const expected = {
+        _id: expect.any(String),
+        ...newExporter,
+      };
+
+      expect(body).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/api-tests/v1/tfm/deal/tfm-gef-deal.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/deal/tfm-gef-deal.api-test.js
@@ -38,7 +38,6 @@ describe('/v1/tfm/deal/:id', () => {
     });
   });
 
-
   describe('PUT /v1/tfm/deal/:id', () => {
     const dealUpdate = {
       tfm: {

--- a/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
@@ -2,6 +2,7 @@ const { ObjectID } = require('mongodb');
 const db = require('../../../../drivers/db-client');
 const CONSTANTS = require('../../../../constants');
 const { findAllGefFacilitiesByDealId } = require('../gef-facility/get-facilities.controller');
+const { findOneExporter } = require('../gef-exporter/get-gef-exporter.controller');
 
 const queryDeals = async (query, start = 0, pagesize = 0) => {
   const collection = await db.getCollection('deals');
@@ -93,6 +94,11 @@ const findOneGefDeal = async (_id, callback) => {
 
   if (deal) {
     deal.facilities = await findAllGefFacilitiesByDealId(_id);
+    const exporter = await findOneExporter(deal.exporterId);
+
+    if (exporter) {
+      deal.exporter = exporter;
+    }
   }
 
   if (callback) {

--- a/dtfs-central-api/src/v1/controllers/portal/gef-exporter/create-gef-exporter.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-exporter/create-gef-exporter.controller.js
@@ -1,0 +1,17 @@
+const db = require('../../../../drivers/db-client');
+
+const createExporter = async (exporter) => {
+  const collection = await db.getCollection('gef-exporter');
+
+  const response = await collection.insertOne(exporter);
+
+  const createdDeal = response.ops[0];
+
+  return createdDeal;
+};
+
+exports.createExporterPost = async (req, res) => {
+  const exporter = await createExporter(req.body);
+
+  return res.status(200).send(exporter);
+};

--- a/dtfs-central-api/src/v1/controllers/portal/gef-exporter/get-gef-exporter.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-exporter/get-gef-exporter.controller.js
@@ -1,0 +1,20 @@
+const { ObjectID } = require('mongodb');
+const db = require('../../../../drivers/db-client');
+
+const findOneExporter = async (exporterId) => {
+  const collection = await db.getCollection('gef-exporter');
+  const exporter = collection.findOne({ _id: ObjectID(exporterId) });
+
+  return exporter;
+};
+exports.findOneExporter = findOneExporter;
+
+exports.findOneExporterGet = async (req, res) => {
+  const exporter = await findOneExporter(req.params.id);
+
+  if (exporter) {
+    return res.status(200).send(exporter);
+  }
+
+  return res.status(404).send();
+};

--- a/dtfs-central-api/src/v1/routes/portal-routes.js
+++ b/dtfs-central-api/src/v1/routes/portal-routes.js
@@ -18,6 +18,10 @@ const updateFacilityStatusController = require('../controllers/portal/facility/u
 
 const createGefDealController = require('../controllers/portal/gef-deal/create-gef-deal.controller');
 const getGefDealController = require('../controllers/portal/gef-deal/get-gef-deal.controller');
+
+const createGefExporterController = require('../controllers/portal/gef-exporter/create-gef-exporter.controller');
+const getGefExporterController = require('../controllers/portal/gef-exporter/get-gef-exporter.controller');
+
 const getGefFacilitiesController = require('../controllers/portal/gef-facility/get-facilities.controller');
 const createGefFacilityController = require('../controllers/portal/gef-facility/create-gef-facility.controller');
 
@@ -99,6 +103,16 @@ portalRouter.route('/gef/deals')
 portalRouter.route('/gef/deals/:id')
   .get(
     getGefDealController.findOneDealGet,
+  );
+
+portalRouter.route('/gef/exporter')
+  .post(
+    createGefExporterController.createExporterPost,
+  );
+
+portalRouter.route('/gef/exporter/:id')
+  .get(
+    getGefExporterController.findOneExporterGet,
   );
 
 portalRouter.route('/gef/deals/:id/facilities')

--- a/reference-data-proxy/src/v1/api-estore.js
+++ b/reference-data-proxy/src/v1/api-estore.js
@@ -5,7 +5,7 @@ const postToAPI = async (apiEndpoint, apiData) => {
     return false;
   }
 
-  console.log('Calling eStore API: ', `${process.env.MULESOFT_API_UKEF_ESTORE_EA_URL}/${apiEndpoint}`);
+  console.log(`Calling eStore API: ${process.env.MULESOFT_API_UKEF_ESTORE_EA_URL}/${apiEndpoint} with \n${apiData}`);
 
   const response = await axios({
     method: 'post',
@@ -19,12 +19,7 @@ const postToAPI = async (apiEndpoint, apiData) => {
     },
     data: [apiData],
   }).catch((catchErr) => {
-    console.error('Error calling eStore API',
-      {
-        url: `${process.env.MULESOFT_API_UKEF_ESTORE_EA_URL}/${apiEndpoint}`,
-        data: [apiData],
-        response: catchErr.response,
-      });
+    console.error(`Error calling eStore API: ${catchErr.response.status} \n`, catchErr.response.data);
     return catchErr.response;
   });
   return response;

--- a/reference-data-proxy/src/v1/controllers/premium-schedule.controller.js
+++ b/reference-data-proxy/src/v1/controllers/premium-schedule.controller.js
@@ -9,7 +9,7 @@ const { objectIsEmpty } = require('../../utils/object');
 
 const postPremiumSchedule = async (premiumScheduleParameters) => {
   if (objectIsEmpty(premiumScheduleParameters)) {
-    console.log('Facility data not valid for premium schedule');
+    console.log('Unable to call Premium schedule - no facility data provided');
     return null;
   }
 

--- a/trade-finance-manager-api/src/graphql/reducers/deal.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deal.api-test.js
@@ -5,6 +5,7 @@ const mapGefDeal = require('./mappings/gef-deal/mapGefDeal');
 
 const MOCK_DEAL_AIN_SUBMITTED = require('../../v1/__mocks__/mock-deal-AIN-submitted');
 const MOCK_GEF_DEAL = require('../../v1/__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../v1/__mocks__/mock-cash-contingent-facilities');
 
 describe('reducer - deal', () => {
   it('should return mapped object', () => {
@@ -51,7 +52,7 @@ describe('reducer - deal', () => {
           ...MOCK_GEF_DEAL,
           facilities: [
             {
-              facilitySnapshot: MOCK_GEF_DEAL.facilities[0],
+              facilitySnapshot: MOCK_CASH_CONTINGENT_FACILIIES[0],
               tfm: {},
             },
           ],

--- a/trade-finance-manager-api/src/graphql/reducers/facility.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/facility.api-test.js
@@ -5,6 +5,7 @@ const mapGefFacility = require('./mappings/gef-facilities/mapGefFacility');
 
 const MOCK_DEAL_AIN_SUBMITTED = require('../../v1/__mocks__/mock-deal-AIN-submitted');
 const MOCK_GEF_DEAL = require('../../v1/__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../v1/__mocks__/mock-cash-contingent-facilities');
 
 describe('reducer - facility', () => {
   it('should return mapped object', () => {
@@ -44,8 +45,8 @@ describe('reducer - facility', () => {
       };
 
       const mockGefFacility = {
-        _id: MOCK_GEF_DEAL.facilities[0]._id,
-        facilitySnapshot: MOCK_GEF_DEAL.facilities[0],
+        _id: MOCK_CASH_CONTINGENT_FACILIIES[0]._id,
+        facilitySnapshot: MOCK_CASH_CONTINGENT_FACILIIES[0],
         tfm: {
           facilityValueInGBP: '12,345.00',
         },

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDeal.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDeal.api-test.js
@@ -1,6 +1,7 @@
 const mapGefDeal = require('./mapGefDeal');
 const mapGefDealSnapshot = require('./mapGefDealSnapshot');
 const MOCK_GEF_DEAL = require('../../../../v1/__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../../../v1/__mocks__/mock-cash-contingent-facilities');
 
 describe('mapGefDeal', () => {
   it('should return mapped deal', () => {
@@ -10,7 +11,7 @@ describe('mapGefDeal', () => {
         ...MOCK_GEF_DEAL,
         facilities: [
           {
-            facilitySnapshot: MOCK_GEF_DEAL.facilities[0],
+            facilitySnapshot: MOCK_CASH_CONTINGENT_FACILIIES[0],
             tfm: {},
           },
         ],

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealSnapshot.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealSnapshot.api-test.js
@@ -4,11 +4,12 @@ const mapGefFacilities = require('../gef-facilities/mapGefFacilities');
 const mapTotals = require('../deal/mapTotals');
 const mapGefSubmissionDetails = require('./mapGefSubmissionDetails');
 const MOCK_GEF_DEAL = require('../../../../v1/__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../../../v1/__mocks__/mock-cash-contingent-facilities');
 
 describe('mapGefDealSnapshot', () => {
   const mockFacilities = [
     {
-      facilitySnapshot: MOCK_GEF_DEAL.facilities[0],
+      facilitySnapshot: MOCK_CASH_CONTINGENT_FACILIIES[0],
       tfm: {
         facilityValueInGBP: '123,45.00',
       },

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilities.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilities.api-test.js
@@ -1,18 +1,17 @@
 const mapGefFacilities = require('./mapGefFacilities');
 const mapGefFacility = require('./mapGefFacility');
-
-const MOCK_GEF_DEAL = require('../../../../v1/__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../../../v1/__mocks__/mock-cash-contingent-facilities');
 
 describe('mapGefFacilities', () => {
   it('should return mapped GEF facilities', () => {
     const mockDealSnapshot = {
       facilities: [
         {
-          facilitySnapshot: MOCK_GEF_DEAL.facilities[0],
+          facilitySnapshot: MOCK_CASH_CONTINGENT_FACILIIES[0],
           tfm: {},
         },
         {
-          facilitySnapshot: MOCK_GEF_DEAL.facilities[0],
+          facilitySnapshot: MOCK_CASH_CONTINGENT_FACILIIES[0],
           tfm: {},
         },
       ],

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacility.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacility.api-test.js
@@ -9,12 +9,13 @@ const mapGefUkefFacilityType = require('./mapGefUkefFacilityType');
 const mapGefFacilityDates = require('./mapGefFacilityDates');
 
 const MOCK_GEF_DEAL = require('../../../../v1/__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../../../v1/__mocks__/mock-cash-contingent-facilities');
 
 describe('mapGefFacility', () => {
   it('should return mapped GEF facility', () => {
     const mockFacility = {
-      _id: MOCK_GEF_DEAL.facilities[0]._id,
-      facilitySnapshot: MOCK_GEF_DEAL.facilities[0],
+      _id: MOCK_CASH_CONTINGENT_FACILIIES[0]._id,
+      facilitySnapshot: MOCK_CASH_CONTINGENT_FACILIIES[0],
       tfm: {},
     };
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityDates.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityDates.api-test.js
@@ -5,10 +5,11 @@ const mapTenorDate = require('../facilities/mapTenorDate');
 const { convertDateToTimestamp } = require('../../../../utils/date');
 
 const MOCK_GEF_DEAL = require('../../../../v1/__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../../../v1/__mocks__/mock-cash-contingent-facilities');
 
 describe('mapGefFacilityDates', () => {
   const mockFacility = {
-    ...MOCK_GEF_DEAL.facilities[0],
+    ...MOCK_CASH_CONTINGENT_FACILIIES[0],
     facilityStage: 'Issued',
   };
 

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-cash-contingent-facilities.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-cash-contingent-facilities.js
@@ -1,0 +1,30 @@
+const MOCK_CASH_CONTINGENT_FACILIIES = [
+  {
+    _id: 'MOCK_CASH_FACILITY_ISSUED',
+    applicationId: 'MOCK_GEF_DEAL',
+    coverEndDate: '2021-12-12T00:00:00.000Z',
+    coverPercentage: 12,
+    coverStartDate: null,
+    createdAt: 1628693855675.0,
+    currency: 'EUR',
+    details: [
+      'RESOLVING',
+    ],
+    detailsOther: '',
+    hasBeenIssued: true,
+    interestPercentage: 24,
+    monthsOfCover: null,
+    name: 'issued1',
+    paymentType: null,
+    shouldCoverStartOnSubmission: true,
+    submittedAsIssuedDate: '1628770126495',
+    type: 'CASH',
+    ukefExposure: 1481472,
+    updatedAt: 1628770126497.0,
+    value: 123456,
+    ukefFacilityId: '123456',
+  },
+];
+
+
+module.exports = MOCK_CASH_CONTINGENT_FACILIIES;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal.js
@@ -57,35 +57,6 @@ const MOCK_GEF_DEAL = {
   updatedAt: null,
   userId: '60e705d74cf03e0013d38395',
   checkerId: '60a705d74bf03d1300d96383',
-  facilities: [
-    {
-      _id: '123456',
-      associatedDealId: 'MOCK_GEF_DEAL',
-      coverEndDate: '2023-12-31T00:00:00.000Z',
-      coverPercentage: 80,
-      coverStartDate: 1626169888809,
-      createdAt: 1625828781317,
-      currency: 'GBP',
-      details: [
-        'TERM',
-        'RESOLVING',
-      ],
-      detailsOther: '',
-      hasBeenIssued: true,
-      interestPercentage: 2,
-      monthsOfCover: 4,
-      name: 'Sample Cash Facility',
-      paymentType: null,
-      shouldCoverStartOnSubmission: true,
-      type: 'CASH',
-      updatedAt: 1625828824412,
-      value: 500000,
-      issuedFacilitySubmittedToUkefTimestamp: 1626169888809,
-    },
-  ],
-  facilityIds: [
-    '123456',
-  ],
   comments: [
     {
       createdAt: 1625482095783,

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -521,7 +521,7 @@ const findOneGefDeal = async (dealId) => {
       },
     });
 
-    return response.data.deal;
+    return response.data;
   } catch ({ response }) {
     return false;
   }

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -28,6 +28,9 @@ const getDeal = async (dealId, dealType) => {
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
     deal = await findOneGefDeal(dealId);
+
+    // temporarily return false for dev.
+    return false;
   }
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -70,13 +70,7 @@ const submitDeal = async (dealId, dealType, checker) => {
 
     const updatedDealWithUpdatedFacilities = await updateFacilities(updatedDealWithTfmDateReceived);
 
-    // TEMP: estore calls currently does not work with GEF deals.
-    // Estore endpoint requires fields that do not exist in GEF deal.
-    let updatedDealWithCreateEstore = updatedDealWithUpdatedFacilities;
-
-    if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
-      updatedDealWithCreateEstore = await createEstoreFolders(updatedDealWithUpdatedFacilities);
-    }
+    const updatedDealWithCreateEstore = await createEstoreFolders(updatedDealWithUpdatedFacilities);
 
     if (mappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN
       || mappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.MIA) {

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -70,7 +70,13 @@ const submitDeal = async (dealId, dealType, checker) => {
 
     const updatedDealWithUpdatedFacilities = await updateFacilities(updatedDealWithTfmDateReceived);
 
-    const updatedDealWithCreateEstore = await createEstoreFolders(updatedDealWithUpdatedFacilities);
+    // TEMP: estore calls currently does not work with GEF deals.
+    // Estore endpoint requires fields that do not exist in GEF deal.
+    let updatedDealWithCreateEstore = updatedDealWithUpdatedFacilities;
+
+    if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
+      updatedDealWithCreateEstore = await createEstoreFolders(updatedDealWithUpdatedFacilities);
+    }
 
     if (mappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN
       || mappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.MIA) {

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -28,9 +28,6 @@ const getDeal = async (dealId, dealType) => {
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
     deal = await findOneGefDeal(dealId);
-
-    // temporarily return false for dev.
-    return false;
   }
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {

--- a/trade-finance-manager-api/src/v1/mappings/map-create-estore.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-create-estore.api-test.js
@@ -1,0 +1,70 @@
+const mapCreateEstore = require('./map-create-estore');
+const formatNameForSharepoint = require('../helpers/formatNameForSharepoint');
+const CONSTANTS = require('../../constants');
+
+describe('mapCreateEstore', () => {
+  describe(`when dealType is ${CONSTANTS.DEALS.DEAL_TYPE.GEF}`, () => {
+    it('should return mapped object with some default values', () => {
+      const mockGefDeal = {
+        dealType: CONSTANTS.DEALS.DEAL_TYPE.GEF,
+        exporter: {
+          companyName: 'Testing',
+        },
+        ukefDealId: '123456',
+        facilities: [
+          { ukefFacilityID: '1' },
+          { ukefFacilityID: '2' },
+        ],
+      };
+
+      const result = mapCreateEstore(mockGefDeal);
+
+      const expected = {
+        exporterName: formatNameForSharepoint(mockGefDeal.exporter.companyName),
+        buyerName: CONSTANTS.DEALS.DEAL_TYPE.GEF,
+        dealIdentifier: mockGefDeal.ukefDealId,
+        destinationMarket: 'United Kingdom',
+        riskMarket: 'United Kingdom',
+        facilityIdentifiers: ['1', '2'],
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when dealType is ${CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS}`, () => {
+    const mockBssDeal = {
+      dealType: CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS,
+      buyer: {
+        name: 'Test',
+        country: {
+          name: 'Belgium',
+        },
+      },
+      destinationOfGoodsAndServices: {
+        name: 'France',
+      },
+      exporter: {
+        companyName: 'Testing',
+      },
+      ukefDealId: '123456',
+      facilities: [
+        { ukefFacilityID: '1' },
+        { ukefFacilityID: '2' },
+      ],
+    };
+
+    const result = mapCreateEstore(mockBssDeal);
+
+    const expected = {
+      exporterName: formatNameForSharepoint(mockBssDeal.exporter.companyName),
+      buyerName: formatNameForSharepoint(mockBssDeal.buyer.name),
+      dealIdentifier: mockBssDeal.ukefDealId,
+      destinationMarket: mockBssDeal.destinationOfGoodsAndServices.name,
+      riskMarket: mockBssDeal.buyer.country.name,
+      facilityIdentifiers: ['1', '2'],
+    };
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/trade-finance-manager-api/src/v1/mappings/map-create-estore.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-create-estore.js
@@ -1,7 +1,9 @@
 const formatNameForSharepoint = require('../helpers/formatNameForSharepoint');
+const CONSTANTS = require('../../constants');
 
 const mapCreateEstore = (deal) => {
   const {
+    dealType,
     ukefDealId,
     facilities,
     exporter,
@@ -9,12 +11,29 @@ const mapCreateEstore = (deal) => {
     destinationOfGoodsAndServices,
   } = deal;
 
+  let buyerName;
+  let destinationMarket;
+  let riskMarket;
+
+  if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
+    // default values for GEF. GEF does not this data.
+    buyerName = CONSTANTS.DEALS.DEAL_TYPE.GEF;
+    destinationMarket = 'United Kingdom';
+    riskMarket = 'United Kingdom';
+  }
+
+  if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
+    buyerName = formatNameForSharepoint(buyer.name);
+    destinationMarket = destinationOfGoodsAndServices.name;
+    riskMarket = buyer.country.name;
+  }
+
   return {
     exporterName: formatNameForSharepoint(exporter.companyName),
-    buyerName: formatNameForSharepoint(buyer.name),
+    buyerName,
     dealIdentifier: ukefDealId,
-    destinationMarket: destinationOfGoodsAndServices.name,
-    riskMarket: buyer.country.name,
+    destinationMarket,
+    riskMarket,
     facilityIdentifiers: facilities.map((facility) => facility.ukefFacilityID),
   };
 };

--- a/trade-finance-manager-api/src/v1/mappings/map-create-estore.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-create-estore.js
@@ -16,7 +16,7 @@ const mapCreateEstore = (deal) => {
   let riskMarket;
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
-    // default values for GEF. GEF does not this data.
+    // default values for GEF. GEF does not have this data.
     buyerName = CONSTANTS.DEALS.DEAL_TYPE.GEF;
     destinationMarket = 'United Kingdom';
     riskMarket = 'United Kingdom';

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/index.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/index.api-test.js
@@ -34,7 +34,12 @@ describe('mappings - map submitted deal - mapSubmittedDeal', () => {
 
   describe(`when dealType is ${CONSTANTS.DEALS.DEAL_TYPE.GEF}`, () => {
     it('should return mapGefDeal', () => {
-      const mockDeal = { dealSnapshot: MOCK_GEF_DEAL };
+      const mockDeal = {
+        dealSnapshot: {
+          ...MOCK_GEF_DEAL,
+          facilities: [],
+        },
+      };
 
       const result = mapSubmittedDeal(mockDeal);
 

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/index.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/index.api-test.js
@@ -1,7 +1,7 @@
 const mapSubmittedDeal = require('.');
 const mapBssEwcsDeal = require('./map-bss-ewcs-deal');
 const { mapBssEwcsFacility } = require('./map-bss-ewcs-facility');
-// const mapGefDeal = require('./map-gef-deal');
+const mapGefDeal = require('./map-gef-deal');
 
 const CONSTANTS = require('../../../constants');
 const MOCK_BSS_EWCS_DEAL = require('../../__mocks__/mock-deal');
@@ -38,8 +38,9 @@ describe('mappings - map submitted deal - mapSubmittedDeal', () => {
 
       const result = mapSubmittedDeal(mockDeal);
 
-      // const expected = mapGefDeal(mockDeal);
-      expect(result).toEqual(false);
+      const expected = mapGefDeal(mockDeal);
+
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/index.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/index.js
@@ -9,9 +9,6 @@ const mapSubmittedDeal = (deal) => {
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
     mappedDeal = mapGefDeal(deal);
-
-    // temporarily return false for dev.
-    return false;
   }
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.js
@@ -39,7 +39,6 @@ const mapBssEwcsFacility = (facility) => {
     ukefGuaranteeInMonths,
     hasBeenAcknowledged,
     requestedCoverStartDate,
-    // TODO are these in gef facility?
     dayCountBasis,
     guaranteeFeePayableByBank,
     feeType,

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.api-test.js
@@ -1,0 +1,81 @@
+const {
+  mapCoverStartDate,
+  mapCashContingentFacility,
+} = require('./map-cash-contingent-facility');
+const { convertDateToTimestamp } = require('../../../utils/date');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../__mocks__/mock-cash-contingent-facilities');
+
+describe('mappings - map submitted deal - mapCashContingentFacility', () => {
+  describe('mapCoverStartDate', () => {
+    it('should return facility.submittedAsIssuedDate when facility.hasBeenIssued is true', () => {
+      const mockFacility = {
+        hasBeenIssued: true,
+        submittedAsIssuedDate: '1628770126495',
+      };
+
+      const result = mapCoverStartDate(mockFacility);
+
+      expect(result).toEqual(mockFacility.submittedAsIssuedDate);
+    });
+
+    it('should return coverStartDate as a timestamp when facility.hasBeenIssued is NOT true', () => {
+      const mockFacility = {
+        hasBeenIssued: null,
+        coverStartDate: '2021-12-12 00:00:00.000Z',
+      };
+
+      const result = mapCoverStartDate(mockFacility);
+
+      const expected = convertDateToTimestamp(mockFacility.coverStartDate);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should return null', () => {
+      const result = mapCoverStartDate({});
+
+      expect(result).toEqual(null);
+    });
+  });
+
+  describe('mapCashContingentFacility', () => {
+    it('should return mapped facility', () => {
+      const mockFacility = {
+        ...MOCK_CASH_CONTINGENT_FACILIIES[0],
+        tfm: {},
+      };
+
+      const result = mapCashContingentFacility(mockFacility);
+
+      const {
+        _id,
+        ukefFacilityId,
+        type,
+        hasBeenIssued,
+        value,
+        currency,
+        monthsOfCover,
+        coverPercentage,
+        ukefExposure,
+        coverEndDate,
+      } = mockFacility;
+
+      const expected = {
+        _id,
+        ukefFacilityID: ukefFacilityId,
+        facilityType: type,
+        currency,
+        value,
+        coverPercentage,
+        hasBeenIssued,
+        ukefGuaranteeInMonths: monthsOfCover || 0,
+        ukefExposure,
+        coverStartDate: mapCoverStartDate(mockFacility),
+        coverEndDate,
+        tfm: mockFacility.tfm,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
@@ -32,8 +32,6 @@ const mapCashContingentFacility = (facility) => {
     coverEndDate,
   } = facility;
 
-  // TODO why is ukefFacilityID empty in original facility?
-
   return {
     _id,
     ukefFacilityID: ukefFacilityId,

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
@@ -1,0 +1,61 @@
+const { convertDateToTimestamp } = require('../../../utils/date');
+
+const mapCoverStartDate = (facility) => {
+  const {
+    hasBeenIssued,
+    submittedAsIssuedDate,
+    coverStartDate,
+  } = facility;
+
+  if (hasBeenIssued && submittedAsIssuedDate) {
+    return submittedAsIssuedDate;
+  }
+
+  if (coverStartDate) {
+    return convertDateToTimestamp(coverStartDate);
+  }
+
+  return null;
+};
+
+const mapCashContingentFacility = (facility) => {
+  const {
+    _id,
+    ukefFacilityId,
+    type,
+    hasBeenIssued,
+    value,
+    currency,
+    monthsOfCover,
+    coverPercentage,
+    ukefExposure,
+    coverEndDate,
+  } = facility;
+
+  // TODO why is ukefFacilityID empty in original facility?
+
+  return {
+    _id,
+    ukefFacilityID: ukefFacilityId,
+    facilityType: type,
+    currency,
+    value,
+    coverPercentage,
+    hasBeenIssued,
+    ukefGuaranteeInMonths: monthsOfCover || 0,
+    ukefExposure,
+    coverStartDate: mapCoverStartDate(facility),
+    coverEndDate,
+    tfm: facility.tfm,
+    // not in the data
+    // premiumType,
+    // dayCountBasis,
+    // guaranteeFeePayableByBank,
+  };
+};
+
+
+module.exports = {
+  mapCoverStartDate,
+  mapCashContingentFacility,
+};

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
@@ -1,10 +1,16 @@
 const mapGefDeal = require('./map-gef-deal');
+const { mapCashContingentFacility } = require('./map-cash-contingent-facility');
+
 const MOCK_GEF_DEAL = require('../../__mocks__/mock-gef-deal');
+const MOCK_CASH_CONTINGENT_FACILIIES = require('../../__mocks__/mock-cash-contingent-facilities');
 
 describe('mappings - map submitted deal - mapGefDeal', () => {
   it('should return mapped deal', () => {
     const mockDeal = {
-      dealSnapshot: MOCK_GEF_DEAL,
+      dealSnapshot: {
+        ...MOCK_GEF_DEAL,
+        facilities: MOCK_CASH_CONTINGENT_FACILIIES,
+      },
       tfm: {},
     };
 
@@ -24,7 +30,7 @@ describe('mappings - map submitted deal - mapGefDeal', () => {
         companyName: mockDeal.dealSnapshot.exporter.companyName,
         companiesHouseRegistrationNumber: mockDeal.dealSnapshot.exporter.companiesHouseRegistrationNumber,
       },
-      facilities: mockDeal.facilities,
+      facilities: mockDeal.dealSnapshot.facilities.map((facility) => mapCashContingentFacility(facility)),
       tfm: mockDeal.tfm,
     };
 

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
@@ -24,6 +24,7 @@ describe('mappings - map submitted deal - mapGefDeal', () => {
         companyName: mockDeal.dealSnapshot.exporter.companyName,
         companiesHouseRegistrationNumber: mockDeal.dealSnapshot.exporter.companiesHouseRegistrationNumber,
       },
+      facilities: mockDeal.facilities,
       tfm: mockDeal.tfm,
     };
 

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
@@ -12,6 +12,7 @@ const mapGefDeal = (deal) => {
     status,
     ukefDealId,
     exporter,
+    facilities,
   } = dealSnapshot;
 
   const mapped = {
@@ -28,6 +29,7 @@ const mapGefDeal = (deal) => {
       companyName: exporter.companyName,
       companiesHouseRegistrationNumber: exporter.companiesHouseRegistrationNumber,
     },
+    facilities,
     tfm,
   };
 

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
@@ -1,3 +1,5 @@
+const { mapCashContingentFacility } = require('./map-cash-contingent-facility');
+
 const mapGefDeal = (deal) => {
   const { dealSnapshot, tfm } = deal;
 
@@ -29,7 +31,7 @@ const mapGefDeal = (deal) => {
       companyName: exporter.companyName,
       companiesHouseRegistrationNumber: exporter.companiesHouseRegistrationNumber,
     },
-    facilities,
+    facilities: facilities.map((facility) => mapCashContingentFacility(facility)),
     tfm,
   };
 


### PR DESCRIPTION
- central API: add create and get endpoints for GEF exporter
- central API: when getting a GEF deal, get exporter details and return in response
- improve logging for external api calls to estore and premium schedule
- TFM API: add GEF specific mappings to `map-create-estore` function. Add test coverage
- TFM API: deal submission - add GEF facilities mapping
- TFM API: move mock GEF facilities into it's own file