### PR TITLE
DTFS2-4511 - TFM default pricing and risk values for GEF

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -167,7 +167,7 @@ describe('/v1/deals', () => {
       expect(body.tfm.product).toEqual(expected);
     });
 
-    describe('exporter credit rating', () => {
+    describe('exporterCreditRating (BSS deal)', () => {
       describe('when deal is AIN', () => {
         it('should add exporterCreditRating to the deal', async () => {
           const { status, body } = await api.put(createSubmitBody(MOCK_DEAL_AIN_SUBMITTED)).to('/v1/deals/submit');
@@ -178,8 +178,28 @@ describe('/v1/deals', () => {
       });
 
       describe('when deal is NOT AIN', () => {
+        it('should NOT add exporterCreditRating to the deal', async () => {
+          const { status, body } = await api.put(createSubmitBody(MOCK_DEAL_MIA_SUBMITTED)).to('/v1/deals/submit');
+
+          expect(status).toEqual(200);
+          expect(body.tfm.exporterCreditRating).toBeUndefined();
+        });
+      });
+    });
+
+    describe('exporterCreditRating (GEF deal)', () => {
+      describe('when deal is AIN', () => {
         it('should add exporterCreditRating to the deal', async () => {
-          const { status, body } = await api.put(createSubmitBody(MOCK_DEAL_MIN)).to('/v1/deals/submit');
+          const { status, body } = await api.put(createSubmitBody(MOCK_GEF_DEAL)).to('/v1/deals/submit');
+
+          expect(status).toEqual(200);
+          expect(body.tfm.exporterCreditRating).toEqual(DEFAULTS.CREDIT_RATING.AIN);
+        });
+      });
+
+      describe('when deal is NOT AIN', () => {
+        it('should NOT add exporterCreditRating to the deal', async () => {
+          const { status, body } = await api.put(createSubmitBody(MOCK_GEF_DEAL_MIA)).to('/v1/deals/submit');
 
           expect(status).toEqual(200);
           expect(body.tfm.exporterCreditRating).toBeUndefined();

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -23,6 +23,7 @@ const MOCK_TEAMS = require('./mock-teams');
 const MOCK_PREMIUM_SCHEUDLE_RESPONSE = require('./mock-premium-schedule-response');
 
 const MOCK_GEF_DEAL = require('./mock-gef-deal');
+const MOCK_GEF_DEAL_MIA = require('./mock-gef-deal-MIA');
 const MOCK_CASH_CONTINGENT_FACILITIES = require('./mock-cash-contingent-facilities');
 
 const ALL_MOCK_DEALS = [
@@ -42,6 +43,7 @@ const ALL_MOCK_DEALS = [
   MOCK_MIA_SUBMITTED,
   MOCK_MIA_SECOND_SUBMIT,
   MOCK_GEF_DEAL,
+  MOCK_GEF_DEAL_MIA,
 ];
 
 const ALL_MOCK_FACILITIES = [

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-cash-contingent-facilities.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-cash-contingent-facilities.js
@@ -24,6 +24,31 @@ const MOCK_CASH_CONTINGENT_FACILIIES = [
     value: 123456,
     ukefFacilityId: '123456',
   },
+  {
+    _id: 'MOCK_CONTINGENT_FACILITY_ISSUED',
+    applicationId: 'MOCK_GEF_DEAL',
+    coverEndDate: '2021-12-12T00:00:00.000Z',
+    coverPercentage: 12,
+    coverStartDate: null,
+    createdAt: 1628693855675.0,
+    currency: 'EUR',
+    details: [
+      'RESOLVING',
+    ],
+    detailsOther: '',
+    hasBeenIssued: true,
+    interestPercentage: 24,
+    monthsOfCover: 10,
+    name: 'issued1',
+    paymentType: null,
+    shouldCoverStartOnSubmission: true,
+    submittedAsIssuedDate: '1628770126495',
+    type: 'CONTINGENT',
+    ukefExposure: 1481472,
+    updatedAt: 1628770126497.0,
+    value: 123456,
+    ukefFacilityId: '123456',
+  },
 ];
 
 

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal-MIA.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal-MIA.js
@@ -1,8 +1,8 @@
 const MOCK_GEF_DEAL = require('./mock-gef-deal');
 
 const MOCK_GEF_DEAL_MIA = {
-  _id: 'MOCK_GEF_DEAL_MIA',
   ...MOCK_GEF_DEAL,
+  _id: 'MOCK_GEF_DEAL_MIA',
   submissionType: 'Manual Inclusion Application',
 };
 

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal.js
@@ -7,6 +7,7 @@ const MOCK_GEF_DEAL = {
   bankInternalRefName: 'Internal Reference 001',
   submissionDate: '1626169888809',
   submissionCount: 1,
+  submissionType: 'Automatic Inclusion Notice',
   coverTerms: {
     coverStart: 'true',
     dueDiligence: 'true',
@@ -54,6 +55,11 @@ const MOCK_GEF_DEAL = {
     },
     smeType: 'MEDIUM',
     updatedAt: 162582748022,
+  },
+  maker: {
+    username: 'JOE',
+    firstname: 'Joe',
+    surname: 'Bloggs',
   },
   bank: {
     id: '9',

--- a/trade-finance-manager-api/src/v1/controllers/deal.pricing-and-risk.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.pricing-and-risk.js
@@ -25,16 +25,16 @@ const addDealPricingAndRisk = async (deal) => {
     },
   };
 
+  if (submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN) {
+    dealUpdate.tfm.exporterCreditRating = DEFAULTS.CREDIT_RATING.AIN;
+  }
+
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
     dealUpdate.tfm.probabilityOfDefault = exporter.probabilityOfDefault;
   }
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
     dealUpdate.tfm.probabilityOfDefault = DEFAULTS.PROBABILITY_OF_DEFAULT;
-
-    if (submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN) {
-      dealUpdate.tfm.exporterCreditRating = DEFAULTS.CREDIT_RATING.AIN;
-    }
   }
 
   const updatedDeal = await api.updateDeal(dealId, dealUpdate);

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
@@ -31,6 +31,7 @@ describe('mappings - map submitted deal - mapGefDeal', () => {
         companiesHouseRegistrationNumber: mockDeal.dealSnapshot.exporter.companiesHouseRegistrationNumber,
         probabilityOfDefault: Number(mockDeal.dealSnapshot.exporter.probabilityOfDefault),
       },
+      maker: mockDeal.dealSnapshot.maker,
       facilities: mockDeal.dealSnapshot.facilities.map((facility) => mapCashContingentFacility(facility)),
       tfm: mockDeal.tfm,
     };

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
@@ -14,6 +14,7 @@ const mapGefDeal = (deal) => {
     status,
     ukefDealId,
     exporter,
+    maker,
     facilities,
   } = dealSnapshot;
 
@@ -32,6 +33,7 @@ const mapGefDeal = (deal) => {
       companiesHouseRegistrationNumber: exporter.companiesHouseRegistrationNumber,
       probabilityOfDefault: Number(exporter.probabilityOfDefault),
     },
+    maker,
     facilities: facilities.map((facility) => mapCashContingentFacility(facility)),
     tfm,
   };


### PR DESCRIPTION
On TFM deal submit, some default values are added to the deal. This PR ensures that they work for GEF and not just BSS.
 
- default `exporterCreditRating` for all AIN deals regardless of deal type
- add tests for default `lossGivenDefault` and `riskProfile` for GEF facilities
- add mock Contingent facility to TFM api mocks
- add maker to GEF deal submission mapping 