### PR TITLE
Fix/DTFS2-4380 - TFM getting GEF facilities with one API call, currency & product fixes

### DIFF
--- a/dtfs-central-api/api-tests/v1/gef-deals/gef-deal-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/gef-deals/gef-deal-get.api-test.js
@@ -24,8 +24,10 @@ describe('/v1/portal/gef/deals/:id', () => {
     });
 
     it('returns the deal', async () => {
+      // create deal
       const { body: createdDeal } = await api.post(newDeal).to('/v1/portal/gef/deals');
 
+      // get deal
       const { body, status } = await api.get(`/v1/portal/gef/deals/${createdDeal._id}`);
 
       expect(status).toEqual(200);

--- a/dtfs-central-api/api-tests/v1/gef-deals/gef-deal-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/gef-deals/gef-deal-get.api-test.js
@@ -24,10 +24,8 @@ describe('/v1/portal/gef/deals/:id', () => {
     });
 
     it('returns the deal', async () => {
-      // create deal
       const { body: createdDeal } = await api.post(newDeal).to('/v1/portal/gef/deals');
 
-      // get deal
       const { body, status } = await api.get(`/v1/portal/gef/deals/${createdDeal._id}`);
 
       expect(status).toEqual(200);

--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facilities-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facilities-get.api-test.js
@@ -1,4 +1,3 @@
-const { ObjectId } = require('mongodb');
 const wipeDB = require('../../../wipeDB');
 const app = require('../../../../src/createApp');
 const api = require('..api/../../api')(app);
@@ -31,14 +30,11 @@ describe('/v1/tfm/deals/:id/facilities', () => {
       const { body: facility1 } = await api.post(newFacility).to('/v1/portal/gef/facilities');
       const { body: facility2 } = await api.post(newFacility).to('/v1/portal/gef/facilities');
 
-
       // submit deal/facilities
       await api.put({
         dealType: CONSTANTS.DEALS.DEAL_TYPE.GEF,
         dealId,
       }).to('/v1/tfm/deals/submit');
-
-      // why is tfm-facilities empty
 
       const { status, body } = await api.get(`/v1/tfm/deals/${dealId}/facilities`);
 

--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facilities-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facilities-get.api-test.js
@@ -1,0 +1,59 @@
+const { ObjectId } = require('mongodb');
+const wipeDB = require('../../../wipeDB');
+const app = require('../../../../src/createApp');
+const api = require('..api/../../api')(app);
+const CONSTANTS = require('../../../../src/constants');
+
+const newDeal = {
+  dealType: CONSTANTS.DEALS.DEAL_TYPE.GEF,
+  status: 'Draft',
+};
+
+const newFacility = {
+  type: CONSTANTS.FACILITIES.FACILITY_TYPE.CASH,
+};
+
+describe('/v1/tfm/deals/:id/facilities', () => {
+  beforeAll(async () => {
+    await wipeDB.wipe(['tfm-deals']);
+    await wipeDB.wipe(['tfm-facilities']);
+  });
+
+  describe('GET /v1/tfm/deal/:id/facilities', () => {
+    it('returns the requested resource', async () => {
+      // create deal
+      const { body: createdDeal } = await api.post(newDeal).to('/v1/portal/gef/deals');
+
+      const dealId = createdDeal._id;
+
+      // create some facilities
+      newFacility.applicationId = dealId;
+      const { body: facility1 } = await api.post(newFacility).to('/v1/portal/gef/facilities');
+      const { body: facility2 } = await api.post(newFacility).to('/v1/portal/gef/facilities');
+
+
+      // submit deal/facilities
+      await api.put({
+        dealType: CONSTANTS.DEALS.DEAL_TYPE.GEF,
+        dealId,
+      }).to('/v1/tfm/deals/submit');
+
+      // why is tfm-facilities empty
+
+      const { status, body } = await api.get(`/v1/tfm/deals/${dealId}/facilities`);
+
+      const expectedFacilityShape = (facility) => ({
+        _id: facility._id,
+        facilitySnapshot: {
+          ...facility,
+        },
+      });
+
+      expect(status).toEqual(200);
+      expect(body).toEqual([
+        expectedFacilityShape(facility1),
+        expectedFacilityShape(facility2),
+      ]);
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/portal/gef-facility/create-gef-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-facility/create-gef-facility.controller.js
@@ -1,8 +1,12 @@
+const { ObjectId } = require('mongodb');
 const db = require('../../../../drivers/db-client');
 const { findOneDeal } = require('../gef-deal/get-gef-deal.controller');
 
-const createFacility = async (facility) => {
+const createFacility = async (newFacility) => {
+  const facility = newFacility;
   const collection = await db.getCollection('gef-facilities');
+
+  facility.applicationId = new ObjectId(facility.applicationId);
 
   const response = await collection.insertOne(facility);
   const createdFacility = response.ops[0];

--- a/dtfs-central-api/src/v1/controllers/portal/gef-facility/get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-facility/get-facilities.controller.js
@@ -1,9 +1,12 @@
+const { ObjectId } = require('mongodb');
 const db = require('../../../../drivers/db-client');
 
 const findAllGefFacilitiesByDealId = async (dealId) => {
   const collection = await db.getCollection('gef-facilities');
-  const facilities = collection.find({ applicationId: dealId });
-  return facilities.toArray();
+
+  const facilities = await collection.find({ applicationId: ObjectId(dealId) }).toArray();
+
+  return facilities;
 };
 exports.findAllGefFacilitiesByDealId = findAllGefFacilitiesByDealId;
 

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-submit-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-submit-deal.controller.js
@@ -68,7 +68,7 @@ const createFacilitiesSnapshot = async (deal) => {
   }
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
-    dealFacilities = await findAllGefFacilitiesByDealId(String(dealId));
+    dealFacilities = await findAllGefFacilitiesByDealId(dealId);
   }
 
   const collection = await db.getCollection('tfm-facilities');

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
@@ -1,0 +1,20 @@
+const { ObjectId } = require('mongodb');
+const db = require('../../../../drivers/db-client');
+
+const findFacilitiesByDealId = async (dealId) => {
+  const collection = await db.getCollection('tfm-facilities');
+
+  // NOTE: only GEF facilities have applicationId.
+  // this could be adapted so that we get the deal, check dealType,
+  // then search for either dealId or applicationId.
+  const facilities = await collection.find({ 'facilitySnapshot.applicationId': { $eq: ObjectId(dealId) } }).toArray();
+
+  return facilities;
+};
+exports.findFacilitiesByDealId = findFacilitiesByDealId;
+
+exports.findFacilitiesGet = async (req, res) => {
+  const facilities = await findFacilitiesByDealId(req.params.id);
+
+  return res.status(200).send(facilities);
+};

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -8,6 +8,7 @@ const tfmUpdateDealController = require('../controllers/tfm/deal/tfm-update-deal
 const tfmDeleteDealController = require('../controllers/tfm/deal/tfm-delete-deal.controller');
 const tfmSubmitDealController = require('../controllers/tfm/deal/tfm-submit-deal.controller');
 const tfmUpdateDealStageController = require('../controllers/tfm/deal/tfm-update-deal-stage.controller');
+const tfmGetFacilitiesController = require('../controllers/tfm/facility/tfm-get-facilities.controller');
 const tfmGetFacilityController = require('../controllers/tfm/facility/tfm-get-facility.controller');
 const tfmUpdateFacilityController = require('../controllers/tfm/facility/tfm-update-facility.controller');
 
@@ -50,6 +51,11 @@ tfmRouter.route('/deals/:id/stage')
 tfmRouter.route('/deals')
   .get(
     tfmGetDealsController.findDealsGet,
+  );
+
+tfmRouter.route('/deals/:id/facilities')
+  .get(
+    tfmGetFacilitiesController.findFacilitiesGet,
   );
 
 tfmRouter.route('/facilities/:id')

--- a/e2e-tests/gef/cypress/integration/facility-value.spec.js
+++ b/e2e-tests/gef/cypress/integration/facility-value.spec.js
@@ -67,7 +67,7 @@ context('Facility Value Page', () => {
       facilityValue.mainHeading().contains('risk');
       facilityValue.hiddenFacilityType().should('be', 'invisible');
       facilityValue.valueLabel().should('contain', 'contingent');
-      facilityValue.valueSuffix().should('contain', 'YEN');
+      facilityValue.valueSuffix().should('contain', 'JPY');
       facilityValue.continueButton();
     });
   });

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
@@ -4,7 +4,7 @@ import tfmPages from '../../../../../../trade-finance-manager/cypress/integratio
 import tfmPartials from '../../../../../../trade-finance-manager/cypress/integration/partials';
 
 import MOCK_USERS from '../../../../../../portal/cypress/fixtures/mockUsers';
-import MOCK_MIADEAL_READY_TO_SUBMIT from '../test-data/MIA-deal/dealReadyToSubmit';
+import MOCK_AIN_DEAL_READY_TO_SUBMIT from '../test-data/AIN-deal/dealReadyToSubmit';
 
 const MAKER_LOGIN = MOCK_USERS.find((user) => (user.roles.includes('maker') && user.username === 'BANK1_MAKER1'));
 const CHECKER_LOGIN = MOCK_USERS.find((user) => (user.roles.includes('checker') && user.username === 'BANK1_CHECKER1'));
@@ -23,7 +23,7 @@ context('Portal to TFM deal submission', () => {
 
   before(() => {
     cy.insertManyDeals([
-      MOCK_MIADEAL_READY_TO_SUBMIT(),
+      MOCK_AIN_DEAL_READY_TO_SUBMIT(),
     ], MAKER_LOGIN)
       .then((insertedDeals) => {
         deal = insertedDeals[0];
@@ -37,7 +37,7 @@ context('Portal to TFM deal submission', () => {
       });
   });
 
-  it('Portal MIA deal is submitted to UKEF, `Application` deal stage is added to the deal in TFM', () => {
+  it('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage and product is added to the deal in TFM', () => {
     //---------------------------------------------------------------
     // portal maker submits deal for review
     //---------------------------------------------------------------
@@ -79,9 +79,15 @@ context('Portal to TFM deal submission', () => {
     cy.forceVisit(tfmCaseDealPage);
 
 
+    //---------------------------------------------------------------
+    // deal stage and product type is populated
+    //---------------------------------------------------------------
     tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
-      expect(text.trim()).to.contain('Application');
+      expect(text.trim()).to.contain('Confirmed');
     });
 
+    tfmPartials.caseSummary.ukefProduct().invoke('text').then((text) => {
+      expect(text.trim()).to.contain('BSS & EWCS');
+    });
   });
 });

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-MIA-deal-creates-tfm-deal-stage-and-product/submit-MIA-deal-creates-tfm-deal-stage-and-product.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-MIA-deal-creates-tfm-deal-stage-and-product/submit-MIA-deal-creates-tfm-deal-stage-and-product.spec.js
@@ -4,7 +4,7 @@ import tfmPages from '../../../../../../trade-finance-manager/cypress/integratio
 import tfmPartials from '../../../../../../trade-finance-manager/cypress/integration/partials';
 
 import MOCK_USERS from '../../../../../../portal/cypress/fixtures/mockUsers';
-import MOCK_AIN_DEAL_READY_TO_SUBMIT from '../test-data/AIN-deal/dealReadyToSubmit';
+import MOCK_MIADEAL_READY_TO_SUBMIT from '../test-data/MIA-deal/dealReadyToSubmit';
 
 const MAKER_LOGIN = MOCK_USERS.find((user) => (user.roles.includes('maker') && user.username === 'BANK1_MAKER1'));
 const CHECKER_LOGIN = MOCK_USERS.find((user) => (user.roles.includes('checker') && user.username === 'BANK1_CHECKER1'));
@@ -23,7 +23,7 @@ context('Portal to TFM deal submission', () => {
 
   before(() => {
     cy.insertManyDeals([
-      MOCK_AIN_DEAL_READY_TO_SUBMIT(),
+      MOCK_MIADEAL_READY_TO_SUBMIT(),
     ], MAKER_LOGIN)
       .then((insertedDeals) => {
         deal = insertedDeals[0];
@@ -37,7 +37,7 @@ context('Portal to TFM deal submission', () => {
       });
   });
 
-  it('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage is added to the deal in TFM', () => {
+  it('Portal MIA deal is submitted to UKEF, `Application` deal stage and product is added to the deal in TFM', () => {
     //---------------------------------------------------------------
     // portal maker submits deal for review
     //---------------------------------------------------------------
@@ -79,9 +79,15 @@ context('Portal to TFM deal submission', () => {
     cy.forceVisit(tfmCaseDealPage);
 
 
+    //---------------------------------------------------------------
+    // deal stage and product type is populated
+    //---------------------------------------------------------------
     tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
-      expect(text.trim()).to.contain('Confirmed');
+      expect(text.trim()).to.contain('Application');
     });
 
+    tfmPartials.caseSummary.ukefProduct().invoke('text').then((text) => {
+      expect(text.trim()).to.contain('BSS & EWCS');
+    });
   });
 });

--- a/e2e-tests/trade-finance-manager/cypress/integration/partials/caseSummary.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/partials/caseSummary.js
@@ -3,6 +3,7 @@ const partial = {
   supplierName: () => cy.get('[data-cy="supplier-name"]'),
   contractValue: () => cy.get('[data-cy="contract-value"]'),
   contractValueInGBP: () => cy.get('[data-cy="contract-value-in-gbp"]'),
+  ukefProduct: () => cy.get('[data-cy="ukef-product"]'),
   ukefDealStage: () => cy.get('[data-cy="ukef-deal-stage-value"]'),
   dealSubmissionType: () => cy.get('[data-cy="submission-type"]'),
 };

--- a/gef-ui/templates/partials/facility-currency.njk
+++ b/gef-ui/templates/partials/facility-currency.njk
@@ -91,9 +91,9 @@
               }
             },
             {
-              value: "YEN",
+              value: "JPY",
               text: "Japanese yen (YEN)",
-              checked: currency === "YEN",
+              checked: currency === "JPY",
               attributes: {
                 'data-cy': 'yen-checkbox'
               }

--- a/portal-api/src/v1/gef/enums.js
+++ b/portal-api/src/v1/gef/enums.js
@@ -49,7 +49,7 @@ const CURRENCY = {
   GBP: 'GBP',
   EUR: 'EUR',
   USD: 'USD',
-  YEN: 'YEN',
+  YEN: 'JPY',
 };
 
 module.exports = {

--- a/portal-api/src/v1/gef/models/facilities.js
+++ b/portal-api/src/v1/gef/models/facilities.js
@@ -30,7 +30,6 @@ function checkPaymentType(paymentType) {
 
 class Facility {
   constructor(req) {
-    console.log('CREATE NEW FACILITY - REQ \n', req);
     if (req.applicationId) {
       // new application
       this.applicationId = req.applicationId ? new ObjectId(req.applicationId) : null;

--- a/portal-api/src/v1/gef/models/facilities.js
+++ b/portal-api/src/v1/gef/models/facilities.js
@@ -30,6 +30,7 @@ function checkPaymentType(paymentType) {
 
 class Facility {
   constructor(req) {
+    console.log('CREATE NEW FACILITY - REQ \n', req);
     if (req.applicationId) {
       // new application
       this.applicationId = req.applicationId ? new ObjectId(req.applicationId) : null;

--- a/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
@@ -67,6 +67,7 @@ const GET_DEAL = gql`
         supplyContractValueInGBP
         lossGivenDefault
         probabilityOfDefault
+        product
         stage
         underwriterManagersDecision {
           decision

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -267,6 +267,20 @@ module.exports = {
       },
     };
   },
+  findFacilitesByDealId: (dealId) => {
+    const facilities = ALL_MOCK_FACILITIES.filter((f) => f.applicationid === dealId);
+
+    const mapped = facilities.map((facility) => ({
+      _id: facility._id,
+      facilitySnapshot: {
+        ...facility,
+        _id: facility._id,
+      },
+      tfm: {},
+    }));
+
+    return mapped;
+  },
   updateFacility: (facilityId, tfmUpdate) => {
     const facility = ALL_MOCK_FACILITIES.find((f) => f._id === facilityId); // eslint-disable-line no-underscore-dangle
 

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -225,6 +225,22 @@ const findOneFacility = async (facilityId) => {
   }
 };
 
+const findFacilitesByDealId = async (dealId) => {
+  try {
+    const response = await axios({
+      method: 'get',
+      url: `${centralApiUrl}/v1/tfm/deals/${dealId}/facilities`,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return response.data;
+  } catch (err) {
+    return err;
+  }
+};
+
 const updateFacility = async (facilityId, facilityUpdate) => {
   try {
     const response = await axios({
@@ -540,6 +556,7 @@ module.exports = {
   updateDealSnapshot,
   submitDeal,
   findOneFacility,
+  findFacilitesByDealId,
   updateFacility,
   queryDeals,
   getPartyDbInfo,

--- a/trade-finance-manager-api/src/v1/mappings/map-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-deal.js
@@ -6,9 +6,7 @@ const mapDeal = async (deal) => {
   const mappedDeal = JSON.parse(JSON.stringify(deal));
 
   if (deal.dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
-    mappedDeal.facilities = await Promise.all(deal.facilities.map(async (facility) =>
-      api.findOneFacility(facility._id)));
-
+    mappedDeal.facilities = await api.findFacilitesByDealId(deal._id);
     return mappedDeal;
   }
 

--- a/trade-finance-manager-ui/server/graphql/queries/deal-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deal-query.js
@@ -5,6 +5,7 @@ const dealQuery = gql`
     deal(params: { _id: $_id, tasksFilters: $tasksFilters }) {
       _id
       tfm {
+        product
         dateReceived
         parties {
           exporter {

--- a/trade-finance-manager-ui/server/graphql/queries/facility-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/facility-query.js
@@ -1,10 +1,5 @@
 import gql from 'graphql-tag';
 
-// TODO
-// this is assuming all facility mappings we have atm
-// will all be used in single facility query
-// revisit and remove any unused fields, once single facility is built out more.
-
 const facilityQuery = gql`
   query Facility($id: ID!) {
     facility(_id: $id) {

--- a/trade-finance-manager-ui/templates/case/_macros/case-summary.component-test.js
+++ b/trade-finance-manager-ui/templates/case/_macros/case-summary.component-test.js
@@ -22,6 +22,7 @@ let params = {
     supplyContractValueInGBP: 'GBP 123,456.78',
     stage: 'Confirmed',
     dateReceived: '01-02-2021',
+    product: 'GEF',
   },
   user: {
     timezone: 'Europe/London',
@@ -39,20 +40,21 @@ describe(component, () => {
     wrapper.expectText('[data-cy="ukef-deal-id"]').toRead(params.deal.details.ukefDealId);
   });
 
-  it('should render correct supplier type', () => {
+  it('should render supplier type', () => {
     wrapper.expectText('[data-cy="case-summary"] [data-cy="supplier-type"]').toRead('Exporter');
   });
+
 
   it('should render supplier name', () => {
     wrapper.expectText('[data-cy="supplier-name"]').toRead(params.deal.submissionDetails.supplierName);
   });
 
-  it('should add `chevron-right` class to supplier column', () => {
-    wrapper.expectElement('[data-cy="supplier-column"]').hasClass('case-summary-supplier chevron-right');
-  });
-
   it('should render buyer name', () => {
     wrapper.expectText('[data-cy="buyer-name"]').toRead(params.deal.submissionDetails.buyerName);
+  });
+
+  it('should add `chevron-right` class to supplier column', () => {
+    wrapper.expectElement('[data-cy="supplier-column"]').hasClass('case-summary-supplier chevron-right');
   });
 
   it('should render ukef deal stage component', () => {
@@ -90,6 +92,14 @@ describe(component, () => {
   it('should render date received', () => {
     const expected = formatDateString(params.tfm.dateReceived, 'DD-MM-YYYY', 'D MMMM YYYY');
     wrapper.expectText('[data-cy="date-received"]').toRead(expected);
+  });
+
+  it('should render UKEF product', () => {
+    wrapper.expectText('[data-cy="ukef-product"]').toRead(params.tfm.product);
+  });
+
+  it('should render submission type', () => {
+    wrapper.expectText('[data-cy="submission-type"]').toRead(params.deal.details.submissionType);
   });
 
   describe('when there is no date received', () => {

--- a/trade-finance-manager-ui/templates/case/_macros/case-summary.njk
+++ b/trade-finance-manager-ui/templates/case/_macros/case-summary.njk
@@ -58,6 +58,11 @@
 
       <div class="case-summary-overview-column ukef-grid-column-one-sixth">
         <div class="case-summary-overview-item">
+          <div class="ukef-heading-xs">Product</div>
+          <div class="ukef-body-s" data-cy="ukef-product">{{ tfm.product | dashIfEmpty }}</div>
+        </div>
+
+        <div class="case-summary-overview-item">
           <div class="ukef-heading-xs">Type</div>
           <div class="ukef-body-s" data-cy="submission-type">{{ deal.details.submissionType | dashIfEmpty }}</div>
         </div>


### PR DESCRIPTION
- central API: add `applicationId` as ObjectId when creating GEF facility
- central API: get GEF facilities with `applicationId` as ObjectId instead of string
- central API: endpoint to get all TFM facilities by `applicationId`.
- TFM API: get TFM facilities when mapping deal for UI with a single API call
- GEF UI: rename YEN currency value to JPY
- TFM UI: query and display TFM product