### PR TITLE
DTFS2-4362 - TFM email acknowledgement working for GEF deal/facilities

### DIFF
--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facilities-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facilities-get.api-test.js
@@ -46,10 +46,12 @@ describe('/v1/tfm/deals/:id/facilities', () => {
       });
 
       expect(status).toEqual(200);
-      expect(body).toEqual([
-        expectedFacilityShape(facility1),
-        expectedFacilityShape(facility2),
-      ]);
+
+      const foundFacility1 = body.find((f) => f._id === facility1._id);
+      const foundFacility2 = body.find((f) => f._id === facility2._id);
+
+      expect(foundFacility1).toEqual(expectedFacilityShape(facility1));
+      expect(foundFacility2).toEqual(expectedFacilityShape(facility2));
     });
   });
 });

--- a/dtfs-central-api/api-tests/v1/user/user-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/user/user-get.api-test.js
@@ -1,0 +1,46 @@
+const wipeDB = require('../../wipeDB');
+const app = require('../../../src/createApp');
+const api = require('../../api')(app);
+
+const newUser = {
+  username: 'BANK1_MAKER1',
+  firstname: 'Tamil',
+  surname: 'Rahani',
+  email: 'maker1@ukexportfinance.gov.uk',
+  timezone: 'Europe/London',
+  roles: ['maker'],
+  bank: {
+    id: '9',
+    name: 'UKEF test bank (Delegated)',
+    mga: ['mga_ukef_1.docx', 'mga_ukef_2.docx'],
+    emails: [
+      'maker1@ukexportfinance.gov.uk',
+      'checker1@ukexportfinance.gov.uk',
+    ],
+    companiesHouseNo: 'UKEF0001',
+    partyUrn: '00318345',
+  },
+};
+
+describe('/v1/user/:id', () => {
+  beforeAll(async () => {
+    await wipeDB.wipe(['users']);
+  });
+
+  describe('GET /v1/user/:id', () => {
+    it('returns a user', async () => {
+      const { body: createdUser } = await api.post(newUser).to('/v1/user');
+
+      const { body, status } = await api.get(`/v1/user/${createdUser._id}`);
+
+      expect(status).toEqual(200);
+
+      const expected = {
+        _id: createdUser._id,
+        ...newUser,
+      };
+
+      expect(body).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/api-tests/v1/user/user-post.api-test.js
+++ b/dtfs-central-api/api-tests/v1/user/user-post.api-test.js
@@ -1,0 +1,44 @@
+const wipeDB = require('../../wipeDB');
+const app = require('../../../src/createApp');
+const api = require('../../api')(app);
+
+const newUser = {
+  username: 'BANK1_MAKER1',
+  firstname: 'Tamil',
+  surname: 'Rahani',
+  email: 'maker1@ukexportfinance.gov.uk',
+  timezone: 'Europe/London',
+  roles: ['maker'],
+  bank: {
+    id: '9',
+    name: 'UKEF test bank (Delegated)',
+    mga: ['mga_ukef_1.docx', 'mga_ukef_2.docx'],
+    emails: [
+      'maker1@ukexportfinance.gov.uk',
+      'checker1@ukexportfinance.gov.uk',
+    ],
+    companiesHouseNo: 'UKEF0001',
+    partyUrn: '00318345',
+  },
+};
+
+describe('/v1/user', () => {
+  beforeAll(async () => {
+    await wipeDB.wipe(['users']);
+  });
+
+  describe('POST /v1/user', () => {
+    it('returns the created user', async () => {
+      const { body, status } = await api.post(newUser).to('/v1/user');
+
+      expect(status).toEqual(200);
+
+      const expected = {
+        _id: expect.any(String),
+        ...newUser,
+      };
+
+      expect(body).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/src/constants/routes.js
+++ b/dtfs-central-api/src/constants/routes.js
@@ -2,6 +2,7 @@ const ROUTES = {
   BANK_ROUTE: 'bank',
   PORTAL_ROUTE: 'portal',
   TFM_ROUTE: 'tfm',
+  USER_ROUTE: 'user',
 };
 
 module.exports = ROUTES;

--- a/dtfs-central-api/src/createApp.js
+++ b/dtfs-central-api/src/createApp.js
@@ -7,6 +7,7 @@ const {
   BANK_ROUTE,
   PORTAL_ROUTE,
   TFM_ROUTE,
+  USER_ROUTE,
 } = require('./constants/routes');
 
 const healthcheck = require('./healthcheck');
@@ -17,6 +18,7 @@ const {
   bankRoutes,
   portalRoutes,
   tfmRoutes,
+  userRoutes,
 } = require('./v1/routes');
 
 // const { CORS_ORIGIN } = process.env;
@@ -28,6 +30,7 @@ app.use(healthcheck);
 app.use(`/v1/${BANK_ROUTE}`, bankRoutes);
 app.use(`/v1/${PORTAL_ROUTE}`, portalRoutes);
 app.use(`/v1/${TFM_ROUTE}`, tfmRoutes);
+app.use(`/v1/${USER_ROUTE}`, userRoutes);
 
 
 // app.use(cors({

--- a/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
@@ -95,11 +95,21 @@ const findOneGefDeal = async (_id, callback) => {
   const deal = await dealsCollection.findOne({ _id: ObjectID(_id) });
 
   if (deal) {
-    // TODO promise all
-    deal.facilities = await findAllGefFacilitiesByDealId(_id);
-    const exporter = await findOneExporter(deal.exporterId);
-    const bank = await findOneBank(deal.bankId);
-    const maker = await findOneUser(deal.userId);
+    const promises = await Promise.all([
+      findAllGefFacilitiesByDealId(_id),
+      findOneExporter(deal.exporterId),
+      findOneBank(deal.bankId),
+      findOneUser(deal.userId),
+    ]);
+
+    const [
+      facilities,
+      exporter,
+      bank,
+      maker,
+    ] = [...promises];
+
+    deal.facilities = facilities;
 
     if (exporter) {
       deal.exporter = exporter;

--- a/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
@@ -4,6 +4,7 @@ const CONSTANTS = require('../../../../constants');
 const { findAllGefFacilitiesByDealId } = require('../gef-facility/get-facilities.controller');
 const { findOneExporter } = require('../gef-exporter/get-gef-exporter.controller');
 const { findOneBank } = require('../../bank/get-bank.controller');
+const { findOneUser } = require('../../user/get-user.controller');
 
 const queryDeals = async (query, start = 0, pagesize = 0) => {
   const collection = await db.getCollection('deals');
@@ -94,9 +95,11 @@ const findOneGefDeal = async (_id, callback) => {
   const deal = await dealsCollection.findOne({ _id: ObjectID(_id) });
 
   if (deal) {
+    // TODO promise all
     deal.facilities = await findAllGefFacilitiesByDealId(_id);
     const exporter = await findOneExporter(deal.exporterId);
     const bank = await findOneBank(deal.bankId);
+    const maker = await findOneUser(deal.userId);
 
     if (exporter) {
       deal.exporter = exporter;
@@ -104,6 +107,10 @@ const findOneGefDeal = async (_id, callback) => {
 
     if (bank) {
       deal.bank = bank;
+    }
+
+    if (maker) {
+      deal.maker = maker;
     }
   }
 

--- a/dtfs-central-api/src/v1/controllers/user/create-user.controller.js
+++ b/dtfs-central-api/src/v1/controllers/user/create-user.controller.js
@@ -1,0 +1,17 @@
+const db = require('../../../drivers/db-client');
+
+const createUser = async (user) => {
+  const collection = await db.getCollection('users');
+
+  const response = await collection.insertOne(user);
+
+  const createdUser = response.ops[0];
+
+  return createdUser;
+};
+
+exports.createUserPost = async (req, res) => {
+  const user = await createUser(req.body);
+
+  return res.status(200).send(user);
+};

--- a/dtfs-central-api/src/v1/controllers/user/get-user.controller.js
+++ b/dtfs-central-api/src/v1/controllers/user/get-user.controller.js
@@ -1,0 +1,21 @@
+const { ObjectId } = require('mongodb');
+const db = require('../../../drivers/db-client');
+
+const findOneUser = async (_id) => {
+  const usersCollection = await db.getCollection('users');
+
+  const user = await usersCollection.findOne({ _id: ObjectId(_id) });
+
+  return user;
+};
+exports.findOneUser = findOneUser;
+
+exports.findOneUserGet = async (req, res) => {
+  const user = await findOneUser(req.params.id);
+
+  if (user) {
+    return res.status(200).send(user);
+  }
+
+  return res.status(404).send();
+};

--- a/dtfs-central-api/src/v1/routes/index.js
+++ b/dtfs-central-api/src/v1/routes/index.js
@@ -1,9 +1,11 @@
 const bankRoutes = require('./bank-routes');
 const portalRoutes = require('./portal-routes');
 const tfmRoutes = require('./tfm-routes');
+const userRoutes = require('./user-routes');
 
 module.exports = {
   bankRoutes,
   portalRoutes,
   tfmRoutes,
+  userRoutes,
 };

--- a/dtfs-central-api/src/v1/routes/user-routes.js
+++ b/dtfs-central-api/src/v1/routes/user-routes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+
+const userRouter = express.Router();
+
+const getUserController = require('../controllers/user/get-user.controller');
+const createUserController = require('../controllers/user/create-user.controller');
+
+userRouter.route('/')
+  .post(
+    createUserController.createUserPost,
+  );
+
+userRouter.route('/:id')
+  .get(
+    getUserController.findOneUserGet,
+  );
+
+module.exports = userRouter;

--- a/trade-finance-manager-api/api-tests/send-deal-submit-emails.api-test.js
+++ b/trade-finance-manager-api/api-tests/send-deal-submit-emails.api-test.js
@@ -2,17 +2,11 @@ const {
   shouldSendFirstTaskEmail,
   sendFirstTaskEmail,
   sendDealSubmitEmails,
-  generateFacilityLists,
   generateAinMinEmailVariables,
   sendMiaAcknowledgement,
-  sendAinMinIssuedFacilitiesAcknowledgement,
 } = require('../src/v1/controllers/send-deal-submit-emails');
-const {
-  generateFacilitiesReferenceListString,
-  generateFacilitiesListString,
-} = require('../src/v1/helpers/notify-template-formatters');
+const { generateFacilityLists } = require('../src/v1/helpers/notify-template-formatters');
 const { generateTaskEmailVariables } = require('../src/v1/helpers/generate-task-email-variables');
-const sendTfmEmail = require('../src/v1/controllers/send-tfm-email');
 
 const CONSTANTS = require('../src/constants');
 const MOCK_TEAMS = require('../src/v1/__mocks__/mock-teams');

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
@@ -62,7 +62,7 @@ describe('/v1/deals', () => {
 
           const { email: expectedTeamEmailAddress } = MOCK_TEAMS.find((t) => t.id === firstTask.team.id);
 
-          expect(sendEmailApiSpy).toBeCalledTimes(1);
+          expect(sendEmailApiSpy).toBeCalledTimes(2);
 
           const expected = {
             templateId: CONSTANTS.EMAIL_TEMPLATE_IDS.TASK_READY_TO_START,
@@ -76,7 +76,9 @@ describe('/v1/deals', () => {
             ),
           };
 
-          expect(sendEmailApiSpy.mock.calls[0][0]).toEqual(
+          const firstSendEmailCall = sendEmailApiSpy.mock.calls[0][0];
+
+          expect(firstSendEmailCall).toEqual(
             expected.templateId,
             expected.sendToEmailAddress,
             expected.emailVariables,

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN.js
@@ -12,6 +12,7 @@ const MOCK_DEAL = {
       username: 'JOE',
       firstname: 'Joe',
       surname: 'Bloggs',
+      email: 'test@testing.com',
     },
     checker: {
       username: 'CHECKER',

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
@@ -3,9 +3,8 @@ const CONSTANTS = require('../../constants');
 const { getFirstTask } = require('../helpers/tasks');
 const { issuedFacilities } = require('../helpers/issued-facilities');
 const {
+  generateFacilitiesReferenceListString,
   generateFacilitiesListString,
-  generateBSSListString,
-  generateEWCSListString,
 } = require('../helpers/notify-template-formatters');
 const { generateTaskEmailVariables } = require('../helpers/generate-task-email-variables');
 const sendTfmEmail = require('./send-tfm-email');
@@ -106,15 +105,11 @@ const generateBssFacilityLists = (facilities) => {
     issuedBonds, unissuedBonds, issuedLoans, unissuedLoans,
   } = issuedFacilities(facilities);
 
-  const issuedBondsList = generateBSSListString(issuedBonds);
-  const issuedLoansList = generateEWCSListString(issuedLoans);
+  const issuedBondsList = generateFacilitiesListString(issuedBonds);
+  const issuedLoansList = generateFacilitiesListString(issuedLoans);
 
-  const unissuedBondsList = generateBSSListString(unissuedBonds);
-  const unissuedLoansList = generateEWCSListString(unissuedLoans);
-
-  if (issuedBondsList.length === 0 && issuedLoansList.length === 0) {
-    return null;
-  }
+  const unissuedBondsList = generateFacilitiesListString(unissuedBonds);
+  const unissuedLoansList = generateFacilitiesListString(unissuedLoans);
 
   const issued = `${issuedBondsList}\n${issuedLoansList}`;
 
@@ -129,26 +124,17 @@ const generateBssFacilityLists = (facilities) => {
   };
 };
 
+
 const generateGefFacilityLists = (facilities) => {
   const {
     issuedCash, unissuedCash, issuedContingent, unissuedContingent,
   } = issuedFacilities(facilities);
 
-  // const issuedCashList = generateBSSListString(issuedCash);
-  // const issuedContingentList = generateEWCSListString(issuedContingent);
+  const issuedCashList = generateFacilitiesListString(issuedCash);
+  const issuedContingentList = generateFacilitiesListString(issuedContingent);
 
-  // const unissuedCashList = generateBSSListString(unissuedCash);
-  // const unissuedContingentList = generateEWCSListString(unissuedContingent);
-
-  const issuedCashList = 'TONY TEST';
-  const issuedContingentList = 'TONY TEST';
-
-  const unissuedCashList = 'TONY TEST';
-  const unissuedContingentList = 'TONY TEST';
-
-  if (issuedCashList.length === 0 && issuedContingentList.length === 0) {
-    return null;
-  }
+  const unissuedCashList = generateFacilitiesListString(unissuedCash);
+  const unissuedContingentList = generateFacilitiesListString(unissuedContingent);
 
   const issued = `${issuedCashList}\n${issuedContingentList}`;
 
@@ -259,6 +245,6 @@ module.exports = {
   sendFirstTaskEmail,
   sendDealSubmitEmails,
   sendMiaAcknowledgement,
-  generateFacilitiesListString,
+  generateFacilitiesReferenceListString,
   sendAinMinIssuedFacilitiesAcknowledgement,
 };

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
@@ -169,35 +169,16 @@ const generateFacilityLists = (dealType, facilities) => {
   };
 };
 
-const sendAinMinIssuedFacilitiesAcknowledgement = async (deal) => {
+const generateAinMinEmailVariables = (deal, facilityLists) => {
   const {
-    dealType,
     ukefDealId,
     bankReferenceNumber,
     submissionType,
     maker,
-    facilities,
     exporter,
   } = deal;
 
-  if (submissionType !== CONSTANTS.DEALS.SUBMISSION_TYPE.MIN
-    && submissionType !== CONSTANTS.DEALS.SUBMISSION_TYPE.AIN) {
-    return null;
-  }
-
-  const facilityLists = generateFacilityLists(dealType, facilities);
-
-  if (!facilityLists.issued) {
-    return null;
-  }
-
-  const {
-    firstname,
-    surname,
-    email: sendToEmailAddress,
-  } = maker;
-
-  const templateId = CONSTANTS.EMAIL_TEMPLATE_IDS.DEAL_SUBMIT_MIN_AIN_FACILITIES_ISSUED;
+  const { firstname, surname } = maker;
 
   const emailVariables = {
     firstname,
@@ -213,6 +194,34 @@ const sendAinMinIssuedFacilitiesAcknowledgement = async (deal) => {
     showUnissuedHeader: facilityLists.unissued ? 'yes' : 'no',
   };
 
+  return emailVariables;
+};
+
+const sendAinMinIssuedFacilitiesAcknowledgement = async (deal) => {
+  const {
+    dealType,
+    submissionType,
+    maker,
+    facilities,
+  } = deal;
+
+  if (submissionType !== CONSTANTS.DEALS.SUBMISSION_TYPE.MIN
+    && submissionType !== CONSTANTS.DEALS.SUBMISSION_TYPE.AIN) {
+    return null;
+  }
+
+  const facilityLists = generateFacilityLists(dealType, facilities);
+
+  if (!facilityLists.issued) {
+    return null;
+  }
+
+  const { email: sendToEmailAddress } = maker;
+
+  const templateId = CONSTANTS.EMAIL_TEMPLATE_IDS.DEAL_SUBMIT_MIN_AIN_FACILITIES_ISSUED;
+
+  const emailVariables = generateAinMinEmailVariables(deal, facilityLists);
+
   const emailResponse = await sendTfmEmail(
     templateId,
     sendToEmailAddress,
@@ -227,9 +236,7 @@ const sendDealSubmitEmails = async (deal) => {
     return false;
   }
 
-  // send email for the first task
   const firstTaskEmail = await sendFirstTaskEmail(deal);
-
   const emailAcknowledgementMIA = await sendMiaAcknowledgement(deal);
   const emailAcknowledgementAinMinIssued = await sendAinMinIssuedFacilitiesAcknowledgement(deal);
 
@@ -246,5 +253,7 @@ module.exports = {
   sendDealSubmitEmails,
   sendMiaAcknowledgement,
   generateFacilitiesReferenceListString,
+  generateFacilityLists,
+  generateAinMinEmailVariables,
   sendAinMinIssuedFacilitiesAcknowledgement,
 };

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
@@ -52,7 +52,6 @@ const sendFirstTaskEmail = async (deal) => {
   return null;
 };
 
-// TODO: is there  a unit test for this
 const sendMiaAcknowledgement = async (deal) => {
   const {
     ukefDealId,

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
@@ -1,9 +1,8 @@
 const api = require('../api');
 const CONSTANTS = require('../../constants');
 const { getFirstTask } = require('../helpers/tasks');
-const { issuedFacilities } = require('../helpers/issued-facilities');
 const {
-  generateFacilitiesReferenceListString,
+  generateFacilityLists,
   generateFacilitiesListString,
 } = require('../helpers/notify-template-formatters');
 const { generateTaskEmailVariables } = require('../helpers/generate-task-email-variables');
@@ -53,6 +52,7 @@ const sendFirstTaskEmail = async (deal) => {
   return null;
 };
 
+// TODO: is there  a unit test for this
 const sendMiaAcknowledgement = async (deal) => {
   const {
     ukefDealId,
@@ -98,75 +98,6 @@ const sendMiaAcknowledgement = async (deal) => {
     deal,
   );
   return emailResponse;
-};
-
-const generateBssFacilityLists = (facilities) => {
-  const {
-    issuedBonds, unissuedBonds, issuedLoans, unissuedLoans,
-  } = issuedFacilities(facilities);
-
-  const issuedBondsList = generateFacilitiesListString(issuedBonds);
-  const issuedLoansList = generateFacilitiesListString(issuedLoans);
-
-  const unissuedBondsList = generateFacilitiesListString(unissuedBonds);
-  const unissuedLoansList = generateFacilitiesListString(unissuedLoans);
-
-  const issued = `${issuedBondsList}\n${issuedLoansList}`;
-
-  let unissued = '';
-  if (unissuedBondsList.length || unissuedLoansList.length) {
-    unissued = `${unissuedBondsList}\n${unissuedLoansList}`;
-  }
-
-  return {
-    issued,
-    unissued,
-  };
-};
-
-
-const generateGefFacilityLists = (facilities) => {
-  const {
-    issuedCash, unissuedCash, issuedContingent, unissuedContingent,
-  } = issuedFacilities(facilities);
-
-  const issuedCashList = generateFacilitiesListString(issuedCash);
-  const issuedContingentList = generateFacilitiesListString(issuedContingent);
-
-  const unissuedCashList = generateFacilitiesListString(unissuedCash);
-  const unissuedContingentList = generateFacilitiesListString(unissuedContingent);
-
-  const issued = `${issuedCashList}\n${issuedContingentList}`;
-
-  let unissued = '';
-  if (unissuedCashList.length || unissuedContingentList.length) {
-    unissued = `${unissuedCashList}\n${unissuedContingentList}`;
-  }
-
-  return {
-    issued,
-    unissued,
-  };
-};
-
-const generateFacilityLists = (dealType, facilities) => {
-  let issuedList;
-  let unissuedList;
-
-  if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
-    const { issued, unissued } = generateBssFacilityLists(facilities);
-    issuedList = issued;
-    unissuedList = unissued;
-  } else if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
-    const { issued, unissued } = generateGefFacilityLists(facilities);
-    issuedList = issued;
-    unissuedList = unissued;
-  }
-
-  return {
-    issued: issuedList,
-    unissued: unissuedList,
-  };
 };
 
 const generateAinMinEmailVariables = (deal, facilityLists) => {
@@ -252,8 +183,6 @@ module.exports = {
   sendFirstTaskEmail,
   sendDealSubmitEmails,
   sendMiaAcknowledgement,
-  generateFacilitiesReferenceListString,
-  generateFacilityLists,
   generateAinMinEmailVariables,
   sendAinMinIssuedFacilitiesAcknowledgement,
 };

--- a/trade-finance-manager-api/src/v1/helpers/issued-facilities.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/issued-facilities.api-test.js
@@ -1,23 +1,43 @@
 const { issuedFacilities } = require('./issued-facilities');
 const CONSTANTS = require('../../constants');
 
-const issuedBond = {
+const issuedBondFacility = {
   facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
   hasBeenIssued: true,
 };
 
-const issuedLoan = {
+const issuedLoanFacility = {
   facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN,
   hasBeenIssued: true,
 };
 
-const unissuedBond = {
+const unissuedBondFacility = {
   facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
   hasBeenIssued: false,
 };
 
-const unissuedLoan = {
+const unissuedLoanFacility = {
   facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN,
+  hasBeenIssued: false,
+};
+
+const issuedCashFacility = {
+  facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CASH,
+  hasBeenIssued: true,
+};
+
+const unissuedCashFacility = {
+  facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CASH,
+  hasBeenIssued: false,
+};
+
+const issuedContingentFacility = {
+  facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT,
+  hasBeenIssued: true,
+};
+
+const unissuedContingentFacility = {
+  facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT,
   hasBeenIssued: false,
 };
 
@@ -26,10 +46,14 @@ describe('return list of issued & unissued facilities', () => {
     let facilities;
     beforeAll(() => {
       facilities = [
-        issuedBond,
-        unissuedBond,
-        issuedLoan,
-        unissuedLoan,
+        issuedBondFacility,
+        unissuedBondFacility,
+        issuedLoanFacility,
+        unissuedLoanFacility,
+        issuedCashFacility,
+        unissuedCashFacility,
+        issuedContingentFacility,
+        unissuedContingentFacility,
       ];
     });
 
@@ -39,12 +63,21 @@ describe('return list of issued & unissued facilities', () => {
         unissuedBonds,
         issuedLoans,
         unissuedLoans,
+        issuedCash,
+        unissuedCash,
+        issuedContingent,
+        unissuedContingent,
       } = issuedFacilities(facilities);
 
-      expect(issuedBonds).toEqual([issuedBond]);
-      expect(unissuedBonds).toEqual([unissuedBond]);
-      expect(unissuedLoans).toEqual([unissuedLoan]);
-      expect(issuedLoans).toEqual([issuedLoan]);
+      expect(issuedBonds).toEqual([issuedBondFacility]);
+      expect(unissuedBonds).toEqual([unissuedBondFacility]);
+      expect(unissuedLoans).toEqual([unissuedLoanFacility]);
+      expect(issuedLoans).toEqual([issuedLoanFacility]);
+
+      expect(issuedCash).toEqual([issuedCashFacility]);
+      expect(unissuedCash).toEqual([unissuedCashFacility]);
+      expect(issuedContingent).toEqual([issuedContingentFacility]);
+      expect(unissuedContingent).toEqual([unissuedContingentFacility]);
     });
   });
 
@@ -52,8 +85,8 @@ describe('return list of issued & unissued facilities', () => {
     let facilities;
     beforeAll(() => {
       facilities = [
-        issuedBond,
-        unissuedLoan,
+        issuedBondFacility,
+        unissuedLoanFacility,
       ];
     });
 
@@ -65,9 +98,9 @@ describe('return list of issued & unissued facilities', () => {
         unissuedLoans,
       } = issuedFacilities(facilities);
 
-      expect(issuedBonds).toEqual([issuedBond]);
+      expect(issuedBonds).toEqual([issuedBondFacility]);
       expect(unissuedBonds).toEqual([]);
-      expect(unissuedLoans).toEqual([unissuedLoan]);
+      expect(unissuedLoans).toEqual([unissuedLoanFacility]);
       expect(issuedLoans).toEqual([]);
     });
   });

--- a/trade-finance-manager-api/src/v1/helpers/issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/helpers/issued-facilities.js
@@ -5,10 +5,18 @@ const issuedFacilities = (facilities) => {
   const unissuedFacilitiesList = facilities.filter((f) => f.hasBeenIssued === false);
 
   return {
+    // BSS & EWCS facilities
     issuedBonds: issuedFacilitiesList.filter((f) => f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.BOND),
     unissuedBonds: unissuedFacilitiesList.filter((f) => f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.BOND),
     issuedLoans: issuedFacilitiesList.filter((f) => f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN),
     unissuedLoans: unissuedFacilitiesList.filter((f) => f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN),
+    // GEF (Cash & Contingent) facilities
+    issuedCash: issuedFacilitiesList.filter((f) => f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CASH),
+    unissuedCash: unissuedFacilitiesList.filter((f) => f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CASH),
+    issuedContingent: issuedFacilitiesList.filter((f) =>
+      f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT),
+    unissuedContingent: unissuedFacilitiesList.filter((f) =>
+      f.facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT),
   };
 };
 

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.api-test.js
@@ -1,13 +1,11 @@
 const {
   generateFacilitiesListHeading,
-  generateFacilitiesReferenceListString,
   generateFacilitiesListString,
   generateBssFacilityLists,
   generateGefFacilityLists,
   generateFacilityLists,
 } = require('./notify-template-formatters');
 const { issuedFacilities } = require('./issued-facilities');
-const { capitalizeFirstLetter } = require('../../utils/string');
 
 const CONSTANTS = require('../../constants');
 
@@ -42,90 +40,6 @@ describe('notify-template-formatters', () => {
         const result = generateFacilitiesListHeading(CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT);
 
         expect(result).toEqual(`#${CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CONTINGENT} facility\n\n`);
-      });
-    });
-  });
-
-  describe('generateFacilitiesReferenceListString', () => {
-    it('should return string list for all facilities', () => {
-      const mockFacilities = [
-        {
-          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
-          ukefFacilityID: '1',
-          uniqueIdentificationNumber: '123',
-        },
-        {
-          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN,
-          ukefFacilityID: '2',
-          uniqueIdentificationNumber: '456',
-        },
-      ];
-
-      const result = generateFacilitiesReferenceListString(mockFacilities);
-
-      const expectedString = (facility) => {
-        const {
-          facilityType,
-          ukefFacilityID,
-          uniqueIdentificationNumber,
-        } = facility;
-
-        const bankRefString = `with your reference ${uniqueIdentificationNumber} `;
-
-        return `- ${capitalizeFirstLetter(facilityType)} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
-      };
-
-      const firstString = expectedString(mockFacilities[0]);
-      const secondString = expectedString(mockFacilities[1]);
-
-      const expected = `${firstString}${secondString}`;
-      expect(result).toEqual(expected);
-    });
-
-    describe('when a facility has no uniqueIdentificationNumber, but has bankReference', () => {
-      it('should return string with bankReference', () => {
-        const mockFacility = {
-          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
-          ukefFacilityID: '1',
-          bankReference: '100',
-        };
-
-        const result = generateFacilitiesReferenceListString([mockFacility]);
-
-        const expectedString = (facility) => {
-          const {
-            facilityType,
-            ukefFacilityID,
-            bankReference,
-          } = facility;
-
-          const bankRefString = `with your reference ${bankReference} `;
-
-          return `- ${capitalizeFirstLetter(facilityType)} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
-        };
-
-        const expected = expectedString(mockFacility);
-        expect(result).toEqual(expected);
-      });
-    });
-
-    describe('when a facility does NOT have uniqueIdentificationNumber or bankReference', () => {
-      it('should return string', () => {
-        const mockFacility = {
-          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
-          ukefFacilityID: '1',
-        };
-
-        const result = generateFacilitiesReferenceListString([mockFacility]);
-
-        const expectedString = (facility) => {
-          const { facilityType, ukefFacilityID } = facility;
-
-          return `- ${capitalizeFirstLetter(facilityType)} facility has been given the UKEF reference: ${ukefFacilityID} \n`;
-        };
-
-        const expected = expectedString(mockFacility);
-        expect(result).toEqual(expected);
       });
     });
   });

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.api-test.js
@@ -1,0 +1,375 @@
+const {
+  generateFacilitiesListHeading,
+  generateFacilitiesReferenceListString,
+  generateFacilitiesListString,
+  generateBssFacilityLists,
+  generateGefFacilityLists,
+  generateFacilityLists,
+} = require('./notify-template-formatters');
+const { issuedFacilities } = require('./issued-facilities');
+const { capitalizeFirstLetter } = require('../../utils/string');
+
+const CONSTANTS = require('../../constants');
+
+describe('notify-template-formatters', () => {
+  describe('generateFacilitiesListHeading', () => {
+    describe('when facilityType is loan', () => {
+      it('should return loan product name', () => {
+        const result = generateFacilitiesListHeading(CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN);
+
+        expect(result).toEqual(`#${CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.LOAN}\n\n`);
+      });
+    });
+
+    describe('when facilityType is bond', () => {
+      it('should return bond product name', () => {
+        const result = generateFacilitiesListHeading(CONSTANTS.FACILITIES.FACILITY_TYPE.BOND);
+
+        expect(result).toEqual(`#${CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.BOND}\n\n`);
+      });
+    });
+
+    describe('when facilityType is cash', () => {
+      it('should return cash product name', () => {
+        const result = generateFacilitiesListHeading(CONSTANTS.FACILITIES.FACILITY_TYPE.CASH);
+
+        expect(result).toEqual(`#${CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CASH} facility\n\n`);
+      });
+    });
+
+    describe('when facilityType is contingent', () => {
+      it('should return contingent product name', () => {
+        const result = generateFacilitiesListHeading(CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT);
+
+        expect(result).toEqual(`#${CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CONTINGENT} facility\n\n`);
+      });
+    });
+  });
+
+  describe('generateFacilitiesReferenceListString', () => {
+    it('should return string list for all facilities', () => {
+      const mockFacilities = [
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+          ukefFacilityID: '1',
+          uniqueIdentificationNumber: '123',
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN,
+          ukefFacilityID: '2',
+          uniqueIdentificationNumber: '456',
+        },
+      ];
+
+      const result = generateFacilitiesReferenceListString(mockFacilities);
+
+      const expectedString = (facility) => {
+        const {
+          facilityType,
+          ukefFacilityID,
+          uniqueIdentificationNumber,
+        } = facility;
+
+        const bankRefString = `with your reference ${uniqueIdentificationNumber} `;
+
+        return `- ${capitalizeFirstLetter(facilityType)} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
+      };
+
+      const firstString = expectedString(mockFacilities[0]);
+      const secondString = expectedString(mockFacilities[1]);
+
+      const expected = `${firstString}${secondString}`;
+      expect(result).toEqual(expected);
+    });
+
+    describe('when a facility has no uniqueIdentificationNumber, but has bankReference', () => {
+      it('should return string with bankReference', () => {
+        const mockFacility = {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+          ukefFacilityID: '1',
+          bankReferenceNumber: '100',
+        };
+
+        const result = generateFacilitiesReferenceListString([mockFacility]);
+
+        const expectedString = (facility) => {
+          const {
+            facilityType,
+            ukefFacilityID,
+            bankReferenceNumber,
+          } = facility;
+
+          const bankRefString = `with your reference ${bankReferenceNumber} `;
+
+          return `- ${capitalizeFirstLetter(facilityType)} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
+        };
+
+        const expected = expectedString(mockFacility);
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when a facility does NOT have uniqueIdentificationNumber or bankReference', () => {
+      it('should return string', () => {
+        const mockFacility = {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+          ukefFacilityID: '1',
+        };
+
+        const result = generateFacilitiesReferenceListString([mockFacility]);
+
+        const expectedString = (facility) => {
+          const { facilityType, ukefFacilityID } = facility;
+
+          return `- ${capitalizeFirstLetter(facilityType)} facility has been given the UKEF reference: ${ukefFacilityID} \n`;
+        };
+
+        const expected = expectedString(mockFacility);
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+
+  describe('generateFacilitiesListString', () => {
+    const expectedString = (facility, bankRefField) => {
+      const { ukefFacilityID } = facility;
+
+      let bankRefStr;
+      if (bankRefField) {
+        bankRefStr = `*Your bank ref: ${facility[bankRefField]}\n`;
+      }
+
+      const ukefIdString = `*UKEF facility ID: ${ukefFacilityID}\n\n`;
+
+      return `${bankRefStr}${ukefIdString}`;
+    };
+
+    it('should return string list for all facilities with a single heading', () => {
+      const mockFacilities = [
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+          ukefFacilityID: '1',
+          uniqueIdentificationNumber: '123',
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+          ukefFacilityID: '2',
+          uniqueIdentificationNumber: '456',
+        },
+      ];
+
+      const result = generateFacilitiesListString(mockFacilities);
+
+      const heading = generateFacilitiesListHeading(mockFacilities[0].facilityType);
+
+      const firstString = expectedString(mockFacilities[0], 'uniqueIdentificationNumber');
+      const secondString = expectedString(mockFacilities[1], 'uniqueIdentificationNumber');
+      const strings = `${firstString}${secondString}`;
+
+      const expected = `${heading}${strings}`;
+
+      expect(result).toEqual(expected);
+    });
+
+    describe('when a facility has no uniqueIdentificationNumber, but has bankReferenceNumber', () => {
+      it('should return string with bankReferenceNumber', () => {
+        const mockFacilities = [
+          {
+            facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+            ukefFacilityID: '1',
+            bankReferenceNumber: '123',
+          },
+        ];
+
+        const result = generateFacilitiesListString(mockFacilities);
+
+        const heading = generateFacilitiesListHeading(mockFacilities[0].facilityType);
+
+        const string = expectedString(mockFacilities[0], 'bankReferenceNumber');
+
+        const expected = `${heading}${string}`;
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when a facility does NOT have uniqueIdentificationNumber or bankReferenceNumber', () => {
+      it('should return string', () => {
+        const mockFacilities = [
+          {
+            facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+            ukefFacilityID: '1',
+          },
+        ];
+
+        const result = generateFacilitiesListString(mockFacilities);
+
+        const heading = generateFacilitiesListHeading(mockFacilities[0].facilityType);
+
+        const string = `*UKEF facility ID: ${mockFacilities[0].ukefFacilityID}\n\n`;
+
+        const expected = `${heading}${string}`;
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when there are no facilities', () => {
+      it('should return empty string', () => {
+        const result = generateFacilitiesListString([]);
+
+        expect(result).toEqual('');
+      });
+    });
+  });
+
+  describe('generateBssFacilityLists', () => {
+    it('should return issued and unissued facilities list string', () => {
+      const mockFacilities = [
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+          hasBeenIssued: true,
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+          hasBeenIssued: false,
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN,
+          hasBeenIssued: true,
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN,
+          hasBeenIssued: false,
+        },
+      ];
+
+      const result = generateBssFacilityLists(mockFacilities);
+
+      const {
+        issuedBonds, unissuedBonds, issuedLoans, unissuedLoans,
+      } = issuedFacilities(mockFacilities);
+
+      const issuedBondsList = generateFacilitiesListString(issuedBonds);
+      const issuedLoansList = generateFacilitiesListString(issuedLoans);
+
+      const unissuedBondsList = generateFacilitiesListString(unissuedBonds);
+      const unissuedLoansList = generateFacilitiesListString(unissuedLoans);
+
+      const expectedIssuedStr = `${issuedBondsList}\n${issuedLoansList}`;
+      const expectedUnissuedStr = `${unissuedBondsList}\n${unissuedLoansList}`;
+
+      const expected = {
+        issued: expectedIssuedStr,
+        unissued: expectedUnissuedStr,
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    describe('when tere are no unissued facilities', () => {
+      it('should return unissued as empty string', () => {
+        const mockFacilities = [
+          {
+            facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
+            hasBeenIssued: true,
+          },
+        ];
+
+        const result = generateBssFacilityLists(mockFacilities);
+
+        expect(result.unissued).toEqual('');
+      });
+    });
+  });
+
+  describe('generateGefFacilityLists', () => {
+    it('should return issued and unissued facilities list string', () => {
+      const mockFacilities = [
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CASH,
+          hasBeenIssued: true,
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CASH,
+          hasBeenIssued: false,
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT,
+          hasBeenIssued: true,
+        },
+        {
+          facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT,
+          hasBeenIssued: false,
+        },
+      ];
+
+      const result = generateGefFacilityLists(mockFacilities);
+
+      const {
+        issuedCash, unissuedCash, issuedContingent, unissuedContingent,
+      } = issuedFacilities(mockFacilities);
+
+      const issuedCashList = generateFacilitiesListString(issuedCash);
+      const issuedContingentList = generateFacilitiesListString(issuedContingent);
+
+      const unissuedCashList = generateFacilitiesListString(unissuedCash);
+      const unissuedContingentList = generateFacilitiesListString(unissuedContingent);
+
+      const expectedIssuedStr = `${issuedCashList}\n${issuedContingentList}`;
+      const expectedUnissuedStr = `${unissuedCashList}\n${unissuedContingentList}`;
+
+      const expected = {
+        issued: expectedIssuedStr,
+        unissued: expectedUnissuedStr,
+      };
+
+      expect(result).toEqual(expected);
+    });
+
+    describe('when tere are no unissued facilities', () => {
+      it('should return unissued as empty string', () => {
+        const mockFacilities = [
+          {
+            facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.CASH,
+            hasBeenIssued: true,
+          },
+        ];
+
+        const result = generateGefFacilityLists(mockFacilities);
+
+        expect(result.unissued).toEqual('');
+      });
+    });
+  });
+
+  describe('generateFacilityLists', () => {
+    describe('when dealType is BSS/EWCS', () => {
+      it('should return result of generateBssFacilityLists', () => {
+        const mockDealType = CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS;
+        const mockFacilities = [];
+
+        const result = generateFacilityLists(mockDealType, mockFacilities);
+        const { issued, unissued } = generateBssFacilityLists(mockFacilities);
+
+        const expected = { issued, unissued };
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when dealType is GEF', () => {
+      it('should return result of generateGefFacilityLists', () => {
+        const mockDealType = CONSTANTS.DEALS.DEAL_TYPE.GEF;
+        const mockFacilities = [];
+
+        const result = generateFacilityLists(mockDealType, mockFacilities);
+        const { issued, unissued } = generateGefFacilityLists(mockFacilities);
+
+        const expected = { issued, unissued };
+
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.api-test.js
@@ -87,7 +87,7 @@ describe('notify-template-formatters', () => {
         const mockFacility = {
           facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
           ukefFacilityID: '1',
-          bankReferenceNumber: '100',
+          bankReference: '100',
         };
 
         const result = generateFacilitiesReferenceListString([mockFacility]);
@@ -96,10 +96,10 @@ describe('notify-template-formatters', () => {
           const {
             facilityType,
             ukefFacilityID,
-            bankReferenceNumber,
+            bankReference,
           } = facility;
 
-          const bankRefString = `with your reference ${bankReferenceNumber} `;
+          const bankRefString = `with your reference ${bankReference} `;
 
           return `- ${capitalizeFirstLetter(facilityType)} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
         };
@@ -171,13 +171,13 @@ describe('notify-template-formatters', () => {
       expect(result).toEqual(expected);
     });
 
-    describe('when a facility has no uniqueIdentificationNumber, but has bankReferenceNumber', () => {
-      it('should return string with bankReferenceNumber', () => {
+    describe('when a facility has no uniqueIdentificationNumber, but has bankReference', () => {
+      it('should return string with bankReference', () => {
         const mockFacilities = [
           {
             facilityType: CONSTANTS.FACILITIES.FACILITY_TYPE.BOND,
             ukefFacilityID: '1',
-            bankReferenceNumber: '123',
+            bankReference: '123',
           },
         ];
 
@@ -185,7 +185,7 @@ describe('notify-template-formatters', () => {
 
         const heading = generateFacilitiesListHeading(mockFacilities[0].facilityType);
 
-        const string = expectedString(mockFacilities[0], 'bankReferenceNumber');
+        const string = expectedString(mockFacilities[0], 'bankReference');
 
         const expected = `${heading}${string}`;
 
@@ -193,7 +193,7 @@ describe('notify-template-formatters', () => {
       });
     });
 
-    describe('when a facility does NOT have uniqueIdentificationNumber or bankReferenceNumber', () => {
+    describe('when a facility does NOT have uniqueIdentificationNumber or bankReference', () => {
       it('should return string', () => {
         const mockFacilities = [
           {

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
@@ -12,11 +12,11 @@ const generateFacilitiesListHeading = (facilityType) => {
   }
 
   if (facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CASH) {
-    heading = CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CASH;
+    heading = `${CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CASH} facility`;
   }
 
   if (facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT) {
-    heading = CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CONTINGENT;
+    heading = `${CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CONTINGENT} facility`;
   }
 
   return `#${heading}\n\n`;

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
@@ -1,4 +1,5 @@
 const { capitalizeFirstLetter } = require('../../utils/string');
+const { issuedFacilities } = require('./issued-facilities');
 const CONSTANTS = require('../../constants');
 
 const generateFacilitiesListHeading = (facilityType) => {
@@ -71,7 +72,78 @@ const generateFacilitiesListString = (facilities) => {
   return '';
 };
 
+const generateBssFacilityLists = (facilities) => {
+  const {
+    issuedBonds, unissuedBonds, issuedLoans, unissuedLoans,
+  } = issuedFacilities(facilities);
+
+  const issuedBondsList = generateFacilitiesListString(issuedBonds);
+  const issuedLoansList = generateFacilitiesListString(issuedLoans);
+
+  const unissuedBondsList = generateFacilitiesListString(unissuedBonds);
+  const unissuedLoansList = generateFacilitiesListString(unissuedLoans);
+
+  const issued = `${issuedBondsList}\n${issuedLoansList}`;
+
+  let unissued = '';
+  if (unissuedBondsList.length || unissuedLoansList.length) {
+    unissued = `${unissuedBondsList}\n${unissuedLoansList}`;
+  }
+
+  return {
+    issued,
+    unissued,
+  };
+};
+
+const generateGefFacilityLists = (facilities) => {
+  const {
+    issuedCash, unissuedCash, issuedContingent, unissuedContingent,
+  } = issuedFacilities(facilities);
+
+  const issuedCashList = generateFacilitiesListString(issuedCash);
+  const issuedContingentList = generateFacilitiesListString(issuedContingent);
+
+  const unissuedCashList = generateFacilitiesListString(unissuedCash);
+  const unissuedContingentList = generateFacilitiesListString(unissuedContingent);
+
+  const issued = `${issuedCashList}\n${issuedContingentList}`;
+
+  let unissued = '';
+  if (unissuedCashList.length || unissuedContingentList.length) {
+    unissued = `${unissuedCashList}\n${unissuedContingentList}`;
+  }
+
+  return {
+    issued,
+    unissued,
+  };
+};
+
+const generateFacilityLists = (dealType, facilities) => {
+  let issuedList;
+  let unissuedList;
+
+  if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
+    const { issued, unissued } = generateBssFacilityLists(facilities);
+    issuedList = issued;
+    unissuedList = unissued;
+  } else if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
+    const { issued, unissued } = generateGefFacilityLists(facilities);
+    issuedList = issued;
+    unissuedList = unissued;
+  }
+
+  return {
+    issued: issuedList,
+    unissued: unissuedList,
+  };
+};
+
 module.exports = {
   generateFacilitiesReferenceListString,
   generateFacilitiesListString,
+  generateBssFacilityLists,
+  generateGefFacilityLists,
+  generateFacilityLists,
 };

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
@@ -1,6 +1,28 @@
 const { capitalizeFirstLetter } = require('../../utils/string');
+const CONSTANTS = require('../../constants');
 
-const generateFacilitiesListString = (facilities) => facilities.reduce((acc, facility) => {
+const generateFacilitiesListHeading = (facilityType) => {
+  let heading;
+  if (facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.LOAN) {
+    heading = CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.LOAN;
+  }
+
+  if (facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.BOND) {
+    heading = CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.BOND;
+  }
+
+  if (facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CASH) {
+    heading = CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CASH;
+  }
+
+  if (facilityType === CONSTANTS.FACILITIES.FACILITY_TYPE.CONTINGENT) {
+    heading = CONSTANTS.FACILITIES.FACILITY_PRODUCT_NAME.CONTINGENT;
+  }
+
+  return `#${heading}\n\n`;
+};
+
+const generateFacilitiesReferenceListString = (facilities) => facilities.reduce((acc, facility) => {
   const {
     facilityType, ukefFacilityID, bankReferenceNumber, uniqueIdentificationNumber,
   } = facility;
@@ -13,52 +35,43 @@ const generateFacilitiesListString = (facilities) => facilities.reduce((acc, fac
   return `${acc}- ${fType} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
 }, '');
 
-const generateBSSListString = (facilities) => {
-  const bssList = facilities.reduce((acc, facility) => {
-    const {
-      bondType, ukefFacilityID, bankReferenceNumber, uniqueIdentificationNumber,
-    } = facility;
+const generateFacilitiesListString = (facilities) => {
+  const list = facilities.reduce((acc, facility) => {
+    const { ukefFacilityID } = facility;
 
-    const bankReference = uniqueIdentificationNumber || bankReferenceNumber;
-    const bankRefString = bankReference
-      ? `*Your bank ref: ${bankReference}\n`
-      : '';
+    let string = `${acc}`;
+    let bankReference;
 
-    return `${acc}*${bondType}\n${bankRefString}*UKEF facility ID: ${ukefFacilityID} \n\n`;
+    if (facility.uniqueIdentificationNumber) {
+      bankReference = facility.uniqueIdentificationNumber;
+    } else if (facility.bankReferenceNumber) {
+      bankReference = facility.bankReferenceNumber;
+    }
+
+    if (bankReference) {
+      const bankRefString = bankReference
+        ? `*Your bank ref: ${bankReference}\n`
+        : '';
+
+      string += bankRefString;
+    }
+
+    string += `*UKEF facility ID: ${ukefFacilityID}\n\n`;
+
+    return string;
   }, '');
 
-  if (bssList.length) {
-    const heading = '#Bond Support Scheme\n\n';
-    return `${heading}${bssList}`;
-  }
+  if (list.length) {
+    const { facilityType } = facilities[0];
 
-  return '';
-};
-
-const generateEWCSListString = (facilities) => {
-  const ewcsList = facilities.reduce((acc, facility) => {
-    const {
-      ukefFacilityID, bankReferenceNumber, uniqueIdentificationNumber,
-    } = facility;
-
-    const bankReference = uniqueIdentificationNumber || bankReferenceNumber;
-    const bankRefString = bankReference
-      ? `*Your bank ref: ${bankReference}\n`
-      : '';
-
-    return `${acc}${bankRefString}*UKEF facility ID: ${ukefFacilityID}\n\n`;
-  }, '');
-
-  if (ewcsList.length) {
-    const heading = '#Export Working Capital Scheme\n\n';
-    return `${heading}${ewcsList}`;
+    const heading = generateFacilitiesListHeading(facilityType);
+    return `${heading}${list}`;
   }
 
   return '';
 };
 
 module.exports = {
+  generateFacilitiesReferenceListString,
   generateFacilitiesListString,
-  generateBSSListString,
-  generateEWCSListString,
 };

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
@@ -1,5 +1,4 @@
 const { issuedFacilities } = require('./issued-facilities');
-const { capitalizeFirstLetter } = require('../../utils/string');
 const CONSTANTS = require('../../constants');
 
 const generateFacilitiesListHeading = (facilityType) => {
@@ -22,25 +21,6 @@ const generateFacilitiesListHeading = (facilityType) => {
 
   return `#${heading}\n\n`;
 };
-
-
-// TODO This is not used, but SHOULD be.
-// it's used for "UKEF has received your facility stage update" email.
-// TODO: rename
-// TODO: maybe move away from this file.
-// NOTE: I don't this is needed at all now.
-const generateFacilitiesReferenceListString = (facilities) => facilities.reduce((acc, facility) => {
-  const {
-    facilityType, ukefFacilityID, bankReference, uniqueIdentificationNumber,
-  } = facility;
-  const fType = capitalizeFirstLetter(facilityType);
-  const bankRef = uniqueIdentificationNumber || bankReference;
-  const bankRefString = bankRef
-    ? `with your reference ${bankRef} `
-    : '';
-
-  return `${acc}- ${fType} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
-}, '');
 
 const generateFacilitiesListString = (facilities) => {
   const list = facilities.reduce((acc, facility) => {
@@ -148,7 +128,6 @@ const generateFacilityLists = (dealType, facilities) => {
 
 module.exports = {
   generateFacilitiesListHeading,
-  generateFacilitiesReferenceListString,
   generateFacilitiesListString,
   generateBssFacilityLists,
   generateGefFacilityLists,

--- a/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
+++ b/trade-finance-manager-api/src/v1/helpers/notify-template-formatters.js
@@ -1,5 +1,5 @@
-const { capitalizeFirstLetter } = require('../../utils/string');
 const { issuedFacilities } = require('./issued-facilities');
+const { capitalizeFirstLetter } = require('../../utils/string');
 const CONSTANTS = require('../../constants');
 
 const generateFacilitiesListHeading = (facilityType) => {
@@ -23,14 +23,20 @@ const generateFacilitiesListHeading = (facilityType) => {
   return `#${heading}\n\n`;
 };
 
+
+// TODO This is not used, but SHOULD be.
+// it's used for "UKEF has received your facility stage update" email.
+// TODO: rename
+// TODO: maybe move away from this file.
+// NOTE: I don't this is needed at all now.
 const generateFacilitiesReferenceListString = (facilities) => facilities.reduce((acc, facility) => {
   const {
-    facilityType, ukefFacilityID, bankReferenceNumber, uniqueIdentificationNumber,
+    facilityType, ukefFacilityID, bankReference, uniqueIdentificationNumber,
   } = facility;
   const fType = capitalizeFirstLetter(facilityType);
-  const bankReference = uniqueIdentificationNumber || bankReferenceNumber;
-  const bankRefString = bankReference
-    ? `with your reference ${bankReference} `
+  const bankRef = uniqueIdentificationNumber || bankReference;
+  const bankRefString = bankRef
+    ? `with your reference ${bankRef} `
     : '';
 
   return `${acc}- ${fType} facility ${bankRefString}has been given the UKEF reference: ${ukefFacilityID} \n`;
@@ -41,17 +47,17 @@ const generateFacilitiesListString = (facilities) => {
     const { ukefFacilityID } = facility;
 
     let string = `${acc}`;
-    let bankReference;
+    let bankRef;
 
     if (facility.uniqueIdentificationNumber) {
-      bankReference = facility.uniqueIdentificationNumber;
-    } else if (facility.bankReferenceNumber) {
-      bankReference = facility.bankReferenceNumber;
+      bankRef = facility.uniqueIdentificationNumber;
+    } else if (facility.bankReference) {
+      bankRef = facility.bankReference;
     }
 
-    if (bankReference) {
-      const bankRefString = bankReference
-        ? `*Your bank ref: ${bankReference}\n`
+    if (bankRef) {
+      const bankRefString = bankRef
+        ? `*Your bank ref: ${bankRef}\n`
         : '';
 
       string += bankRefString;
@@ -141,6 +147,7 @@ const generateFacilityLists = (dealType, facilities) => {
 };
 
 module.exports = {
+  generateFacilitiesListHeading,
   generateFacilitiesReferenceListString,
   generateFacilitiesListString,
   generateBssFacilityLists,

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.api-test.js
@@ -77,7 +77,7 @@ describe('mappings - map submitted deal - mapBssEwcsFacility', () => {
         premiumFrequency,
         feeType,
         premiumType,
-        bankReferenceNumber,
+        bankReference: bankReferenceNumber,
         uniqueIdentificationNumber,
         bondType,
         tfm: mockFacility.tfm,

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.js
@@ -70,7 +70,7 @@ const mapBssEwcsFacility = (facility) => {
     premiumFrequency,
     feeType,
     premiumType,
-    bankReferenceNumber,
+    bankReference: bankReferenceNumber,
     uniqueIdentificationNumber,
     bondType,
     tfm: facility.tfm,

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.api-test.js
@@ -58,6 +58,7 @@ describe('mappings - map submitted deal - mapCashContingentFacility', () => {
         coverPercentage,
         ukefExposure,
         coverEndDate,
+        name,
       } = mockFacility;
 
       const expected = {
@@ -72,6 +73,7 @@ describe('mappings - map submitted deal - mapCashContingentFacility', () => {
         ukefExposure,
         coverStartDate: mapCoverStartDate(mockFacility),
         coverEndDate,
+        bankReference: name,
         tfm: mockFacility.tfm,
       };
 

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
@@ -30,6 +30,8 @@ const mapCashContingentFacility = (facility) => {
     coverPercentage,
     ukefExposure,
     coverEndDate,
+    name,
+    tfm,
   } = facility;
 
   return {
@@ -44,11 +46,8 @@ const mapCashContingentFacility = (facility) => {
     ukefExposure,
     coverStartDate: mapCoverStartDate(facility),
     coverEndDate,
-    tfm: facility.tfm,
-    // not in the data
-    // premiumType,
-    // dayCountBasis,
-    // guaranteeFeePayableByBank,
+    bankReference: name,
+    tfm,
   };
 };
 

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.api-test.js
@@ -19,7 +19,7 @@ describe('mappings - map submitted deal - mapGefDeal', () => {
     const expected = {
       _id: mockDeal.dealSnapshot._id,
       dealType: mockDeal.dealSnapshot.dealType,
-      bankSupplyContractID: mockDeal.dealSnapshot.bankInternalRefName,
+      bankReferenceNumber: mockDeal.dealSnapshot.bankInternalRefName,
       bankAdditionalReferenceName: mockDeal.dealSnapshot.additionalRefName,
       submissionCount: mockDeal.dealSnapshot.submissionCount,
       submissionType: mockDeal.dealSnapshot.submissionType,

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-gef-deal.js
@@ -21,7 +21,7 @@ const mapGefDeal = (deal) => {
   const mapped = {
     _id,
     dealType,
-    bankSupplyContractID: bankInternalRefName,
+    bankReferenceNumber: bankInternalRefName,
     bankAdditionalReferenceName: additionalRefName,
     submissionCount,
     submissionType,


### PR DESCRIPTION
When TFM receives a deal, an email needs to be sent to the Maker that includes a list of issued and unissued facilities. This was already in place for BSS deals, but not GEF. This PR ensures that all functions have the necessary data for GEF deal.


- central API: add get & create user endpoints
- central API: when getting a GEF deal, return maker (so it can be used for sending email)
- TFM API: add Cash & Contingent facilities to `issued-facilities` helper
- TFM API: split up and clean `send-deal-submit-emails`, improve test coverage
- TFM API: split up and clean `notify-template-formatters`, add test coverage
- TFM API: submitted facilities mapping: use `bankReference` instead of `bankReferenceNumber`