### PR TITLE
DTFS2-4727 - only call estore if BSS

### DIFF
--- a/e2e-tests/gef/cypress/integration/submit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/integration/submit-to-ukef.spec.js
@@ -5,7 +5,7 @@ import submitToUkef from './pages/submit-to-ukef';
 import submitToUkefConfirmation from './pages/submit-to-ukef-confirmation';
 import CREDENTIALS from '../fixtures/credentials.json';
 
-const applicationIds = [];
+let applicationId;
 
 context('Submit to UKEF', () => {
   before(() => {
@@ -16,10 +16,9 @@ context('Submit to UKEF', () => {
         cy.apiFetchAllApplications(token);
       })
       .then(({ body }) => {
-        body.items.forEach((item) => {
-          applicationIds.push(item._id);
-        });
+        applicationId = body.items[0]._id;
       });
+
     cy.login(CREDENTIALS.CHECKER);
 
     cy.on('uncaught:exception', () => false);
@@ -27,7 +26,7 @@ context('Submit to UKEF', () => {
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('connect.sid');
-    cy.visit(relative(`/gef/application-details/${applicationIds[2]}/submit-to-ukef`));
+    cy.visit(relative(`/gef/application-details/${applicationId}/submit-to-ukef`));
   });
 
   // TODO add negative tests - i.e. checking that the application state is correct.
@@ -38,18 +37,6 @@ context('Submit to UKEF', () => {
       submitToUkef.comment();
       submitToUkef.submitButton();
       submitToUkef.cancelLink();
-    });
-
-    it('submits without comments and displays the confirmation page', () => {
-      submitToUkef.submitButton().click();
-      submitToUkefConfirmation.confirmationPanel();
-      submitToUkefConfirmation.dashboardLink();
-    });
-
-    it('submits with comments', () => {
-      submitToUkef.comment().type('Test comment');
-      submitToUkef.submitButton().click();
-      submitToUkefConfirmation.confirmationPanel();
     });
 
     it('display an error when the comment is greater than 400 characters', () => {
@@ -63,7 +50,7 @@ context('Submit to UKEF', () => {
     it('takes checker back to application review page when cancelled', () => {
       submitToUkef.comment().type('Some comments here ....');
       submitToUkef.cancelLink().click();
-      cy.location('pathname').should('eq', `/gef/application-details/${applicationIds[2]}`);
+      cy.location('pathname').should('eq', `/gef/application-details/${applicationId}`);
     });
 
     it('takes checker to dashboard from the confirmation page', () => {
@@ -72,6 +59,18 @@ context('Submit to UKEF', () => {
       submitToUkef.submitButton().click();
       submitToUkefConfirmation.dashboardLink().click();
       cy.location('pathname').should('contain', 'dashboard');
+    });
+
+    it('submits without comments and displays the confirmation page', () => {
+      submitToUkef.submitButton().click();
+      submitToUkefConfirmation.confirmationPanel();
+      submitToUkefConfirmation.dashboardLink();
+    });
+
+    it('submits with comments', () => {
+      submitToUkef.comment().type('Test comment');
+      submitToUkef.submitButton().click();
+      submitToUkefConfirmation.confirmationPanel();
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -499,7 +499,7 @@ const createEstoreFolders = async (eStoreFolderInfo) => {
     });
     return response.data;
   } catch (err) {
-    return err;
+    return false;
   }
 };
 

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -70,7 +70,11 @@ const submitDeal = async (dealId, dealType, checker) => {
 
     const updatedDealWithUpdatedFacilities = await updateFacilities(updatedDealWithTfmDateReceived);
 
-    const updatedDealWithCreateEstore = await createEstoreFolders(updatedDealWithUpdatedFacilities);
+    let updatedDealWithCreateEstore = updatedDealWithUpdatedFacilities;
+
+    if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
+      updatedDealWithCreateEstore = await createEstoreFolders(updatedDealWithUpdatedFacilities);
+    }
 
     if (mappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN
       || mappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.MIA) {

--- a/utils/mock-data-loader/gef/exporter.js
+++ b/utils/mock-data-loader/gef/exporter.js
@@ -1,18 +1,64 @@
 const faker = require('faker');
 
-const EXPORTER = [
-  {
-    companiesHouseRegistrationNumber: 123456789,
-    companyName: faker.company.companyName(),
-    registeredAddress: {
-      line1: faker.address.streetName(),
-      line2: faker.address.streetAddress(),
-      county: faker.address.county(),
-      country: 'GB',
-      postcode: 'AB1 1AB',
+const EXPORTER = [{
+  // Not started - the mock inserter will ignore this line as the updatedTime is bumped
+  // but leave it in as its index based
+},
+{ // Half Completed
+  companiesHouseRegistrationNumber: null,
+  companyName: faker.company.companyName(),
+  registeredAddress: null,
+  correspondenceAddress: null,
+  selectedIndustry: {
+    code: '1003',
+    name: 'Manufacturing',
+    class: {
+      code: '25300',
+      name: 'Manufacture of steam generators, except central heating hot water boilers',
     },
-    correspondenceAddress: null,
-    selectedIndustry: {
+  },
+  industries: [
+    {
+      code: '1003',
+      name: 'Manufacturing',
+      class: {
+        code: '25300',
+        name: 'Manufacture of steam generators, except central heating hot water boilers',
+      },
+    },
+  ],
+  smeType: 'MEDIUM',
+  probabilityOfDefault: 67,
+  isFinanceIncreasing: false,
+}, { // Completed
+  companiesHouseRegistrationNumber: 123456789,
+  companyName: faker.company.companyName(),
+  registeredAddress: {
+    line1: faker.address.streetName(),
+    line2: faker.address.streetAddress(),
+    county: faker.address.county(),
+    country: 'GB',
+    postcode: 'AB1 1AB',
+  },
+  correspondenceAddress: null,
+  selectedIndustry: {
+    code: '1003',
+    name: 'Manufacturing',
+    class: {
+      code: '25620',
+      name: 'Machining',
+    },
+  },
+  industries: [
+    {
+      code: '1003',
+      name: 'Manufacturing',
+      class: {
+        code: '25300',
+        name: 'Manufacture of steam generators, except central heating hot water boilers',
+      },
+    },
+    {
       code: '1003',
       name: 'Manufacturing',
       class: {
@@ -20,36 +66,18 @@ const EXPORTER = [
         name: 'Machining',
       },
     },
-    industries: [
-      {
-        code: '1003',
-        name: 'Manufacturing',
-        class: {
-          code: '25300',
-          name: 'Manufacture of steam generators, except central heating hot water boilers',
-        },
+    {
+      code: '1003',
+      name: 'Manufacturing',
+      class: {
+        code: '28110',
+        name: 'Manufacture of engines and turbines, except aircraft, vehicle and cycle engines',
       },
-      {
-        code: '1003',
-        name: 'Manufacturing',
-        class: {
-          code: '25620',
-          name: 'Machining',
-        },
-      },
-      {
-        code: '1003',
-        name: 'Manufacturing',
-        class: {
-          code: '28110',
-          name: 'Manufacture of engines and turbines, except aircraft, vehicle and cycle engines',
-        },
-      },
-    ],
-    smeType: 'MICRO',
-    probabilityOfDefault: 45.5,
-    isFinanceIncreasing: true,
-  },
-];
+    },
+  ],
+  smeType: 'MICRO',
+  probabilityOfDefault: 45.5,
+  isFinanceIncreasing: true,
+}];
 
 module.exports = EXPORTER;

--- a/utils/mock-data-loader/gef/exporter.js
+++ b/utils/mock-data-loader/gef/exporter.js
@@ -1,64 +1,18 @@
 const faker = require('faker');
 
-const EXPORTER = [{
-// Not started - the mock inserter will ignore this line as the updatedTime is bumped
-// but leave it in as its index based
-},
-{ // Half Completed
-  companiesHouseRegistrationNumber: null,
-  companyName: faker.company.companyName(),
-  registeredAddress: null,
-  correspondenceAddress: null,
-  selectedIndustry: {
-    code: '1003',
-    name: 'Manufacturing',
-    class: {
-      code: '25300',
-      name: 'Manufacture of steam generators, except central heating hot water boilers',
+const EXPORTER = [
+  {
+    companiesHouseRegistrationNumber: 123456789,
+    companyName: faker.company.companyName(),
+    registeredAddress: {
+      line1: faker.address.streetName(),
+      line2: faker.address.streetAddress(),
+      county: faker.address.county(),
+      country: 'GB',
+      postcode: 'AB1 1AB',
     },
-  },
-  industries: [
-    {
-      code: '1003',
-      name: 'Manufacturing',
-      class: {
-        code: '25300',
-        name: 'Manufacture of steam generators, except central heating hot water boilers',
-      },
-    },
-  ],
-  smeType: 'MEDIUM',
-  probabilityOfDefault: 67,
-  isFinanceIncreasing: false,
-}, { // Completed
-  companiesHouseRegistrationNumber: 123456789,
-  companyName: faker.company.companyName(),
-  registeredAddress: {
-    line1: faker.address.streetName(),
-    line2: faker.address.streetAddress(),
-    county: faker.address.county(),
-    country: 'GB',
-    postcode: 'AB1 1AB',
-  },
-  correspondenceAddress: null,
-  selectedIndustry: {
-    code: '1003',
-    name: 'Manufacturing',
-    class: {
-      code: '25620',
-      name: 'Machining',
-    },
-  },
-  industries: [
-    {
-      code: '1003',
-      name: 'Manufacturing',
-      class: {
-        code: '25300',
-        name: 'Manufacture of steam generators, except central heating hot water boilers',
-      },
-    },
-    {
+    correspondenceAddress: null,
+    selectedIndustry: {
       code: '1003',
       name: 'Manufacturing',
       class: {
@@ -66,18 +20,36 @@ const EXPORTER = [{
         name: 'Machining',
       },
     },
-    {
-      code: '1003',
-      name: 'Manufacturing',
-      class: {
-        code: '28110',
-        name: 'Manufacture of engines and turbines, except aircraft, vehicle and cycle engines',
+    industries: [
+      {
+        code: '1003',
+        name: 'Manufacturing',
+        class: {
+          code: '25300',
+          name: 'Manufacture of steam generators, except central heating hot water boilers',
+        },
       },
-    },
-  ],
-  smeType: 'MICRO',
-  probabilityOfDefault: 45.5,
-  isFinanceIncreasing: true,
-}];
+      {
+        code: '1003',
+        name: 'Manufacturing',
+        class: {
+          code: '25620',
+          name: 'Machining',
+        },
+      },
+      {
+        code: '1003',
+        name: 'Manufacturing',
+        class: {
+          code: '28110',
+          name: 'Manufacture of engines and turbines, except aircraft, vehicle and cycle engines',
+        },
+      },
+    ],
+    smeType: 'MICRO',
+    probabilityOfDefault: 45.5,
+    isFinanceIncreasing: true,
+  },
+];
 
 module.exports = EXPORTER;

--- a/utils/mock-data-loader/insert-mocks-gef.js
+++ b/utils/mock-data-loader/insert-mocks-gef.js
@@ -32,13 +32,12 @@ const insertMocks = async () => {
     await api.createApplication(item, token);
   }
 
-  const application = await api.listApplication(token);
+  const applications = await api.listApplication(token);
 
   console.log('update exporter information');
-  for (const [index, item] of MOCKS.EXPORTER.entries()) {
-    if (index > 0) {
-      await api.updateExporter(application[index].exporterId, item, token);
-    }
+
+  for (const application of applications) {
+    await api.updateExporter(application.exporterId, MOCKS.EXPORTER[0], token);
   }
 
   console.log('inserting and updating facilities information');
@@ -46,7 +45,7 @@ const insertMocks = async () => {
     // eslint-disable-next-line no-restricted-syntax
     for (const subitem of item) {
       // eslint-disable-next-line no-param-reassign
-      subitem.applicationId = application[index]._id;
+      subitem.applicationId = applications[index]._id;
       const facilty = await api.createFacilities(subitem, token);
       // eslint-disable-next-line no-param-reassign
       delete subitem.applicationId;
@@ -57,7 +56,7 @@ const insertMocks = async () => {
   console.log('updating cover terms information');
   for (const [index, item] of MOCKS.COVER_TERMS.entries()) {
     if (index > 0) {
-      await api.updateCoverTerms(application[index].coverTermsId, item, token);
+      await api.updateCoverTerms(applications[index].coverTermsId, item, token);
     }
   }
 };

--- a/utils/mock-data-loader/insert-mocks-gef.js
+++ b/utils/mock-data-loader/insert-mocks-gef.js
@@ -32,12 +32,13 @@ const insertMocks = async () => {
     await api.createApplication(item, token);
   }
 
-  const applications = await api.listApplication(token);
+  const application = await api.listApplication(token);
 
   console.log('update exporter information');
-
-  for (const application of applications) {
-    await api.updateExporter(application.exporterId, MOCKS.EXPORTER[0], token);
+  for (const [index, item] of MOCKS.EXPORTER.entries()) {
+    if (index > 0) {
+      await api.updateExporter(application[index].exporterId, item, token);
+    }
   }
 
   console.log('inserting and updating facilities information');
@@ -45,7 +46,7 @@ const insertMocks = async () => {
     // eslint-disable-next-line no-restricted-syntax
     for (const subitem of item) {
       // eslint-disable-next-line no-param-reassign
-      subitem.applicationId = applications[index]._id;
+      subitem.applicationId = application[index]._id;
       const facilty = await api.createFacilities(subitem, token);
       // eslint-disable-next-line no-param-reassign
       delete subitem.applicationId;
@@ -56,7 +57,7 @@ const insertMocks = async () => {
   console.log('updating cover terms information');
   for (const [index, item] of MOCKS.COVER_TERMS.entries()) {
     if (index > 0) {
-      await api.updateCoverTerms(applications[index].coverTermsId, item, token);
+      await api.updateCoverTerms(application[index].coverTermsId, item, token);
     }
   }
 };


### PR DESCRIPTION
- remove incomplete exporters from GEF data. Can cause issues with estore
- in GEF submit-to-ukef e2e test, use a deal with only 1 facility
- disable estore API call until it doesn't error (pending Mulesoft IT team)
