### PR TITLE
DTFS2-4339: nunjucks currency format filter float fix

### DIFF
--- a/portal/server/nunjucks-configuration/formatAsCurrency.js
+++ b/portal/server/nunjucks-configuration/formatAsCurrency.js
@@ -3,7 +3,7 @@ const formatAsCurrency = (str) => {
   const isEmpty = !(str && str.trim().length > 0);
   let amount = 0;
   if (!isEmpty) {
-    amount = parseInt(str, 10);
+    amount = parseFloat(str);
     amount = amount.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,');
   }
   return isEmpty ? '-' : amount;


### PR DESCRIPTION
https://ukef-dtfs.atlassian.net/browse/DTFS2-4339
- Fixes issue where decimals were being ignored. `formatAsCurrency` filter was casting as an Int, so changed to float