### PR TITLE
Fix TFM sorting tests

### DIFF
--- a/e2e-tests/trade-finance-manager/cypress/fixtures/create-mock-deal.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/create-mock-deal.js
@@ -3,7 +3,9 @@ import MOCK_DEAL_AIN from './deal-AIN';
 
 const createMockDeal = (overrides) => {
   let submissionDate = moment().utc().valueOf().toString();
-  let facilities = MOCK_DEAL_AIN.mockFacilities;
+  let facilities = [
+    { ...MOCK_DEAL_AIN.mockFacilities[0] },
+  ];
 
   if (overrides.mockFacilities) {
     facilities = overrides.mockFacilities;

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -134,9 +134,19 @@ context('User can view and filter multiple deals', () => {
 
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
 
-    pages.dealsPage.heading().invoke('text').then((text) => {
-      expect(text.trim()).to.equal(`${expectedResultsLength} result for "${searchString}"`);
-    });
+    if (expectedResultsLength > 1) {
+      pages.dealsPage.heading().invoke('text').then((text) => {
+        expect(text.trim()).to.equal(`${expectedResultsLength} results for "${searchString}"`);
+      });
+    } else if (expectedResultsLength === 1) {
+      pages.dealsPage.heading().invoke('text').then((text) => {
+        expect(text.trim()).to.equal(`${expectedResultsLength} result for "${searchString}"`);
+      });
+    } else {
+      pages.dealsPage.heading().invoke('text').then((text) => {
+        expect(text.trim()).to.equal(`${expectedResultsLength} results for "${searchString}"`);
+      });
+    }
   });
 
   it('search/filter by bank name', () => {

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -240,14 +240,7 @@ context('User can view and filter multiple deals', () => {
   it('search/filter by loan productCode', () => {
     const searchString = 'EWCS';
 
-    const dealsWithLoans = MOCK_DEALS.filter((deal) => {
-      if (deal.mockFacilities.find((f) => f.facilityType === 'loan')) {
-        return deal;
-      }
-      return null;
-    });
-
-    const expectedResultsLength = dealsWithLoans.length;
+    const expectedResultsLength = 1;
 
     pages.dealsPage.searchFormInput().type(searchString);
     pages.dealsPage.searchFormSubmitButton().click();
@@ -255,7 +248,7 @@ context('User can view and filter multiple deals', () => {
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
 
     pages.dealsPage.heading().invoke('text').then((text) => {
-      expect(text.trim()).to.equal(`${expectedResultsLength} results for "${searchString}"`);
+      expect(text.trim()).to.equal(`${expectedResultsLength} result for "${searchString}"`);
     });
   });
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-buyer.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-buyer.spec.js
@@ -9,7 +9,6 @@ context('User can view and sort deals by buyer', () => {
   let ALL_FACILITIES = [];
   let dealBuyerA;
   let dealBuyerB;
-  let dealBuyerC;
 
   const DEAL_BUYER_A = createMockDeal({
     details: {
@@ -29,19 +28,9 @@ context('User can view and sort deals by buyer', () => {
     },
   });
 
-  const DEAL_BUYER_C = createMockDeal({
-    details: {
-      testId: 'DEAL_BUYER_C',
-    },
-    submissionDetails: {
-      'buyer-name': 'BUYER C',
-    },
-  });
-
   const MOCK_DEALS = [
     DEAL_BUYER_A,
     DEAL_BUYER_B,
-    DEAL_BUYER_C,
   ];
 
   before(() => {
@@ -71,9 +60,6 @@ context('User can view and sort deals by buyer', () => {
 
           dealBuyerB = ALL_SUBMITTED_DEALS.find((deal) =>
             deal.dealSnapshot.details.testId === DEAL_BUYER_B.details.testId);
-
-          dealBuyerC = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_BUYER_C.details.testId);
         });
       });
   });
@@ -108,10 +94,6 @@ context('User can view and sort deals by buyer', () => {
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
     row2.invoke('attr', 'data-cy').should('eq', `deal-${dealBuyerB._id}`);
 
-    // check third row
-    const row3 = pages.dealsPage.dealsTableRows().eq(2);
-    row3.invoke('attr', 'data-cy').should('eq', `deal-${dealBuyerC._id}`);
-
     pages.dealsPage.dealsTable.headings.buyer().invoke('attr', 'aria-sort').should('eq', 'ascending');
     pages.dealsPage.dealsTable.headings.buyerSortButton().invoke('attr', 'name').should('eq', 'descending');
   });
@@ -125,16 +107,13 @@ context('User can view and sort deals by buyer', () => {
 
     pages.dealsPage.dealsTableRows().should('have.length', ALL_SUBMITTED_DEALS.length);
 
+    // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealBuyerC._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealBuyerB._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealBuyerB._id}`);
-
-    // check third row
-    const row3 = pages.dealsPage.dealsTableRows().eq(2);
-    row3.invoke('attr', 'data-cy').should('eq', `deal-${dealBuyerA._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealBuyerA._id}`);
 
     pages.dealsPage.dealsTable.headings.buyer().invoke('attr', 'aria-sort').should('eq', 'descending');
     pages.dealsPage.dealsTable.headings.buyerSortButton().invoke('attr', 'name').should('eq', 'ascending');

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-exporter.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-exporter.spec.js
@@ -7,24 +7,21 @@ import { MOCK_MAKER_TFM } from '../../../fixtures/users-portal';
 context('User can view and sort deals by exporter', () => {
   let ALL_SUBMITTED_DEALS = [];
   let ALL_FACILITIES = [];
-  let dealSupplier1;
-  let dealSupplier2;
+  let dealAscending1;
+  let dealAscending2;
+  let dealDescending1;
+  let dealDescending2;
 
+  // Exporter (called supplier-name in a BSS deal), is generated automatically with mock data and deal ID.
   const DEAL_A_SUPPLIER = createMockDeal({
     details: {
       testId: 'DEAL_A_SUPPLIER',
-    },
-    submissionDetails: {
-      'supplier-name': 'A_SUPPLIER',
     },
   });
 
   const DEAL_B_SUPPLIER = createMockDeal({
     details: {
       testId: 'DEAL_B_SUPPLIER',
-    },
-    submissionDetails: {
-      'supplier-name': 'B_SUPPLIER',
     },
   });
 
@@ -53,13 +50,19 @@ context('User can view and sort deals by exporter', () => {
         });
 
         cy.submitManyDeals(insertedDeals).then((submittedDeals) => {
-          ALL_SUBMITTED_DEALS = submittedDeals;
+          // sort by ascending order
+          ALL_SUBMITTED_DEALS = submittedDeals.sort((a, b) => {
+            const dealASupplier = a.dealSnapshot.submissionDetails['supplier-name'];
+            const dealBSupplier = b.dealSnapshot.submissionDetails['supplier-name'];
 
-          dealSupplier1 = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_A_SUPPLIER.details.testId);
+            return dealASupplier.localeCompare(dealBSupplier);
+          });
 
-          dealSupplier2 = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_B_SUPPLIER.details.testId);
+          dealAscending1 = ALL_SUBMITTED_DEALS[0];
+          dealAscending2 = ALL_SUBMITTED_DEALS[1];
+
+          dealDescending1 = dealAscending2;
+          dealDescending2 = dealAscending1;
         });
       });
   });
@@ -88,11 +91,11 @@ context('User can view and sort deals by exporter', () => {
 
     // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier1._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealAscending1._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier2._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealAscending2._id}`);
 
 
     pages.dealsPage.dealsTable.headings.exporter().invoke('attr', 'aria-sort').should('eq', 'ascending');
@@ -110,11 +113,11 @@ context('User can view and sort deals by exporter', () => {
 
     // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier2._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealDescending1._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier1._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealDescending2._id}`);
 
     pages.dealsPage.dealsTable.headings.exporter().invoke('attr', 'aria-sort').should('eq', 'descending');
     pages.dealsPage.dealsTable.headings.exporterSortButton().invoke('attr', 'name').should('eq', 'ascending');

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-exporter.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-exporter.spec.js
@@ -9,7 +9,6 @@ context('User can view and sort deals by exporter', () => {
   let ALL_FACILITIES = [];
   let dealSupplier1;
   let dealSupplier2;
-  let dealSupplier3;
 
   const DEAL_A_SUPPLIER = createMockDeal({
     details: {
@@ -29,20 +28,9 @@ context('User can view and sort deals by exporter', () => {
     },
   });
 
-  const DEAL_C_SUPPLIER = createMockDeal({
-    details: {
-      testId: 'DEAL_C_SUPPLIER',
-    },
-    submissionDetails: {
-      'supplier-name': 'C_SUPPLIER',
-    },
-  });
-
-
   const MOCK_DEALS = [
     DEAL_A_SUPPLIER,
     DEAL_B_SUPPLIER,
-    DEAL_C_SUPPLIER,
   ];
 
   before(() => {
@@ -72,9 +60,6 @@ context('User can view and sort deals by exporter', () => {
 
           dealSupplier2 = ALL_SUBMITTED_DEALS.find((deal) =>
             deal.dealSnapshot.details.testId === DEAL_B_SUPPLIER.details.testId);
-
-          dealSupplier3 = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_C_SUPPLIER.details.testId);
         });
       });
   });
@@ -109,9 +94,6 @@ context('User can view and sort deals by exporter', () => {
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
     row2.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier2._id}`);
 
-    // check third row
-    const row3 = pages.dealsPage.dealsTableRows().eq(2);
-    row3.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier3._id}`);
 
     pages.dealsPage.dealsTable.headings.exporter().invoke('attr', 'aria-sort').should('eq', 'ascending');
     pages.dealsPage.dealsTable.headings.exporterSortButton().invoke('attr', 'name').should('eq', 'descending');
@@ -126,16 +108,13 @@ context('User can view and sort deals by exporter', () => {
 
     pages.dealsPage.dealsTableRows().should('have.length', ALL_SUBMITTED_DEALS.length);
 
+    // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier3._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier2._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier2._id}`);
-
-    // check third row
-    const row3 = pages.dealsPage.dealsTableRows().eq(2);
-    row3.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier1._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealSupplier1._id}`);
 
     pages.dealsPage.dealsTable.headings.exporter().invoke('attr', 'aria-sort').should('eq', 'descending');
     pages.dealsPage.dealsTable.headings.exporterSortButton().invoke('attr', 'name').should('eq', 'ascending');

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-ukefDealId.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-ukefDealId.spec.js
@@ -8,12 +8,14 @@ import { MOCK_MAKER_TFM } from '../../../fixtures/users-portal';
 context('User can view and sort deals by ukefDealId', () => {
   let ALL_SUBMITTED_DEALS = [];
   let ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER = [];
-  let ALL_SUBMITTED_DEALS_SORTED_IN_DESCENDING_ORDER = [];
   let ALL_FACILITIES = [];
+  let dealAscending1;
+  let dealAscending2;
+  let dealDescending1;
+  let dealDescending2;
 
   const twoDaysAgo = moment().subtract(2, 'day');
   const yesterday = moment().subtract(1, 'day');
-  const today = moment();
 
   const DEAL_1 = createMockDeal({
     details: {
@@ -27,16 +29,9 @@ context('User can view and sort deals by ukefDealId', () => {
     },
   });
 
-  const DEAL_3 = createMockDeal({
-    details: {
-      submissionDate: moment(today).utc().valueOf().toString(),
-    },
-  });
-
   const MOCK_DEALS = [
-    DEAL_3,
-    DEAL_2,
     DEAL_1,
+    DEAL_2,
   ];
 
   before(() => {
@@ -61,8 +56,19 @@ context('User can view and sort deals by ukefDealId', () => {
         cy.submitManyDeals(insertedDeals).then((submittedDeals) => {
           ALL_SUBMITTED_DEALS = submittedDeals;
 
-          ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER = Array.from(ALL_SUBMITTED_DEALS);
-          ALL_SUBMITTED_DEALS_SORTED_IN_DESCENDING_ORDER = Array.from(ALL_SUBMITTED_DEALS).reverse();
+          ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER = ALL_SUBMITTED_DEALS.sort((a, b) => {
+            const dealAUkefId = a.dealSnapshot.details.ukefDealId;
+            const dealBUkefId = b.dealSnapshot.details.ukefDealId;
+
+            return (Number(dealAUkefId) - Number(dealBUkefId));
+          });
+
+
+          dealAscending1 = ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER[0];
+          dealAscending2 = ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER[1];
+
+          dealDescending1 = dealAscending2;
+          dealDescending2 = dealAscending1;
         });
       });
   });
@@ -91,15 +97,11 @@ context('User can view and sort deals by ukefDealId', () => {
 
     // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER[0]._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealAscending1._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER[1]._id}`);
-
-    // check third row
-    const row3 = pages.dealsPage.dealsTableRows().eq(2);
-    row3.invoke('attr', 'data-cy').should('eq', `deal-${ALL_SUBMITTED_DEALS_SORTED_IN_ASCENDING_ORDER[2]._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealAscending2._id}`);
 
     pages.dealsPage.dealsTable.headings.ukefDealId().invoke('attr', 'aria-sort').should('eq', 'ascending');
     pages.dealsPage.dealsTable.headings.ukefDealIdSortButton().invoke('attr', 'name').should('eq', 'descending');
@@ -116,15 +118,11 @@ context('User can view and sort deals by ukefDealId', () => {
 
     // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${ALL_SUBMITTED_DEALS_SORTED_IN_DESCENDING_ORDER[0]._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealDescending1._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${ALL_SUBMITTED_DEALS_SORTED_IN_DESCENDING_ORDER[1]._id}`);
-
-    // check third row
-    const row3 = pages.dealsPage.dealsTableRows().eq(2);
-    row3.invoke('attr', 'data-cy').should('eq', `deal-${ALL_SUBMITTED_DEALS_SORTED_IN_DESCENDING_ORDER[2]._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealDescending2._id}`);
 
     pages.dealsPage.dealsTable.headings.ukefDealId().invoke('attr', 'aria-sort').should('eq', 'descending');
     pages.dealsPage.dealsTable.headings.ukefDealIdSortButton().invoke('attr', 'name').should('eq', 'ascending');

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort.spec.js
@@ -10,11 +10,9 @@ context('User can view and sort deals', () => {
   let ALL_FACILITIES = [];
   let deal1;
   let deal2;
-  let deal3;
 
   const twoDaysAgo = moment().subtract(2, 'day');
   const yesterday = moment().subtract(1, 'day');
-  const today = moment();
 
   const DEAL_WITH_UKDEALID_1 = createMockDeal({
     details: {
@@ -30,15 +28,7 @@ context('User can view and sort deals', () => {
     },
   });
 
-  const DEAL_WITH_UKDEALID_3 = createMockDeal({
-    details: {
-      ukefDealId: 3,
-      submissionDate: moment(today).utc().valueOf().toString(),
-    },
-  });
-
   const MOCK_DEALS = [
-    DEAL_WITH_UKDEALID_3,
     DEAL_WITH_UKDEALID_2,
     DEAL_WITH_UKDEALID_1,
   ];
@@ -70,10 +60,6 @@ context('User can view and sort deals', () => {
 
           deal2 = ALL_SUBMITTED_DEALS.find((deal) =>
             deal.dealSnapshot.details.ukefDealId === DEAL_WITH_UKDEALID_2.details.ukefDealId);
-
-          deal3 = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.ukefDealId === DEAL_WITH_UKDEALID_3.details.ukefDealId);
-
         });
       });
   });
@@ -95,14 +81,10 @@ context('User can view and sort deals', () => {
 
     // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${deal3._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${deal2._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${deal2._id}`);
-
-    // check third row
-    const row3 = pages.dealsPage.dealsTableRows().eq(2);
-    row3.invoke('attr', 'data-cy').should('eq', `deal-${deal1._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${deal1._id}`);
   });
 });

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort.spec.js
@@ -8,20 +8,20 @@ import { MOCK_MAKER_TFM } from '../../../fixtures/users-portal';
 context('User can view and sort deals', () => {
   let ALL_SUBMITTED_DEALS = [];
   let ALL_FACILITIES = [];
-  let deal1;
-  let deal2;
+  let dealMostRecent;
+  let dealNotRecent;
 
   const twoDaysAgo = moment().subtract(2, 'day');
   const yesterday = moment().subtract(1, 'day');
 
-  const DEAL_WITH_UKDEALID_1 = createMockDeal({
+  const DEAL_NOT_RECENT = createMockDeal({
     details: {
       ukefDealId: 1,
       submissionDate: moment(twoDaysAgo).utc().valueOf().toString(),
     },
   });
 
-  const DEAL_WITH_UKDEALID_2 = createMockDeal({
+  const DEAL_MOST_RECENT = createMockDeal({
     details: {
       ukefDealId: 2,
       submissionDate: moment(yesterday).utc().valueOf().toString(),
@@ -29,8 +29,8 @@ context('User can view and sort deals', () => {
   });
 
   const MOCK_DEALS = [
-    DEAL_WITH_UKDEALID_2,
-    DEAL_WITH_UKDEALID_1,
+    DEAL_NOT_RECENT,
+    DEAL_MOST_RECENT,
   ];
 
   before(() => {
@@ -55,11 +55,11 @@ context('User can view and sort deals', () => {
         cy.submitManyDeals(insertedDeals).then((submittedDeals) => {
           ALL_SUBMITTED_DEALS = submittedDeals;
 
-          deal1 = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.ukefDealId === DEAL_WITH_UKDEALID_1.details.ukefDealId);
+          dealMostRecent = ALL_SUBMITTED_DEALS.find((deal) =>
+            deal.dealSnapshot.details.submissionDate === DEAL_MOST_RECENT.details.submissionDate);
 
-          deal2 = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.ukefDealId === DEAL_WITH_UKDEALID_2.details.ukefDealId);
+          dealNotRecent = ALL_SUBMITTED_DEALS.find((deal) =>
+            deal.dealSnapshot.details.submissionDate === DEAL_NOT_RECENT.details.submissionDate);
         });
       });
   });
@@ -81,10 +81,10 @@ context('User can view and sort deals', () => {
 
     // check first row
     const row1 = pages.dealsPage.dealsTableRows().eq(0);
-    row1.invoke('attr', 'data-cy').should('eq', `deal-${deal2._id}`);
+    row1.invoke('attr', 'data-cy').should('eq', `deal-${dealMostRecent._id}`);
 
     // check second row
     const row2 = pages.dealsPage.dealsTableRows().eq(1);
-    row2.invoke('attr', 'data-cy').should('eq', `deal-${deal1._id}`);
+    row2.invoke('attr', 'data-cy').should('eq', `deal-${dealNotRecent._id}`);
   });
 });

--- a/trade-finance-manager-api/src/v1/mappings/map-create-estore.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-create-estore.api-test.js
@@ -51,7 +51,7 @@ describe('mapCreateEstore', () => {
 
       expect(result).toEqual(expected);
     });
-  }); 
+  });
 
   describe(`when dealType is ${CONSTANTS.DEALS.DEAL_TYPE.GEF}`, () => {
     it('should return mapped object with some default values', () => {


### PR DESCRIPTION
- reduce the amount of deals & facilities used in TFM sorting tests
- check expected ascending/descending properties based on the deal data _after_ submission, instead of based on the mock data we provide before submission