### PR TITLE
fix(DTFS2-7019): get API call race condition build-up

### DIFF
--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -1,4 +1,3 @@
-const { delay } = require('lodash');
 const { findOneTfmDeal, findOnePortalDeal, findOneGefDeal } = require('./deal.controller');
 const { addPartyUrns } = require('./deal.party-db');
 const { createDealTasks } = require('./deal.tasks');
@@ -20,6 +19,7 @@ const { updatePortalDealFromMIAtoMIN } = require('./update-portal-deal-from-MIA-
 const { sendDealSubmitEmails, sendAinMinAcknowledgement } = require('./send-deal-submit-emails');
 const mapSubmittedDeal = require('../mappings/map-submitted-deal');
 const { dealHasAllUkefIds, dealHasAllValidUkefIds } = require('../helpers/dealHasAllUkefIds');
+const { delay } = require('../helpers/delay');
 
 /**
  * Retrieves a deal from the portal based on the provided deal ID and deal type.
@@ -53,7 +53,7 @@ const submitDealAfterUkefIds = async (dealId, dealType, checker) => {
    * where portal deal updates `deals` collection will not be
    * fetched when updated on close proximity calls.
    */
-  await delay(() => {}, 200);
+  await delay(200);
 
   const deal = await getPortalDeal(dealId, dealType);
   console.info('Setting essential deal properties in TFM for deal %s', dealId);

--- a/trade-finance-manager-api/src/v1/helpers/delay.js
+++ b/trade-finance-manager-api/src/v1/helpers/delay.js
@@ -1,0 +1,14 @@
+/**
+ * Returns a promise that resolves after a specified delay.
+ * @param {number} ms - The number of milliseconds to delay.
+ * Defaults to 1000ms (1 second).
+ * @returns {Promise} - A promise that resolves after the specified delay.
+ */
+const delay = (ms = 1000) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+module.exports = {
+  delay,
+};


### PR DESCRIPTION
## Introduction :pencil2:
A sporadic issue has been identified where when a MIA deal is submitted to TFM on the second submission (to be coverted to a MIN), the deal does not successfully converts to MIN. After a prologues RCA following was identified:

* `submissionCount` is set to `1` when `TFM-API` fetches deal from `deal.submit.controller.js`, however `Portal-API` updated the submission count to `2` before submitting the deal to TFM (before TFM fetches the portal deal for further processing).
* The issue is sporadic in nature and seems to suggest either a delay in portal deal update in `deals` collection or an ambigious race condition being build up.

## Resolution :heavy_check_mark:
* Added an artificial `200ms` delay as the RCA has identified `53ms` delay in `lastUpdatedAt` timestamp property field when fetching the `BSS/EWCS` deal since portal deal last update from `portal-api`.

## Miscellaneous :heavy_plus_sign:
* Addec complimentary unit test cases.

