### PR TITLE
chore(github-hooks): only run commit hooks on staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "stop": "docker compose down",
     "type-check:all": "npm run type-check --workspaces --if-present",
     "validate:all": "npm run lint:all && npm run prettier:all && npm run type-check:all && npm run validate:yml && npm run validate:md",
-    "validate:md": "npx markdownlint-cli --config .markdownlint.json '**/*.md'",
+    "validate:md": "npx markdownlint-cli --config .markdownlint.json \"**/*.md\"",
     "validate:yml": "npx yaml-lint **/*.yml --ignore=**/node_modules --ignore=dtfs-mongo-volume-dtfs-submissions"
   },
   "lint-staged": {
@@ -56,10 +56,10 @@
     ],
     "**/*.md": [
       "prettier --write",
-      "npm run validate:md"
+      "npx markdownlint-cli --config .markdownlint.json"
     ],
     "**/*.yml": [
-      "npm run validate:yml"
+      "npx yaml-lint --ignore=**/node_modules --ignore=dtfs-mongo-volume-dtfs-submissions"
     ],
     "**/*": [
       "cspell lint --gitignore --no-must-find-files --unique --no-progress --show-suggestions --color"


### PR DESCRIPTION
# Introduction :pencil2:

Updates to our lint-staged config to ensure that we only run `.md` and `.yml` validation on staged files in commit hooks.

Further details on the changes on the [equivalent PR in the GIFT repo](https://github.com/UK-Export-Finance/GIFT/pull/831/files).
