### PR TITLE
fix(DTFS2-8150): updated clamav base image to stable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clamav:
-    image: docker-clamav:1.1.2-alpine
+    image: clamav/clamav:stable
     restart: always
     ports:
       - '3310:3310'


### PR DESCRIPTION
# Introduction :pencil2:

ClamAV container is not initialising due to an outdated defintion.

## Resolution :heavy_check_mark:

* Updated image to `clamav/clamav:stable`.