### PR TITLE
chore(DTFS2-8363): remove XAF HKD NGN ZMK currencies from BSS supply contract currencies

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/maker-loan/loan-financial-details.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker-loan/loan-financial-details.spec.js
@@ -92,7 +92,13 @@ context('Loan Financial Details', () => {
       pages.loanFinancialDetails.currencySameAsSupplyContractCurrencyInputNo().click();
 
       pages.loanFinancialDetails.currencyInput().should('be.visible');
+
       pages.loanFinancialDetails.currencyInput().should('not.contain', 'RUB'); // should not contain Russian Ruble
+      pages.loanFinancialDetails.currencyInput().should('not.contain', 'XAF'); // should not contain CFA Francs
+      pages.loanFinancialDetails.currencyInput().should('not.contain', 'HKD'); // should not contain Hong Kong Dollars
+      pages.loanFinancialDetails.currencyInput().should('not.contain', 'NGN'); // should not contain Nigerian Naira
+      pages.loanFinancialDetails.currencyInput().should('not.contain', 'ZMK'); // should not contain Zambian Kwacha
+
       pages.loanFinancialDetails.conversionRateInput().should('be.visible');
 
       pages.loanFinancialDetails.conversionRateDateDayInput().should('be.visible');

--- a/libs/common/src/constants/currency.ts
+++ b/libs/common/src/constants/currency.ts
@@ -22,7 +22,6 @@ export const ALL_CURRENCIES = {
   EGP: 'EGP',
   EUR: 'EUR',
   GBP: 'GBP',
-  HKD: 'HKD',
   ILS: 'ILS',
   INR: 'INR',
   IQD: 'IQD',
@@ -34,7 +33,6 @@ export const ALL_CURRENCIES = {
   MWK: 'MWK',
   MXN: 'MXN',
   MYR: 'MYR',
-  NGN: 'NGN',
   NOK: 'NOK',
   NZD: 'NZD',
   OMR: 'OMR',
@@ -47,7 +45,6 @@ export const ALL_CURRENCIES = {
   THB: 'THB',
   TWD: 'TWD',
   USD: 'USD',
-  XAF: 'XAF',
   XAU: 'XAU',
   ZAR: 'ZAR',
   BHD: 'BHD',
@@ -62,11 +59,9 @@ export const ALL_CURRENCIES = {
   IDR: 'IDR',
   MUR: 'MUR',
   PEN: 'PEN',
-  RUB: 'RUB',
   KRW: 'KRW',
   TRY: 'TRY',
   UYU: 'UYU',
-  ZMK: 'ZMK',
   MAD: 'MAD',
 } as const;
 
@@ -151,11 +146,6 @@ export const CURRENCIES: CurrencyInterface[] = [
     id: 'GBP',
   },
   {
-    currencyId: 13,
-    text: 'HKD - Hong Kong Dollars',
-    id: 'HKD',
-  },
-  {
     currencyId: 14,
     text: 'ILS - Israeli Shekels',
     id: 'ILS',
@@ -212,11 +202,6 @@ export const CURRENCIES: CurrencyInterface[] = [
     currencyId: 24,
     text: 'MYR - Malaysian Ringgitts',
     id: 'MYR',
-  },
-  {
-    currencyId: 25,
-    text: 'NGN - Nigerian Naira',
-    id: 'NGN',
   },
   {
     currencyId: 26,
@@ -277,11 +262,6 @@ export const CURRENCIES: CurrencyInterface[] = [
     currencyId: 37,
     text: 'USD - US Dollars',
     id: 'USD',
-  },
-  {
-    currencyId: 38,
-    text: 'XAF - CFA Francs',
-    id: 'XAF',
   },
   {
     currencyId: 39,
@@ -370,11 +350,6 @@ export const CURRENCIES: CurrencyInterface[] = [
     currencyId: 57,
     text: 'UYU - Uruguayan Peso',
     id: 'UYU',
-  },
-  {
-    currencyId: 58,
-    text: 'ZMK - Zambian Kwacha',
-    id: 'ZMK',
   },
   {
     currencyId: 59,

--- a/portal-api/server/external-api/__mocks__/currencies.js
+++ b/portal-api/server/external-api/__mocks__/currencies.js
@@ -61,11 +61,6 @@ const CURRENCIES = [
     id: 'GBP',
   },
   {
-    currencyId: 13,
-    text: 'HKD - Hong Kong Dollars',
-    id: 'HKD',
-  },
-  {
     currencyId: 14,
     text: 'ILS - Israeli Shekels',
     id: 'ILS',
@@ -122,11 +117,6 @@ const CURRENCIES = [
     currencyId: 24,
     text: 'MYR - Malaysian Ringgitts',
     id: 'MYR',
-  },
-  {
-    currencyId: 25,
-    text: 'NGN - Nigerian Naira',
-    id: 'NGN',
   },
   {
     currencyId: 26,
@@ -188,12 +178,6 @@ const CURRENCIES = [
     currencyId: 37,
     text: 'USD - US Dollars',
     id: 'USD',
-  },
-  {
-    currencyId: 38,
-    text: 'XAF - CFA Francs',
-    id: 'XAF',
-    disabled: true,
   },
   {
     currencyId: 39,
@@ -282,11 +266,6 @@ const CURRENCIES = [
     currencyId: 57,
     text: 'UYU - Uruguayan Peso',
     id: 'UYU',
-  },
-  {
-    currencyId: 58,
-    text: 'ZMK - Zambian Kwacha',
-    id: 'ZMK',
   },
   {
     currencyId: 59,


### PR DESCRIPTION
# Introduction :pencil2:

This PR removes XAF, HKD, NGN, ZMK from the currency list for BSS

## Resolution :heavy_check_mark:

* Remove Central African Franc (XAF)
* Remove Hong Kong Dollar (HKD)
* Remove Nigerian Naira (NGN)
* Remove Zambian Kwacha (ZMK)
* Add e2e test to ensure its not there

