### PR TITLE
feat(DTFS2-8416): tfm parties update - create gift facilities

### DIFF
--- a/gef-ui/templates/_macros/eligibility-criteria-answer-tag.njk
+++ b/gef-ui/templates/_macros/eligibility-criteria-answer-tag.njk
@@ -10,7 +10,7 @@
     {% set answerClass = 'govuk-tag--red' %}
   {% endif %}
 
-  {{govukTag({
+  {{ govukTag({
     text: answerText,
     classes: answerClass,
     attributes: {

--- a/portal-ui/templates/_macros/status-tag.njk
+++ b/portal-ui/templates/_macros/status-tag.njk
@@ -5,7 +5,7 @@
   {% set greyColourStatus = (status === "Not started" or status === "Incomplete" or status === "Ready for check" or status === "Acknowledged" or status === "Maker's input required") %}
 
   {% if status %}
-    {{govukTag({
+    {{ govukTag({
       text: status,
       classes: greyColourStatus and "govuk-tag--grey",
       attributes: {

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.facilities.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.facilities.api-test.js
@@ -5,7 +5,6 @@ const acbsController = require('../../../server/v1/controllers/acbs.controller')
 const { canSubmitToApimGift, submitFacilitiesToApimGift } = require('../../../server/v1/integrations/apim-gift');
 const calculateUkefExposure = require('../../../server/v1/helpers/calculateUkefExposure');
 const { submitDeal, createSubmitBody } = require('../../helpers/submitDeal');
-
 const { MOCK_BSS_EWCS_DEAL } = require('../../../server/v1/__mocks__/mock-deal');
 const MOCK_DEAL_FACILITIES_USD_CURRENCY = require('../../../server/v1/__mocks__/mock-deal-facilities-USD-currency');
 const MOCK_DEAL_ISSUED_FACILITIES = require('../../../server/v1/__mocks__/mock-deal-issued-facilities');

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-update-lead-underwriter.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-update-lead-underwriter.api-test.js
@@ -1,6 +1,5 @@
 const { when } = require('jest-when');
 const { withClientAuthenticationTests } = require('../../common-tests/client-authentication-tests');
-
 const app = require('../../../server/createApp');
 const { createApi } = require('../../api');
 const { initialiseTestUsers } = require('../../api-test-users');

--- a/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
@@ -1,3 +1,4 @@
+const { HttpStatusCode } = require('axios');
 const { when } = require('jest-when');
 const { canSubmitToApimGift, submitFacilitiesToApimGift } = require('../../../server/v1/integrations/apim-gift');
 const { createACBS } = require('../../../server/v1/controllers/acbs.controller');
@@ -13,8 +14,6 @@ const { createApi } = require('../../api');
 jest.mock('../../../server/v1/controllers/user/user.controller', () => ({
   findByUsername: jest.fn(),
 }));
-
-jest.setTimeout(30000);
 
 jest.mock('../../../server/v1/integrations/apim-gift', () => ({
   canSubmitToApimGift: jest.fn(),
@@ -99,12 +98,12 @@ describe('PUT /v1/parties/:dealId', () => {
       }),
   });
 
-  it('returns updated parties', async () => {
+  it(`should return ${HttpStatusCode.Ok} with updated parties`, async () => {
     // Act
     const { status, body } = await as({ token }).put(partiesUpdate).to(VALID_URL);
 
     // Assert
-    expect(status).toEqual(200);
+    expect(status).toEqual(HttpStatusCode.Ok);
 
     expect(body).toEqual({
       updateParty: {
@@ -139,7 +138,7 @@ describe('PUT /v1/parties/:dealId', () => {
   });
 
   describe('when APIM/GIFT submission is not allowed', () => {
-    it('should not call submitFacilitiesToApimGift when APIM/GIFT submission is not allowed', async () => {
+    it(`should not call submitFacilitiesToApimGift when APIM/GIFT submission is not allowed`, async () => {
       // Arrange
       canSubmitToApimGift.mockResolvedValue({
         canSubmitFacilitiesToApimGift: false,
@@ -157,12 +156,13 @@ describe('PUT /v1/parties/:dealId', () => {
   });
 
   describe('when deal id is invalid', () => {
-    it('should return a 400', async () => {
+    it(`should return ${HttpStatusCode.BadRequest}`, async () => {
       // Act
       const { status, body } = await as({ token }).put(partiesUpdate).to(`/v1/parties/${INVALID_DEAL_ID}`);
 
       // Assert
-      expect(status).toEqual(400);
+      expect(status).toEqual(HttpStatusCode.BadRequest);
+
       expect(body).toEqual({
         errors: [
           {
@@ -173,13 +173,13 @@ describe('PUT /v1/parties/:dealId', () => {
             value: INVALID_DEAL_ID,
           },
         ],
-        status: 400,
+        status: HttpStatusCode.BadRequest,
       });
     });
   });
 
   describe('when updateDeal throws an error', () => {
-    it('should return a 500', async () => {
+    it(`should return ${HttpStatusCode.InternalServerError}`, async () => {
       // Arrange
       when(api.updateDeal).calledWith(expect.anything()).mockRejectedValueOnce(new Error('update failed'));
 
@@ -187,7 +187,7 @@ describe('PUT /v1/parties/:dealId', () => {
       const { status } = await as({ token }).put(partiesUpdate).to(VALID_URL);
 
       // Assert
-      expect(status).toEqual(500);
+      expect(status).toEqual(HttpStatusCode.InternalServerError);
     });
   });
 });

--- a/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
@@ -1,0 +1,172 @@
+const { when } = require('jest-when');
+const { canSubmitToApimGift, submitFacilitiesToApimGift } = require('../../../server/v1/integrations/apim-gift');
+const { createACBS } = require('../../../server/v1/controllers/acbs.controller');
+const canSubmitToACBS = require('../../../server/v1/helpers/can-submit-to-acbs');
+const api = require('../../../server/v1/api');
+const { mockUpdateDeal } = require('../../../server/v1/__mocks__/common-api-mocks');
+const { issueJWT } = require('../../../server/utils/crypto.util');
+const { findByUsername } = require('../../../server/v1/controllers/user/user.controller');
+const { withClientAuthenticationTests } = require('../../common-tests/client-authentication-tests');
+const app = require('../../../server/createApp');
+const { createApi } = require('../../api');
+
+jest.mock('../../../server/v1/controllers/user/user.controller', () => ({
+  findByUsername: jest.fn(),
+}));
+
+jest.setTimeout(30000);
+
+jest.mock('../../../server/v1/integrations/apim-gift', () => ({
+  canSubmitToApimGift: jest.fn(),
+  submitFacilitiesToApimGift: jest.fn(),
+}));
+
+jest.mock('../../../server/v1/controllers/acbs.controller', () => ({
+  createACBS: jest.fn(),
+}));
+
+jest.mock('../../../server/v1/helpers/can-submit-to-acbs', () => jest.fn());
+
+const { as, put } = createApi(app);
+
+describe('PUT /v1/parties/:dealId', () => {
+  const VALID_DEAL_ID = '61f6b18502fade01b1e8f07f';
+  const INVALID_DEAL_ID = 'InvalidDealId';
+  const VALID_URL = `/v1/parties/${VALID_DEAL_ID}`;
+
+  const partiesUpdate = {
+    exporter: {
+      partyUrn: '123',
+      partyUrnRequired: true,
+    },
+    buyer: {
+      partyUrn: '456',
+      partyUrnRequired: true,
+    },
+  };
+
+  const mockUser = {
+    _id: '61f6b18502fade01b1e8f07f',
+    username: 'api-tester@ukexportfinance.gov.uk',
+    teams: [],
+    firstName: 'API',
+    lastName: 'Tester',
+  };
+
+  let token;
+
+  beforeEach(() => {
+    api.updateDeal.mockReset();
+
+    canSubmitToApimGift.mockReset();
+    canSubmitToApimGift.mockResolvedValue({
+      canSubmitFacilitiesToApimGift: false,
+      issuedFacilities: [],
+      isBssEwcsDeal: false,
+      isGefDeal: true,
+    });
+
+    submitFacilitiesToApimGift.mockReset();
+
+    canSubmitToACBS.mockReset();
+    canSubmitToACBS.mockResolvedValue(false);
+
+    createACBS.mockReset();
+
+    const auth = issueJWT(mockUser);
+    token = auth.token;
+
+    findByUsername.mockImplementation((username, callback) => {
+      callback(null, {
+        ...mockUser,
+        sessionIdentifier: auth.sessionIdentifier,
+      });
+    });
+
+    mockUpdateDeal({
+      _id: VALID_DEAL_ID,
+      tfm: {
+        parties: partiesUpdate,
+      },
+    });
+  });
+
+  withClientAuthenticationTests({
+    makeRequestWithoutAuthHeader: () => put(VALID_URL, partiesUpdate),
+    makeRequestWithAuthHeader: (authHeader) =>
+      put(VALID_URL, partiesUpdate, {
+        headers: { Authorization: authHeader },
+      }),
+  });
+
+  it('returns updated parties', async () => {
+    const { status, body } = await as({ token }).put(partiesUpdate).to(VALID_URL);
+
+    expect(status).toEqual(200);
+    expect(body).toEqual({
+      updateParty: {
+        parties: partiesUpdate,
+      },
+    });
+    expect(canSubmitToApimGift).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls submitFacilitiesToApimGift when APIM/GIFT submission is allowed', async () => {
+    const issuedFacilities = [{ _id: 'facility-1' }];
+
+    canSubmitToApimGift.mockResolvedValue({
+      canSubmitFacilitiesToApimGift: true,
+      issuedFacilities,
+      isBssEwcsDeal: false,
+      isGefDeal: true,
+    });
+
+    await as({ token }).put(partiesUpdate).to(VALID_URL);
+
+    expect(submitFacilitiesToApimGift).toHaveBeenCalledWith({
+      deal: expect.any(Object),
+      facilities: issuedFacilities,
+      isBssEwcsDeal: false,
+      isGefDeal: true,
+    });
+  });
+
+  it('does not call submitFacilitiesToApimGift when APIM/GIFT submission is not allowed', async () => {
+    canSubmitToApimGift.mockResolvedValue({
+      canSubmitFacilitiesToApimGift: false,
+      issuedFacilities: [],
+      isBssEwcsDeal: false,
+      isGefDeal: true,
+    });
+
+    await as({ token }).put(partiesUpdate).to(VALID_URL);
+
+    expect(submitFacilitiesToApimGift).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when deal id is invalid', async () => {
+    const { status, body } = await as({ token }).put(partiesUpdate).to(`/v1/parties/${INVALID_DEAL_ID}`);
+
+    expect(status).toEqual(400);
+    expect(body).toEqual({
+      errors: [
+        {
+          location: 'params',
+          msg: 'The Deal ID (dealId) provided should be a Mongo ID',
+          path: 'dealId',
+          type: 'field',
+          value: INVALID_DEAL_ID,
+        },
+      ],
+      status: 400,
+    });
+  });
+
+  it('returns 500 if updateDeal fails', async () => {
+    when(api.updateDeal).calledWith(expect.anything()).mockRejectedValueOnce(new Error('update failed'));
+
+    const { status } = await as({ token }).put(partiesUpdate).to(VALID_URL);
+
+    expect(status).toEqual(500);
+  });
+});

--- a/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
@@ -100,73 +100,94 @@ describe('PUT /v1/parties/:dealId', () => {
   });
 
   it('returns updated parties', async () => {
+    // Act
     const { status, body } = await as({ token }).put(partiesUpdate).to(VALID_URL);
 
+    // Assert
     expect(status).toEqual(200);
+
     expect(body).toEqual({
       updateParty: {
         parties: partiesUpdate,
       },
     });
-    expect(canSubmitToApimGift).toHaveBeenCalledTimes(1);
   });
 
-  it('calls submitFacilitiesToApimGift when APIM/GIFT submission is allowed', async () => {
-    const issuedFacilities = [{ _id: 'facility-1' }];
+  describe('when APIM/GIFT submission is allowed', () => {
+    it('should call submitFacilitiesToApimGift', async () => {
+      // Arrange
+      const issuedFacilities = [{ _id: 'facility-1' }];
 
-    canSubmitToApimGift.mockResolvedValue({
-      canSubmitFacilitiesToApimGift: true,
-      issuedFacilities,
-      isBssEwcsDeal: false,
-      isGefDeal: true,
-    });
+      canSubmitToApimGift.mockResolvedValue({
+        canSubmitFacilitiesToApimGift: true,
+        issuedFacilities,
+        isBssEwcsDeal: false,
+        isGefDeal: true,
+      });
 
-    await as({ token }).put(partiesUpdate).to(VALID_URL);
+      // Act
+      await as({ token }).put(partiesUpdate).to(VALID_URL);
 
-    expect(submitFacilitiesToApimGift).toHaveBeenCalledWith({
-      deal: expect.any(Object),
-      facilities: issuedFacilities,
-      isBssEwcsDeal: false,
-      isGefDeal: true,
-    });
-  });
-
-  it('does not call submitFacilitiesToApimGift when APIM/GIFT submission is not allowed', async () => {
-    canSubmitToApimGift.mockResolvedValue({
-      canSubmitFacilitiesToApimGift: false,
-      issuedFacilities: [],
-      isBssEwcsDeal: false,
-      isGefDeal: true,
-    });
-
-    await as({ token }).put(partiesUpdate).to(VALID_URL);
-
-    expect(submitFacilitiesToApimGift).not.toHaveBeenCalled();
-  });
-
-  it('returns 400 when deal id is invalid', async () => {
-    const { status, body } = await as({ token }).put(partiesUpdate).to(`/v1/parties/${INVALID_DEAL_ID}`);
-
-    expect(status).toEqual(400);
-    expect(body).toEqual({
-      errors: [
-        {
-          location: 'params',
-          msg: 'The Deal ID (dealId) provided should be a Mongo ID',
-          path: 'dealId',
-          type: 'field',
-          value: INVALID_DEAL_ID,
-        },
-      ],
-      status: 400,
+      // Assert
+      expect(submitFacilitiesToApimGift).toHaveBeenNthCalledWith(1, {
+        deal: expect.any(Object),
+        facilities: issuedFacilities,
+        isBssEwcsDeal: false,
+        isGefDeal: true,
+      });
     });
   });
 
-  it('returns 500 if updateDeal fails', async () => {
-    when(api.updateDeal).calledWith(expect.anything()).mockRejectedValueOnce(new Error('update failed'));
+  describe('when APIM/GIFT submission is not allowed', () => {
+    it('should not call submitFacilitiesToApimGift when APIM/GIFT submission is not allowed', async () => {
+      // Arrange
+      canSubmitToApimGift.mockResolvedValue({
+        canSubmitFacilitiesToApimGift: false,
+        issuedFacilities: [],
+        isBssEwcsDeal: false,
+        isGefDeal: true,
+      });
 
-    const { status } = await as({ token }).put(partiesUpdate).to(VALID_URL);
+      // Act
+      await as({ token }).put(partiesUpdate).to(VALID_URL);
 
-    expect(status).toEqual(500);
+      // Assert
+      expect(submitFacilitiesToApimGift).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when deal id is invalid', () => {
+    it('should return a 400', async () => {
+      // Act
+      const { status, body } = await as({ token }).put(partiesUpdate).to(`/v1/parties/${INVALID_DEAL_ID}`);
+
+      // Assert
+      expect(status).toEqual(400);
+      expect(body).toEqual({
+        errors: [
+          {
+            location: 'params',
+            msg: 'The Deal ID (dealId) provided should be a Mongo ID',
+            path: 'dealId',
+            type: 'field',
+            value: INVALID_DEAL_ID,
+          },
+        ],
+        status: 400,
+      });
+    });
+  });
+
+  describe('when updateDeal throws an error', () => {
+    it('should return a 500', async () => {
+      // Arrange
+      when(api.updateDeal).calledWith(expect.anything()).mockRejectedValueOnce(new Error('update failed'));
+
+      // Act
+      const { status } = await as({ token }).put(partiesUpdate).to(VALID_URL);
+
+      // Assert
+      expect(status).toEqual(500);
+    });
   });
 });

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.js
@@ -33,12 +33,18 @@ const updateParty = async (req, res) => {
     if (canSubmitFacilitiesToApimGift) {
       console.info('TFM deal %s updateParty - calling submitFacilitiesToApimGift', dealId);
 
-      await submitFacilitiesToApimGift({
-        deal: tfmDeal,
-        facilities: issuedFacilities,
-        isBssEwcsDeal,
-        isGefDeal,
-      });
+      try {
+        await submitFacilitiesToApimGift({
+          deal: tfmDeal,
+          facilities: issuedFacilities,
+          isBssEwcsDeal,
+          isGefDeal,
+        });
+      } catch (error) {
+        console.error('TFM deal %s updateParty - submitFacilitiesToApimGift failed %o', dealId, error);
+
+        throw error;
+      }
     }
 
     // Submit to ACBS
@@ -47,7 +53,13 @@ const updateParty = async (req, res) => {
     if (canSubmitDealToACBS) {
       console.info('TFM deal %s updateParty - calling createACBS', dealId);
 
-      await createACBS(dealId);
+      try {
+        await createACBS(dealId);
+      } catch (error) {
+        console.error('TFM deal %s updateParty - createACBS failed %o', dealId, error);
+
+        throw error;
+      }
     }
 
     const response = res.status(HttpStatusCode.Ok).send({
@@ -59,6 +71,7 @@ const updateParty = async (req, res) => {
     return response;
   } catch (error) {
     console.error('Unable to update parties for deal %s %o', req.params.dealId, error);
+
     return res.status(HttpStatusCode.InternalServerError).send(error);
   }
 };

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.js
@@ -1,11 +1,14 @@
 const { HttpStatusCode } = require('axios');
 const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/change-stream');
+const { canSubmitToApimGift, submitFacilitiesToApimGift } = require('../integrations/apim-gift');
 const api = require('../api');
 const { createACBS } = require('./acbs.controller');
 const canSubmitToACBS = require('../helpers/can-submit-to-acbs');
 
 /**
- * Updates the parties in TFM associated with the deal.
+ * 1) Update the parties in TFM associated with the deal.
+ * 2) If the deal's facilities can be submitted to APIM/GIFT, submit to APIM/GIFT.
+ * 3) If the deal can be submitted to ACBS, submit to ACBS.
  *
  * @param {object} req - The request object containing the parameters, body, and user information.
  * @param {object} res - The response object.
@@ -14,6 +17,7 @@ const canSubmitToACBS = require('../helpers/can-submit-to-acbs');
 const updateParty = async (req, res) => {
   try {
     const { dealId } = req.params;
+
     const dealUpdate = {
       tfm: {
         parties: req.body,
@@ -22,9 +26,27 @@ const updateParty = async (req, res) => {
 
     const auditDetails = generateTfmAuditDetails(req.user._id);
     const tfmDeal = await api.updateDeal({ dealId, dealUpdate, auditDetails });
+
+    // Submit facilities to APIM/GIFT
+    const { canSubmitFacilitiesToApimGift, issuedFacilities, isBssEwcsDeal, isGefDeal } = await canSubmitToApimGift(tfmDeal);
+
+    if (canSubmitFacilitiesToApimGift) {
+      console.info('TFM deal %s updateParty - calling submitFacilitiesToApimGift', dealId);
+
+      await submitFacilitiesToApimGift({
+        deal: tfmDeal,
+        facilities: issuedFacilities,
+        isBssEwcsDeal,
+        isGefDeal,
+      });
+    }
+
+    // Submit to ACBS
     const canSubmitDealToACBS = await canSubmitToACBS(tfmDeal);
 
     if (canSubmitDealToACBS) {
+      console.info('TFM deal %s updateParty - calling createACBS', dealId);
+
       await createACBS(dealId);
     }
 

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.js
@@ -53,13 +53,7 @@ const updateParty = async (req, res) => {
     if (canSubmitDealToACBS) {
       console.info('TFM deal %s updateParty - calling createACBS', dealId);
 
-      try {
-        await createACBS(dealId);
-      } catch (error) {
-        console.error('TFM deal %s updateParty - createACBS failed %o', dealId, error);
-
-        throw error;
-      }
+      await createACBS(dealId);
     }
 
     const response = res.status(HttpStatusCode.Ok).send({

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
@@ -176,7 +176,7 @@ describe('updateParty', () => {
       });
     });
 
-    it('should return 500 when submitFacilitiesToApimGift fails', async () => {
+    it(`should return ${HttpStatusCode.InternalServerError} when submitFacilitiesToApimGift fails`, async () => {
       const mockRequest = {
         params: {
           dealId: '5ce819935e539c343f141ece',
@@ -234,7 +234,7 @@ describe('updateParty', () => {
   });
 
   describe('when ACBS submission is allowed', () => {
-    it('should return 500 when createACBS fails', async () => {
+    it(`should return ${HttpStatusCode.InternalServerError} when createACBS fails`, async () => {
       const mockRequest = {
         params: {
           dealId: '5ce819935e539c343f141ece',

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
@@ -175,6 +175,34 @@ describe('updateParty', () => {
         isGefDeal: true,
       });
     });
+
+    it('should return 500 when submitFacilitiesToApimGift fails', async () => {
+      const mockRequest = {
+        params: {
+          dealId: '5ce819935e539c343f141ece',
+        },
+        body: mockTfmDeal.tfm.parties,
+        user: {
+          _id: '5ce819935e539c343f141ece',
+        },
+      };
+      const apimGiftError = new Error('APIM/GIFT failed');
+
+      canSubmitToApimGift.mockResolvedValue({
+        canSubmitFacilitiesToApimGift: true,
+        issuedFacilities,
+        isBssEwcsDeal: false,
+        isGefDeal: true,
+      });
+      submitFacilitiesToApimGift.mockRejectedValueOnce(apimGiftError);
+
+      await updateParty(mockRequest, mockResponse);
+
+      expect(consoleErrorMock).toHaveBeenCalledWith('TFM deal %s updateParty - submitFacilitiesToApimGift failed %o', mockRequest.params.dealId, apimGiftError);
+      expect(consoleErrorMock).toHaveBeenCalledWith('Unable to update parties for deal %s %o', mockRequest.params.dealId, apimGiftError);
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
+      expect(mockResponse.send).toHaveBeenCalledWith(apimGiftError);
+    });
   });
 
   describe('when APIM/GIFT submission is not allowed', () => {
@@ -202,6 +230,31 @@ describe('updateParty', () => {
 
       // Assert
       expect(submitFacilitiesToApimGift).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when ACBS submission is allowed', () => {
+    it('should return 500 when createACBS fails', async () => {
+      const mockRequest = {
+        params: {
+          dealId: '5ce819935e539c343f141ece',
+        },
+        body: mockTfmDeal.tfm.parties,
+        user: {
+          _id: '5ce819935e539c343f141ece',
+        },
+      };
+      const acbsError = new Error('ACBS failed');
+
+      canSubmitToACBS.mockResolvedValue(true);
+      createACBS.mockRejectedValueOnce(acbsError);
+
+      await updateParty(mockRequest, mockResponse);
+
+      expect(consoleErrorMock).toHaveBeenCalledWith('TFM deal %s updateParty - createACBS failed %o', mockRequest.params.dealId, acbsError);
+      expect(consoleErrorMock).toHaveBeenCalledWith('Unable to update parties for deal %s %o', mockRequest.params.dealId, acbsError);
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
+      expect(mockResponse.send).toHaveBeenCalledWith(acbsError);
     });
   });
 

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
@@ -234,7 +234,7 @@ describe('updateParty', () => {
   });
 
   describe('when ACBS submission is allowed', () => {
-    it(`should return ${HttpStatusCode.InternalServerError} when createACBS fails`, async () => {
+    it('should call createACBS', async () => {
       const mockRequest = {
         params: {
           dealId: '5ce819935e539c343f141ece',
@@ -251,10 +251,7 @@ describe('updateParty', () => {
 
       await updateParty(mockRequest, mockResponse);
 
-      expect(consoleErrorMock).toHaveBeenCalledWith('TFM deal %s updateParty - createACBS failed %o', mockRequest.params.dealId, acbsError);
-      expect(consoleErrorMock).toHaveBeenCalledWith('Unable to update parties for deal %s %o', mockRequest.params.dealId, acbsError);
-      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
-      expect(mockResponse.send).toHaveBeenCalledWith(acbsError);
+      expect(createACBS).toHaveBeenNthCalledWith(1, mockRequest.params.dealId);
     });
   });
 

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
@@ -1,8 +1,36 @@
 const { HttpStatusCode } = require('axios');
 const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { updateParty } = require('./party.controller');
+const { canSubmitToApimGift, submitFacilitiesToApimGift } = require('../integrations/apim-gift');
+const { createACBS } = require('./acbs.controller');
+const canSubmitToACBS = require('../helpers/can-submit-to-acbs');
 const api = require('../api');
-const CONSTANTS = require('../../constants');
+const { DEAL_TYPE, SUBMISSION_TYPE } = require('../../constants/deals');
+const { updateParty } = require('./party.controller');
+
+jest.mock('@ukef/dtfs2-common/change-stream', () => ({
+  generateTfmAuditDetails: jest.fn((userId) => ({ userId })),
+}));
+
+jest.mock('@ukef/dtfs2-common', () => ({
+  DEAL_SUBMISSION_TYPE: {
+    AIN: 'AIN',
+  },
+}));
+
+jest.mock('../api', () => ({
+  updateDeal: jest.fn(),
+}));
+
+jest.mock('../integrations/apim-gift', () => ({
+  canSubmitToApimGift: jest.fn(),
+  submitFacilitiesToApimGift: jest.fn(),
+}));
+
+jest.mock('./acbs.controller', () => ({
+  createACBS: jest.fn(),
+}));
+
+jest.mock('../helpers/can-submit-to-acbs', () => jest.fn());
 
 const mockTfmFacility = {
   facilitySnapshot: {
@@ -11,6 +39,8 @@ const mockTfmFacility = {
   },
   tfm: {},
 };
+
+const issuedFacilities = [mockTfmFacility];
 
 const mockTfmDeal = {
   _id: '5ce819935e539c343f141ece',
@@ -21,8 +51,8 @@ const mockTfmDeal = {
       partyUrn: '123',
     },
     ukefDealId: '0030113304',
-    dealType: CONSTANTS.DEALS.DEAL_TYPE.GEF,
-    submissionType: CONSTANTS.DEALS.SUBMISSION_TYPE.AIN,
+    dealType: DEAL_TYPE.GEF,
+    submissionType: SUBMISSION_TYPE.AIN,
     facilities: [mockTfmFacility],
   },
   tfm: {
@@ -55,34 +85,32 @@ const mockResponse = {
 const consoleErrorMock = jest.spyOn(console, 'error');
 consoleErrorMock.mockImplementation();
 
-const findOneDealMock = jest.spyOn(api, 'findOneDeal');
-findOneDealMock.mockResolvedValue(mockTfmDeal);
-
-const findOneFacilityMock = jest.spyOn(api, 'findOneFacility');
-findOneFacilityMock.mockResolvedValue(mockTfmFacility);
-const findFacilitiesByDealIdMock = jest.spyOn(api, 'findFacilitiesByDealId');
-findFacilitiesByDealIdMock.mockResolvedValue([mockTfmFacility]);
-
-const updateDealMock = jest.spyOn(api, 'updateDeal');
-updateDealMock.mockResolvedValue(mockTfmDeal);
-
-const createACBSMock = jest.spyOn(api, 'createACBS');
-createACBSMock.mockResolvedValue({});
+const updateDealMock = api.updateDeal;
 
 describe('updateParty', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    updateDealMock.mockResolvedValue(mockTfmDeal);
+
+    canSubmitToApimGift.mockResolvedValue({
+      canSubmitFacilitiesToApimGift: false,
+      issuedFacilities: [],
+      isBssEwcsDeal: false,
+      isGefDeal: true,
+    });
+
+    canSubmitToACBS.mockResolvedValue(false);
+    createACBS.mockResolvedValue({});
   });
 
-  it('should update party, call ACBS and return 200', async () => {
+  it('should update party and return 200', async () => {
     // Arrange
     const mockRequest = {
       params: {
         dealId: '5ce819935e539c343f141ece',
       },
-      body: {
-        ...mockTfmDeal.tfm.parties,
-      },
+      body: mockTfmDeal.tfm.parties,
       user: {
         _id: '5ce819935e539c343f141ece',
       },
@@ -92,15 +120,9 @@ describe('updateParty', () => {
     await updateParty(mockRequest, mockResponse);
 
     // Assert
-    expect(consoleErrorMock).toHaveBeenCalledTimes(0);
+    expect(consoleErrorMock).not.toHaveBeenCalled();
 
-    expect(findOneDealMock).toHaveBeenCalledTimes(2);
-    expect(findOneDealMock).toHaveBeenCalledWith(mockTfmDeal._id);
-
-    expect(findFacilitiesByDealIdMock).toHaveBeenCalledTimes(2);
-
-    expect(updateDealMock).toHaveBeenCalledTimes(1);
-    expect(updateDealMock).toHaveBeenCalledWith({
+    expect(updateDealMock).toHaveBeenNthCalledWith(1, {
       dealId: mockTfmDeal._id,
       dealUpdate: {
         tfm: {
@@ -110,8 +132,9 @@ describe('updateParty', () => {
       auditDetails: generateTfmAuditDetails(mockRequest.user._id),
     });
 
-    expect(createACBSMock).toHaveBeenCalledTimes(1);
-    expect(createACBSMock).toHaveBeenCalledWith(mockTfmDeal, mockTfmDeal.dealSnapshot.bank);
+    expect(canSubmitToApimGift).toHaveBeenCalledWith(mockTfmDeal);
+    expect(submitFacilitiesToApimGift).not.toHaveBeenCalled();
+    expect(createACBS).not.toHaveBeenCalled();
 
     expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCode.Ok);
     expect(mockResponse.send).toHaveBeenCalledWith({
@@ -121,31 +144,92 @@ describe('updateParty', () => {
     });
   });
 
-  it('should throw an error when user session does not exist', async () => {
-    // Arrange
-    const mockRequest = {
-      params: {},
-      body: {
-        ...mockTfmDeal.tfm.parties,
-      },
-    };
+  describe('when APIM/GIFT submission is allowed', () => {
+    it('should call submitFacilitiesToApimGift', async () => {
+      // Arrange
+      const mockRequest = {
+        params: {
+          dealId: '5ce819935e539c343f141ece',
+        },
+        body: mockTfmDeal.tfm.parties,
+        user: {
+          _id: '5ce819935e539c343f141ece',
+        },
+      };
 
-    // Mock `res.status().send()` to return `res` itself
-    mockResponse.status.mockImplementation(() => mockResponse);
+      canSubmitToApimGift.mockResolvedValue({
+        canSubmitFacilitiesToApimGift: true,
+        issuedFacilities,
+        isBssEwcsDeal: false,
+        isGefDeal: true,
+      });
 
-    // Act
-    await updateParty(mockRequest, mockResponse);
+      // Act
+      await updateParty(mockRequest, mockResponse);
 
-    // Assert
-    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
-    expect(consoleErrorMock).toHaveBeenCalledWith(
-      'Unable to update parties for deal %s %o',
-      undefined,
-      new Error("Cannot read properties of undefined (reading '_id')"),
-    );
+      // Assert
+      expect(submitFacilitiesToApimGift).toHaveBeenCalledWith({
+        deal: mockTfmDeal,
+        facilities: issuedFacilities,
+        isBssEwcsDeal: false,
+        isGefDeal: true,
+      });
+    });
+  });
 
-    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
-    expect(mockResponse.send).toHaveBeenCalledWith(new Error("Cannot read properties of undefined (reading '_id')"));
+  describe('when APIM/GIFT submission is not allowed', () => {
+    it('should not call submitFacilitiesToApimGift', async () => {
+      // Arrange
+      const mockRequest = {
+        params: {
+          dealId: '5ce819935e539c343f141ece',
+        },
+        body: mockTfmDeal.tfm.parties,
+        user: {
+          _id: '5ce819935e539c343f141ece',
+        },
+      };
+
+      canSubmitToApimGift.mockResolvedValue({
+        canSubmitFacilitiesToApimGift: false,
+        issuedFacilities,
+        isBssEwcsDeal: false,
+        isGefDeal: true,
+      });
+
+      // Act
+      await updateParty(mockRequest, mockResponse);
+
+      // Assert
+      expect(submitFacilitiesToApimGift).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when user session does not exist', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const mockRequest = {
+        params: {},
+        body: mockTfmDeal.tfm.parties,
+      };
+
+      // Mock `res.status().send()` to return `res` itself
+      mockResponse.status.mockImplementation(() => mockResponse);
+
+      // Act
+      await updateParty(mockRequest, mockResponse);
+
+      // Assert
+      expect(consoleErrorMock).toHaveBeenNthCalledWith(
+        1,
+        'Unable to update parties for deal %s %o',
+        undefined,
+        new Error("Cannot read properties of undefined (reading '_id')"),
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
+      expect(mockResponse.send).toHaveBeenCalledWith(new Error("Cannot read properties of undefined (reading '_id')"));
+    });
   });
 
   const requests = [
@@ -163,9 +247,7 @@ describe('updateParty', () => {
     },
     {
       params: {},
-      body: {
-        ...mockTfmDeal.tfm.parties,
-      },
+      body: mockTfmDeal.tfm.parties,
       user: {
         _id: '5ce819935e539c343f141ece',
       },
@@ -184,6 +266,9 @@ describe('updateParty', () => {
   it.each(requests)('should throw an error when request is invalid', async (request) => {
     // Arrange
     const mockRequest = request;
+    const apiError = new Error('Invalid deal object supplied');
+
+    updateDealMock.mockRejectedValueOnce(apiError);
 
     // Mock `res.status().send()` to return `res` itself
     mockResponse.status.mockImplementation(() => mockResponse);
@@ -192,15 +277,9 @@ describe('updateParty', () => {
     await updateParty(mockRequest, mockResponse);
 
     // Assert
-    expect(consoleErrorMock).toHaveBeenCalledTimes(2);
-    expect(consoleErrorMock).toHaveBeenCalledWith('Unable to submit deal to ACBS %o', new Error('Invalid deal object supplied'));
-    expect(consoleErrorMock).toHaveBeenCalledWith(
-      'Unable to update parties for deal %s %o',
-      mockRequest.params.dealId,
-      new Error("Cannot read properties of undefined (reading 'tfm')"),
-    );
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(1, 'Unable to update parties for deal %s %o', mockRequest.params.dealId, apiError);
 
     expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCode.InternalServerError);
-    expect(mockResponse.send).toHaveBeenCalledWith(new Error("Cannot read properties of undefined (reading 'tfm')"));
+    expect(mockResponse.send).toHaveBeenCalledWith(apiError);
   });
 });

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -38,6 +38,17 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
       };
     }
 
+    /**
+     * NOTE: During first BSS/EWCS deal submission, tfm.parties.buyer?.partyUrn will always be an empty string.
+     *
+     * The buyer party URN is populated in TFM - after the first deal submission.
+     * BSS/EWCS should only send facilities to APIM/GIFT if the buyer party URN is populated.
+     *
+     * Therefore, for the first submission of a BSS/EWCS deal, we should return canSubmitFacilitiesToApimGift as false.
+     * For GEF deals, there is no requirement for a buyer party URN to be populated to submit facilities to APIM/GIFT, so GEF deals can submit facilities on the first submission.
+     * This is an edge case but this is future proofed, and is important to prevent attempts to submit facilities to APIM/GIFT when the buyer party URN is not populated as this will cause errors in the APIM/GIFT integration.
+     * Once the buyer party URN is populated after the first submission, BSS/EWCS deals can submit facilities to APIM/GIFT on subsequent submissions as normal.
+     */
     const isValidBssEwcsDeal = isBssEwcsDeal && Boolean(deal.tfm.parties.buyer?.partyUrn);
 
     if (!isValidBssEwcsDeal && !isGefDeal) {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-party-urns/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-party-urns/index.ts
@@ -51,7 +51,3 @@ export const mapPartyUrns = ({ deal, isBssEwcsDeal, isGefDeal }: MapPartyUrnsPar
     exporterPartyUrn,
   };
 };
-
-// exporterPartyUrn = deal.tfm.parties.exporter.partyUrn - comes from salesforce during deal submission
-// buyerPartyUrn = deal.tfm.parties.buyer?.partyUrn
-// bankPartyUrn= deal.dealSnapshot.bank.partyUrn

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-party-urns/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-party-urns/index.ts
@@ -51,3 +51,7 @@ export const mapPartyUrns = ({ deal, isBssEwcsDeal, isGefDeal }: MapPartyUrnsPar
     exporterPartyUrn,
   };
 };
+
+// exporterPartyUrn = deal.tfm.parties.exporter.partyUrn - comes from salesforce during deal submission
+// buyerPartyUrn = deal.tfm.parties.buyer?.partyUrn
+// bankPartyUrn= deal.dealSnapshot.bank.partyUrn

--- a/trade-finance-manager-ui/templates/case/amendments/_macros/banks-decision-submitted.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/_macros/banks-decision-submitted.njk
@@ -12,7 +12,7 @@
       <div class="govuk-grid-column-full">
 
       <div class="govuk-!-padding-bottom-7">
-        {{govukTag({
+        {{ govukTag({
           text: bankDecision,
           classes: bankDecisionTags[bankDecision],
           attributes: { "data-cy": "decision-status-tag" }

--- a/trade-finance-manager-ui/templates/case/amendments/_macros/summary-table.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/_macros/summary-table.njk
@@ -5,7 +5,7 @@
   {% set rows = [] %}
   {% if amendment.changeCoverEndDate === true %}
     {% set coverEndDateDecisionHtml %}
-        {{govukTag({
+        {{ govukTag({
           text: amendment.ukefDecision.coverEndDate,
           classes: amendment.tags[amendment.ukefDecision.coverEndDate],
           attributes: { "data-cy": "amendment--details-"+amendment.version+"-cover-end-date-decision" }
@@ -35,7 +35,7 @@
 
   {% if amendment.changeFacilityValue === true %}
     {% set facilityValueDecisionHtml %}
-        {{govukTag({
+        {{ govukTag({
           text: amendment.ukefDecision.value,
           classes: amendment.tags[amendment.ukefDecision.value],
           attributes: { "data-cy": "amendment--details-"+amendment.version+"-facility-value-decision" }

--- a/trade-finance-manager-ui/templates/case/deal/_macros/eligibility-criteria-answer-tag.njk
+++ b/trade-finance-manager-ui/templates/case/deal/_macros/eligibility-criteria-answer-tag.njk
@@ -9,7 +9,7 @@
     {% set answerClass = 'govuk-tag--red' %}
   {% endif %}
 
-  {{govukTag({
+  {{ govukTag({
     text: answerText,
     classes: answerClass,
     attributes: {

--- a/trade-finance-manager-ui/templates/case/facility/_macros/amendment-details.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/amendment-details.njk
@@ -47,7 +47,7 @@
 
         {% if amendment.changeCoverEndDate === true %}
           {% set coverEndDateDecisionHtml %}
-              {{govukTag({
+              {{ govukTag({
                 text: amendment.ukefDecisionCoverEndDate,
                 classes: amendment.tags[amendment.ukefDecisionCoverEndDate],
                 attributes: { "data-cy": "amendment--details-"+loop.index+"-cover-end-date-decision" }
@@ -65,7 +65,7 @@
 
           {% if amendment.requireUkefApproval === 'Yes' %}
             {% set banksDecisionHtml %}
-              {{govukTag({
+              {{ govukTag({
                 text: amendment.banksDecision,
                 classes: amendment.bankDecisionTags[amendment.banksDecision],
                 attributes: { "data-cy": "amendment--details-"+loop.index+"-banks-decision" }
@@ -81,7 +81,7 @@
 
         {% if amendment.changeFacilityValue === true %}
           {% set facilityValueDecisionHtml %}
-              {{govukTag({
+              {{ govukTag({
                 text: amendment.ukefDecisionValue,
                 classes: amendment.tags[amendment.ukefDecisionValue],
                 attributes: { "data-cy": "amendment--details-"+loop.index+"-facility-value-decision" }
@@ -101,7 +101,7 @@
             {% set banksDecisionHtml = '' %}
             {% if amendment.changeCoverEndDate === false %}
               {% set banksDecisionHtml %}
-                {{govukTag({
+                {{ govukTag({
                   text: amendment.banksDecision,
                   classes: amendment.bankDecisionTags[amendment.banksDecision],
                   attributes: { "data-cy": "amendment--details-"+loop.index+"-banks-decision" }

--- a/trade-finance-manager-ui/templates/case/facility/_macros/credit-rating.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/credit-rating.njk
@@ -10,7 +10,7 @@
 
       {% else %}
 
-        {{govukTag({
+        {{ govukTag({
           text: 'Not set',
           classes: "govuk-tag--yellow",
           attributes: {

--- a/trade-finance-manager-ui/templates/case/facility/_macros/facility_details.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/facility_details.njk
@@ -23,7 +23,7 @@
 
         <dt class="govuk-grid-column-one-quarter govuk-body-s">Facility stage</dt>
         <dd class="govuk-grid-column-three-quarters">
-          {{govukTag({
+          {{ govukTag({
             text: facility.facilityStage,
             classes: "govuk-tag--blue",
             attributes: {

--- a/trade-finance-manager-ui/templates/case/parties/_macros/bond-beneficiary-facilities-table.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/bond-beneficiary-facilities-table.njk
@@ -38,7 +38,7 @@
               <span data-cy="facility-{{ facility._id }}-unique-reference-number">{{ facility.tfm.bondBeneficiaryPartyUrn }}</span>
 
             {% else %}
-              {{govukTag({
+              {{ govukTag({
                 text: 'Not matched',
                 classes: "govuk-tag--red",
                 attributes: {

--- a/trade-finance-manager-ui/templates/case/parties/_macros/bond-issuer-facilities-table.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/bond-issuer-facilities-table.njk
@@ -38,7 +38,7 @@
               <span data-cy="facility-{{ facility._id }}-unique-reference-number">{{ facility.tfm.bondIssuerPartyUrn }}</span>
 
             {% else %}
-              {{govukTag({
+              {{ govukTag({
                 text: 'Not matched',
                 classes: "govuk-tag--red",
                 attributes: {

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-agent-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-agent-area.njk
@@ -99,6 +99,7 @@
                     deal.eligibility.agentAddressPostcode],
             dataCy: 'agent-address'
           }) }}
+
           {{ keyValueGridRow.render({
             key: 'Country',
             value: deal.eligibility.agentAddressCountry.name,

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-beneficiary-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-beneficiary-area.njk
@@ -19,7 +19,6 @@
       {{ uniqueReferenceNumberEditLink.render({dealId: deal._id, type: 'bond-beneficiary'}) }}
     </div>
   {% endif %}
-
 </div>
 
 <div class="govuk-grid-row deal">

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-beneficiary-edit.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-beneficiary-edit.njk
@@ -20,31 +20,32 @@
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half govuk-!-margin-top-4">
-        {{ govukInput({
-          label: {
-            text: "Unique reference number (URN)"
-          },
-          attributes: {
-            "data-cy": "urn-input-" + index
-          },
-          id: "partyUrn-" + index,
-          name: "bondBeneficiaryPartyUrn[]",
-          value: urn[index - 1] or bond.tfm.bondBeneficiaryPartyUrn,
-          errorMessage: errors and errors.fieldErrors["partyUrn-" + index] and {
-            text: errors.fieldErrors["partyUrn-" + index].text,
+          {{ govukInput({
+            label: {
+              text: "Unique reference number (URN)"
+            },
             attributes: {
-              'data-cy': 'partyUrn--inline-error-' + index
+              "data-cy": "urn-input-" + index
+            },
+            id: "partyUrn-" + index,
+            name: "bondBeneficiaryPartyUrn[]",
+            value: urn[index - 1] or bond.tfm.bondBeneficiaryPartyUrn,
+            errorMessage: errors and errors.fieldErrors["partyUrn-" + index] and {
+              text: errors.fieldErrors["partyUrn-" + index].text,
+              attributes: {
+                'data-cy': 'partyUrn--inline-error-' + index
+              }
             }
-          }
-        }) }}
+          }) }}
         </div>
       </div>
 
       {{ keyValueArrayGridRow.render({
         key: 'Address',
-        values:  [ ],
+        values:  [],
         dataCy: 'bond-beneficiary-address'
       }) }}
+
       {{ keyValueGridRow.render({
         key: 'Country',
         value: '',

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-issuer-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-issuer-area.njk
@@ -9,10 +9,10 @@
 {% set filteredFacilities = deal.facilities | bondIssuerFacilities %}
 
 <div class="govuk-grid-row {% if renderEditLink %}ukef-flex-container deal{% endif %}" data-cy="bond-issuer-area">
-    <div class="govuk-grid-column-one-half">
+  <div class="govuk-grid-column-one-half">
     <h2 class="ukef-heading-l" data-cy="bond-issuer-heading">Bond issuer</h2>
     <p class="ukef-hint" id="parties-bond-issuer-area-ukef-hint" data-cy="bond-issuer-sub-heading">(if different to bank)</p>
-    </div>
+  </div>
 
   {% if filteredFacilities.length > 0 and renderEditLink %}
     <div class="govuk-grid-column-one-half ukef-flex-container--align-center-right">
@@ -22,7 +22,6 @@
 </div>
 
 <div class="govuk-grid-row deal">
-
   {% if deal.dealType === 'GEF' or not filteredFacilities.length > 0%}
     <div class="govuk-grid-column-one-half">
       {{ notApplicable.render({ id: 'bond-issuer' })}}
@@ -38,7 +37,6 @@
     </div>
 
   {% endif %}
-
 </div>
 
 {% endmacro %}

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-issuer-edit.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-bond-issuer-edit.njk
@@ -19,35 +19,38 @@
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half govuk-!-margin-top-4">
-        {{ govukInput({
-          label: {
-            text: "Unique reference number (URN)"
-          },
-          attributes: {
-            "data-cy": "urn-input-" + index
-          },
-          id: "partyUrn-" + index,
-          name: "bondIssuerPartyUrn[]",
-          value: urn[index - 1] or bond.tfm.bondIssuerPartyUrn,
-          errorMessage: errors and errors.fieldErrors["partyUrn-" + index] and {
-            text: errors.fieldErrors["partyUrn-" + index].text,
+          {{ govukInput({
+            label: {
+              text: "Unique reference number (URN)"
+            },
             attributes: {
-              'data-cy': 'partyUrn--inline-error-' + index
+              "data-cy": "urn-input-" + index
+            },
+            id: "partyUrn-" + index,
+            name: "bondIssuerPartyUrn[]",
+            value: urn[index - 1] or bond.tfm.bondIssuerPartyUrn,
+            errorMessage: errors and errors.fieldErrors["partyUrn-" + index] and {
+              text: errors.fieldErrors["partyUrn-" + index].text,
+              attributes: {
+                'data-cy': 'partyUrn--inline-error-' + index
+              }
             }
-          }
-        }) }}
+          }) }}
         </div>
       </div>
 
       {{ keyValueArrayGridRow.render({
         key: 'Address',
-        values:  [ bond.facilitySnapshot.bondIssuerAddressLine1,
-                bond.facilitySnapshot.bondIssuerAddressLine2,
-                bond.facilitySnapshot.bondIssuerAddressLine3,
-                bond.facilitySnapshot.bondIssuerAddressTown,
-                bond.facilitySnapshot.bondIssuerAddressPostcode],
+        values: [
+          bond.facilitySnapshot.bondIssuerAddressLine1,
+          bond.facilitySnapshot.bondIssuerAddressLine2,
+          bond.facilitySnapshot.bondIssuerAddressLine3,
+          bond.facilitySnapshot.bondIssuerAddressTown,
+          bond.facilitySnapshot.bondIssuerAddressPostcode
+        ],
         dataCy: 'bond-issuer-address'
       }) }}
+
       {{ keyValueGridRow.render({
         key: 'Country',
         value: bond.facilitySnapshot.agentAddressCountry,

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-buyer-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-buyer-area.njk
@@ -19,7 +19,7 @@
     {% set uniqueRefStyle = "govuk-tag govuk-tag--red govuk-!-margin-top-2" %}
   {% endif %}
 
-    {% if errors %}
+  {% if errors %}
     {{ govukErrorSummary({
       titleText: "There is a problem",
       errorList: errors.errorSummary,
@@ -93,13 +93,16 @@
 
           {{ keyValueArrayGridRow.render({
             key: 'Address',
-            values:  [ deal.submissionDetails.buyerAddressLine1,
-                    deal.submissionDetails.buyerAddressLine2,
-                    deal.submissionDetails.buyerAddressLine3,
-                    deal.submissionDetails.buyerAddressTown,
-                    deal.submissionDetails.buyerAddressPostcode],
+            values: [
+              deal.submissionDetails.buyerAddressLine1,
+              deal.submissionDetails.buyerAddressLine2,
+              deal.submissionDetails.buyerAddressLine3,
+              deal.submissionDetails.buyerAddressTown,
+              deal.submissionDetails.buyerAddressPostcode
+            ],
             dataCy: 'buyer-address'
           }) }}
+
           {{ keyValueGridRow.render({
             key: 'Country',
             value: deal.submissionDetails.buyerAddressCountry,

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.njk
@@ -21,13 +21,13 @@
   {% endif %}
 
   {% if errors %}
-      {{ govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: errors.errorSummary,
-        attributes: {
-          'data-cy': 'error-summary'
-        }
-      }) }}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors.errorSummary,
+      attributes: {
+        'data-cy': 'error-summary'
+      }
+    }) }}
   {% endif %}
 
   <div class="govuk-grid-row {% if renderEditLink %}ukef-flex-container deal{% endif %}" data-cy="parties-exporter">
@@ -42,7 +42,7 @@
     </div>
 
     {% if renderEditLink %}
-        <div class="govuk-grid-column-one-half ukef-flex-container--align-center-right">
+      <div class="govuk-grid-column-one-half ukef-flex-container--align-center-right">
         {{ uniqueReferenceNumberEditLink.render({dealId: deal._id, type: 'exporter'}) }}
       </div>
     {% endif %}
@@ -90,11 +90,13 @@
 
       {{ keyValueArrayGridRow.render({
         key: 'Address',
-        values:  [ deal.submissionDetails.supplierAddressLine1,
-                deal.submissionDetails.supplierAddressLine2,
-                deal.submissionDetails.supplierAddressLine3,
-                deal.submissionDetails.supplierAddressTown,
-                deal.submissionDetails.supplierAddressPostcode],
+        values: [
+          deal.submissionDetails.supplierAddressLine1,
+          deal.submissionDetails.supplierAddressLine2,
+          deal.submissionDetails.supplierAddressLine3,
+          deal.submissionDetails.supplierAddressTown,
+          deal.submissionDetails.supplierAddressPostcode
+        ],
         dataCy: 'exporter-address'
 
       }) }}
@@ -103,21 +105,25 @@
         value: deal.submissionDetails.supplierCountry,
         dataCy: 'exporter-country'
       }) }}
+
       {{ keyValueGridRow.render({
         key: 'Industry sector',
         value: deal.submissionDetails.industrySector,
         dataCy: 'industry-sector'
       }) }}
+
       {{ keyValueGridRow.render({
         key: 'Industry class',
         value: deal.submissionDetails.industryClass,
         dataCy: 'industry-class'
       }) }}
+
       {{ keyValueGridRow.render({
         key: 'Companies house<br/>registration number',
         value: deal.submissionDetails.supplierCompaniesHouseRegistrationNumber,
         dataCy: 'exporter-companies-house-registration-number'
       }) }}
+
       {{ keyValueGridRow.render({
         key: 'SME size',
         value: deal.submissionDetails.smeType,
@@ -132,11 +138,13 @@
 
         {{ keyValueArrayGridRow.render({
           key: 'Correspondence address',
-          values:  [ deal.submissionDetails.supplierCorrespondenceAddressLine1,
-                  deal.submissionDetails.supplierCorrespondenceAddressLine2,
-                  deal.submissionDetails.supplierCorrespondenceAddressLine3,
-                  deal.submissionDetails.supplierCorrespondenceAddressTown,
-                  deal.submissionDetails.supplierCorrespondenceAddressPostcode],
+          values: [
+            deal.submissionDetails.supplierCorrespondenceAddressLine1,
+            deal.submissionDetails.supplierCorrespondenceAddressLine2,
+            deal.submissionDetails.supplierCorrespondenceAddressLine3,
+            deal.submissionDetails.supplierCorrespondenceAddressTown,
+            deal.submissionDetails.supplierCorrespondenceAddressPostcode
+          ],
           dataCy: 'exporter-correspondence-address'
         }) }}
 

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-indemnifier-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-indemnifier-area.njk
@@ -76,9 +76,9 @@
                   text: errors.fieldErrors.partyUrn.text,
                   attributes: {
                     'data-cy': 'partyUrn--inline-error'
+                  }
                 }
-            }
-              }) }} 
+              }) }}
               </div>
             </div>
           {% else %}

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-indemnifier-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-indemnifier-area.njk
@@ -20,13 +20,13 @@
   {% endif %}
 
   {% if errors %}
-      {{ govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: errors.errorSummary,
-        attributes: {
-          'data-cy': 'error-summary'
-        }
-      }) }}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors.errorSummary,
+      attributes: {
+        'data-cy': 'error-summary'
+      }
+    }) }}
   {% endif %}
 
   <div class="govuk-grid-row {% if renderEditLink %}ukef-flex-container deal{% endif %}" data-cy="parties-indemnifier">
@@ -78,7 +78,7 @@
                     'data-cy': 'partyUrn--inline-error'
                 }
             }
-              }) }}
+              }) }} 
               </div>
             </div>
           {% else %}
@@ -92,13 +92,14 @@
 
           {{ keyValueArrayGridRow.render({
             key: 'Address',
-            values:  [ deal.submissionDetails.indemnifierAddressLine1,
-                    deal.submissionDetails.indemnifierAddressLine2,
-                    deal.submissionDetails.indemnifierAddressLine3,
-                    deal.submissionDetails.indemnifierAddressTown,
-                    deal.submissionDetails.indemnifierAddressPostcode],
+            values: [
+              deal.submissionDetails.indemnifierAddressLine1,
+              deal.submissionDetails.indemnifierAddressLine2,
+              deal.submissionDetails.indemnifierAddressLine3,
+              deal.submissionDetails.indemnifierAddressTown,
+              deal.submissionDetails.indemnifierAddressPostcode
+            ],
             dataCy: 'indemnifier-address'
-
           }) }}
 
           {{ keyValueGridRow.render({
@@ -108,15 +109,17 @@
           }) }}
 
           {{ keyValueGridRow.render({
-            key: 'Companies house<br>registration number',
+            key: 'Companies house registration number',
             value: deal.submissionDetails.indemnifierCompaniesHouseRegistrationNumber,
             dataCy: 'indemnifier-companies-house-registration-number'
           }) }}
+
           {{ keyValueGridRow.render({
-            key: 'Is the indemnifier legally<br>distinct from the exporter?',
+            key: 'Is the indemnifier legally distinct from the exporter?',
             value: deal.submissionDetails.legallyDistinct,
             dataCy: 'indemnifier-legally-distinct'
           }) }}
+
           {{ keyValueGridRow.render({
             key: 'Approval level required',
             value: '',
@@ -125,13 +128,16 @@
 
           {{ keyValueArrayGridRow.render({
             key: 'Correspondence Address',
-            values:  [ deal.submissionDetails.indemnifierCorrespondenceAddressLine1,
-                    deal.submissionDetails.indemnifierCorrespondenceAddressLine2,
-                    deal.submissionDetails.indemnifierCorrespondenceAddressLine3,
-                    deal.submissionDetails.indemnifierCorrespondenceAddressTown,
-                    deal.submissionDetails.indemnifierCorrespondenceAddressPostcode],
+            values:  [
+              deal.submissionDetails.indemnifierCorrespondenceAddressLine1,
+              deal.submissionDetails.indemnifierCorrespondenceAddressLine2,
+              deal.submissionDetails.indemnifierCorrespondenceAddressLine3,
+              deal.submissionDetails.indemnifierCorrespondenceAddressTown,
+              deal.submissionDetails.indemnifierCorrespondenceAddressPostcode
+            ],
             dataCy: 'correspondence-address'
           }) }}
+
           {{ keyValueGridRow.render({
             key: 'Correspondence country',
             value: deal.submissionDetails.indemnifierCorrespondenceAddressCountry,

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-key-value-array-grid-row.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-key-value-array-grid-row.njk
@@ -4,6 +4,7 @@
     <dt class="govuk-grid-column-one-third">
       <p class="ukef-heading-xs">{{params.key}}</p>
     </dt>
+
     <dd class="govuk-grid-column-two-thirds">
       <p class="govuk-body-s govuk-!-margin-top-3" data-cy="{{ params.dataCy }}">
         {% for value in params.values %}

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-key-value-grid-row.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-key-value-grid-row.njk
@@ -5,9 +5,10 @@
       {% if params.keyClass %}
         <p class="{{ params.keyClass }}">{{ params.key }}</p>
       {% else %}
-        <p class="ukef-heading-xs">{{ params.key }}</p>
+        <p class="ukef-heading-xs">{{ params.key | safe }}</p>
         {% endif %}
     </dt>
+
     <dd class="govuk-grid-column-two-thirds">
       {% if params.dataCy %}
         <p class="govuk-body-s govuk-!-margin-top-3 {{ params.valueStyle }}" data-cy="{{ params.dataCy }}">

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-key-value-grid-row.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-key-value-grid-row.njk
@@ -5,7 +5,7 @@
       {% if params.keyClass %}
         <p class="{{ params.keyClass }}">{{ params.key }}</p>
       {% else %}
-        <p class="ukef-heading-xs">{{ params.key | safe }}</p>
+        <p class="ukef-heading-xs">{{ params.key }}</p>
         {% endif %}
     </dt>
 

--- a/trade-finance-manager-ui/templates/case/parties/parties.njk
+++ b/trade-finance-manager-ui/templates/case/parties/parties.njk
@@ -19,6 +19,7 @@
     hasAmendmentInProgressSubmittedFromPim: hasAmendmentInProgressSubmittedFromPim,
     amendmentsInProgressSubmittedFromPim: amendmentsInProgressSubmittedFromPim
   } %}
+
   {{ amendmentInProgressBar.render(amendmentBarParams) }}
 
   <div class="govuk-grid-row">

--- a/trade-finance-manager-ui/templates/case/tasks/_macros/task-status-tag.njk
+++ b/trade-finance-manager-ui/templates/case/tasks/_macros/task-status-tag.njk
@@ -4,7 +4,7 @@
   {% set status = params.status %}
 
   {% if status === 'Cannot start yet' %}
-    {{govukTag({
+    {{ govukTag({
       text: status,
       attributes: {
         'data-cy': 'status-tag'
@@ -14,7 +14,7 @@
   {% endif %}
 
   {% if status === 'To do' %}
-    {{govukTag({
+    {{ govukTag({
       text: status,
       attributes: {
         'data-cy': 'status-tag'
@@ -23,7 +23,7 @@
   {% endif %}
 
   {% if status === 'In progress' %}
-    {{govukTag({
+    {{ govukTag({
       text: status,
       attributes: {
         'data-cy': 'status-tag'
@@ -33,7 +33,7 @@
   {% endif %}
 
   {% if status === 'Done' %}
-    {{govukTag({
+    {{ govukTag({
       text: status,
       attributes: {
         'data-cy': 'status-tag'

--- a/trade-finance-manager-ui/templates/case/underwriting/managers-decision/_macros/status-tag.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/managers-decision/_macros/status-tag.njk
@@ -15,7 +15,7 @@
     {% set statusClass = 'govuk-tag--green' %}
   {% endif %}
 
-  {{govukTag({
+  {{ govukTag({
     text: decision,
     classes: statusClass,
     attributes: {

--- a/trade-finance-manager-ui/templates/deals/_macros/deals-table.njk
+++ b/trade-finance-manager-ui/templates/deals/_macros/deals-table.njk
@@ -111,7 +111,7 @@
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-buyerName">{{ deal.dealSnapshot.submissionDetails.buyerName | dashIfEmpty}}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-bank">{{ deal.dealSnapshot.bank.name | dashIfEmpty }}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-stage">
-              {{govukTag({
+              {{ govukTag({
                 text: deal.tfm.stage | dashIfEmpty,
                 classes: "govuk-tag--blue"
               })}}

--- a/trade-finance-manager-ui/templates/facilities/_macros/facilities-table.njk
+++ b/trade-finance-manager-ui/templates/facilities/_macros/facilities-table.njk
@@ -127,7 +127,7 @@
             <td class="govuk-table__cell govuk-body-s" data-cy="facility-{{ facility.facilityId }}-value">{{ facility.currencyAndValue | dashIfEmpty}}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="facility-{{ facility.facilityId }}-coverEndDate">{{ facility.coverEndDate | dashIfEmpty }}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="facility-{{ facility.facilityId }}-facilityStage">
-              {{govukTag({
+              {{ govukTag({
                 text: facilityStage | dashIfEmpty,
                 classes: "govuk-tag--blue"
               })}}


### PR DESCRIPTION
# Introduction :pencil2:

When a buyer party URN is added to a deal in TFM, it then has the required data to send BSS/GEF facilities data to APIM/GIFT.

This PR introduces that mechanism.

Note that other scenarios will be discussed and actioned in other tickets/PRs, such as:
- Only sending if the facility does not already exist in GIFT
- Only triggering the call to GIFT, specifically for "buyer party" URN update
- What to do if the URN is edited in TFM, after sending to GIFT


## Resolution :heavy_check_mark:

- Update `party.controller` / `updateParty` to conditionaly call `submitFacilitiesToApimGift`.
- Add/update unit test.
- Add API test.
- Add documentation.

## Miscellaneous :heavy_plus_sign:

- Various minor nunjucks improvements - indentation, readability.
- Remove some empty lines.
- Minor logging improvement.
- Fix a bug where `<br>` HTML would render in text (`trade-finance-manager-ui/templates/case/parties/_macros/parties-key-value-grid-row.njk`)

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
