### PR TITLE
fix(DTFS2-8416): create a gift facility - ukefIndustryCode fall back

### DIFF
--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -57,6 +57,7 @@ export const create = async (req: Request, res: Response) => {
       data: req.body,
     }).catch((error: any) => {
       console.error('Error calling APIM TFS GIFT facility endpoint %o', error);
+
       return {
         status: error.response?.status,
       };

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -1940,7 +1940,7 @@ const createGiftFacility = async (facilityData) => {
   try {
     const { facilityId, dealId } = facilityData || {};
 
-    console.info('Calling external API "Create GIFT facility" endpoint', { facilityId, dealId });
+    console.info('Calling external API "Create GIFT facility" endpoint - facilityId %s dealId %s', facilityId, dealId);
 
     const response = await axios({
       method: 'post',

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -1938,7 +1938,8 @@ const getRecordCorrectionLogDetailsById = async (correctionId) => {
  */
 const createGiftFacility = async (facilityData) => {
   try {
-    const { facilityId, dealId } = facilityData || {};
+    const facilityId = facilityData?.overview?.facilityId;
+    const dealId = facilityData?.riskDetails?.dealId;
 
     console.info('Calling external API "Create GIFT facility" endpoint - facilityId %s dealId %s', facilityId, dealId);
 

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -1938,7 +1938,9 @@ const getRecordCorrectionLogDetailsById = async (correctionId) => {
  */
 const createGiftFacility = async (facilityData) => {
   try {
-    console.info('Calling external API "Create GIFT facility" endpoint with data: %o', facilityData);
+    const { facilityId, dealId } = facilityData || {};
+
+    console.info('Calling external API "Create GIFT facility" endpoint', { facilityId, dealId });
 
     const response = await axios({
       method: 'post',

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -1938,6 +1938,8 @@ const getRecordCorrectionLogDetailsById = async (correctionId) => {
  */
 const createGiftFacility = async (facilityData) => {
   try {
+    console.info('Calling external API "Create GIFT facility" endpoint with data: %o', facilityData);
+
     const response = await axios({
       method: 'post',
       url: `${EXTERNAL_API_URL}/gift/facility`,
@@ -1946,7 +1948,7 @@ const createGiftFacility = async (facilityData) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Unable to send GIFT facility %o', error);
+    console.error('Unable to send GIFT facility to external API %o', error);
 
     return false;
   }

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
@@ -111,7 +111,7 @@ describe('mapRiskDetails', () => {
       // Arrange
       const mockApi = jest.mocked(api) as jest.Mocked<typeof api>;
 
-      mockApi.getUkefIndustryCodeByCompaniesHouseIndustryCode = jest.fn().mockResolvedValueOnce(false);
+      mockApi.getUkefIndustryCodeByCompaniesHouseIndustryCode = jest.fn().mockResolvedValueOnce(undefined);
 
       // Act
       const result = await mapRiskDetails(params);

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
@@ -91,12 +91,27 @@ describe('mapRiskDetails', () => {
     expect(result).toEqual(expected);
   });
 
-  describe('when api.getUkefIndustryCodeByCompaniesHouseIndustryCode does not return an ukefIndustryCode', () => {
+  describe('when api.getUkefIndustryCodeByCompaniesHouseIndustryCode returns false, no ukefIndustryCode', () => {
     it('should default ukefIndustryCode to an empty string', async () => {
       // Arrange
       const mockApi = jest.mocked(api) as jest.Mocked<typeof api>;
 
-      mockApi.getUkefIndustryCodeByCompaniesHouseIndustryCode = jest.fn().mockResolvedValueOnce({} as never);
+      mockApi.getUkefIndustryCodeByCompaniesHouseIndustryCode = jest.fn().mockResolvedValueOnce(false);
+
+      // Act
+      const result = await mapRiskDetails(params);
+
+      // Assert
+      expect(result.ukefIndustryCode).toEqual('');
+    });
+  });
+
+  describe('when api.getUkefIndustryCodeByCompaniesHouseIndustryCode returns undefined, no ukefIndustryCode', () => {
+    it('should default ukefIndustryCode to an empty string', async () => {
+      // Arrange
+      const mockApi = jest.mocked(api) as jest.Mocked<typeof api>;
+
+      mockApi.getUkefIndustryCodeByCompaniesHouseIndustryCode = jest.fn().mockResolvedValueOnce(false);
 
       // Act
       const result = await mapRiskDetails(params);

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
@@ -91,6 +91,21 @@ describe('mapRiskDetails', () => {
     expect(result).toEqual(expected);
   });
 
+  describe('when api.getUkefIndustryCodeByCompaniesHouseIndustryCode does not return an ukefIndustryCode', () => {
+    it('should default ukefIndustryCode to an empty string', async () => {
+      // Arrange
+      const mockApi = jest.mocked(api) as jest.Mocked<typeof api>;
+
+      mockApi.getUkefIndustryCodeByCompaniesHouseIndustryCode = jest.fn().mockResolvedValueOnce({} as never);
+
+      // Act
+      const result = await mapRiskDetails(params);
+
+      // Assert
+      expect(result.ukefIndustryCode).toEqual('');
+    });
+  });
+
   describe('when api.getUkefIndustryCodeByCompaniesHouseIndustryCode throws an error', () => {
     beforeEach(() => {
       // Arrange

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.ts
@@ -46,15 +46,15 @@ export const mapRiskDetails = async ({
    * Ultimately, this will trigger an alert in APIM for the failed API call, which can be investigated by the team.
    * The alternative of this would be to have retry logic in DTFS, which is not desired - this is APIM's responsibility.
    */
-  let industryCodeResponse: UkefIndustryCode;
+  let ukefIndustryCode = '';
 
   try {
     const response = (await api.getUkefIndustryCodeByCompaniesHouseIndustryCode(industryCode)) as UkefIndustryCode | undefined;
 
-    industryCodeResponse = response ?? { ukefIndustryCode: '' };
+    ukefIndustryCode = response?.ukefIndustryCode ?? '';
   } catch {
     // Swallow errors and default ukefIndustryCode to an empty string
-    industryCodeResponse = { ukefIndustryCode: '' };
+    ukefIndustryCode = '';
   }
 
   const mapped: ApimGiftFacilityRiskDetails = {
@@ -67,7 +67,7 @@ export const mapRiskDetails = async ({
     }),
     facilityCreditRating: mapFacilityCreditRating(creditRiskRatings, exporterCreditRating),
     riskStatus: DEFAULTS.RISK_DETAILS.RISK_STATUS,
-    ukefIndustryCode: industryCodeResponse.ukefIndustryCode,
+    ukefIndustryCode,
   };
 
   return mapped;

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.ts
@@ -49,9 +49,11 @@ export const mapRiskDetails = async ({
   let ukefIndustryCode = '';
 
   try {
-    const response = (await api.getUkefIndustryCodeByCompaniesHouseIndustryCode(industryCode)) as UkefIndustryCode | undefined;
+    const response: UkefIndustryCode | false = await api.getUkefIndustryCodeByCompaniesHouseIndustryCode(industryCode);
 
-    ukefIndustryCode = response?.ukefIndustryCode ?? '';
+    if (response) {
+      ukefIndustryCode = response.ukefIndustryCode ?? '';
+    }
   } catch {
     // Swallow errors and default ukefIndustryCode to an empty string
     ukefIndustryCode = '';

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-category-code/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-category-code/index.ts
@@ -13,6 +13,7 @@ type MapFacilityCategoryCodeParams = {
  * where the category description includes both "GEF" and the TFM facility category code.
  * This is required because GEF facility categories are not codes.
  * Any other product/facility does not require a facility category code in the payload.
+ * NOTE: BSS/EWCS facilities are expected to have a null facility category code.
  * @param {MapFacilityCategoryCodeParams} params - Data required to map the facility category code for GEF facilities.
  * @param {FacilityCategory[]} params.facilityCategories - The list of facility categories from APIM MDM.
  * @param {string} [params.facilityType] - Facility type (e.g. "Cash", "Contingent").


### PR DESCRIPTION
# Introduction :pencil2:

As part of APIM/GIFT payload mapping, `riskDetails` could be sent without a `ukefIndustryCode`.

This should always be present in the `riskDetails` object - empty string as a fall back.

## Resolution :heavy_check_mark:

- Update `mapRiskDetails` to return `ukefIndustryCode` as an empty string.

## Miscellaneous :heavy_plus_sign:

- Minor logging and documentation improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
