### PR TITLE
fix(DTFS2-8406-8416): create a gift facility - external api industry code

### DIFF
--- a/external-api/server/v1/controllers/ukef-industry-code.controller.ts
+++ b/external-api/server/v1/controllers/ukef-industry-code.controller.ts
@@ -58,6 +58,7 @@ export const getByCompaniesHouseIndustryCode = async (req: Request, res: Respons
       headers,
     }).catch((error: any) => {
       console.error('Error calling UKEF Industry Code API, %o', error);
+
       return {
         data: error.response?.data,
         status: error.response?.status,

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -984,7 +984,7 @@ const getUkefIndustryCodeByCompaniesHouseIndustryCode = async (industryCode) => 
     const response = await axios({
       method: 'get',
       url: `${EXTERNAL_API_URL}/ukef-industry-code/by-companies-house-industry-code/${industryCode}`,
-      headers: headers.central,
+      headers: headers.external,
     });
     return response.data;
   } catch (error) {

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -923,6 +923,8 @@ const getCompanyInfo = async (partyUrn) => {
  */
 const getCreditRiskRatings = async () => {
   try {
+    console.info('Calling external API "Get credit risk ratings" endpoint');
+
     const response = await axios({
       method: 'get',
       url: `${EXTERNAL_API_URL}/credit-risk-ratings`,
@@ -942,6 +944,8 @@ const getCreditRiskRatings = async () => {
  */
 const getFacilityCategories = async () => {
   try {
+    console.info('Calling external API "Get facility categories" endpoint');
+
     const response = await axios({
       method: 'get',
       url: `${EXTERNAL_API_URL}/facility-categories`,
@@ -961,6 +965,8 @@ const getFacilityCategories = async () => {
  */
 const getObligationSubtypes = async () => {
   try {
+    console.info('Calling external API "Get obligation subtypes" endpoint');
+
     const response = await axios({
       method: 'get',
       url: `${EXTERNAL_API_URL}/obligation-subtypes`,
@@ -981,6 +987,8 @@ const getObligationSubtypes = async () => {
  */
 const getUkefIndustryCodeByCompaniesHouseIndustryCode = async (industryCode) => {
   try {
+    console.info('Calling external API "Get UKEF industry code by companies house industry code" endpoint - industryCode %s', industryCode);
+
     const response = await axios({
       method: 'get',
       url: `${EXTERNAL_API_URL}/ukef-industry-code/by-companies-house-industry-code/${industryCode}`,

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -991,7 +991,7 @@ const getUkefIndustryCodeByCompaniesHouseIndustryCode = async (industryCode) => 
 
     const response = await axios({
       method: 'get',
-      url: `${EXTERNAL_API_URL}/ukef-industry-code/by-companies-house-industry-code/${industryCode}`,
+      url: `${EXTERNAL_API_URL}/ukef-industry-code/by-companies-house-industry-code/${encodeURIComponent(industryCode)}`,
       headers: headers.external,
     });
     return response.data;


### PR DESCRIPTION
# Introduction :pencil2:

The external API's call to get a UKEF industry code by a Companies House industry code was not working.

It was silently failing due to an API key being sent in headers, instead of an external API key.

## Resolution :heavy_check_mark:

- Update TFM `api.getUkefIndustryCodeByCompaniesHouseIndustryCode` call.

## Miscellaneous :heavy_plus_sign:

- Logging improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
