### PR TITLE
chore(DTFS2-8415): can submit to apim gift - trim exporter credit rating

### DIFF
--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -294,8 +294,8 @@ describe('canSubmitToApimGift', () => {
       },
     );
 
-    describe.each([{ exporterCreditRating: undefined }, { exporterCreditRating: null }, { exporterCreditRating: '' }])(
-      'when deal does not have exporterCreditRating (exporterCreditRating: $exporterCreditRating)',
+    describe.each([{ exporterCreditRating: undefined }, { exporterCreditRating: null }, { exporterCreditRating: '' }, { exporterCreditRating: ' ' }])(
+      'when deal does not have an exporterCreditRating (exporterCreditRating: $exporterCreditRating)',
       ({ exporterCreditRating }) => {
         // Arrange
         const mockDeal = {

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -42,7 +42,7 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
      *
      * Therefore, for the first submission of a BSS/EWCS deal, we should return canSubmitFacilitiesToApimGift as false.
      */
-    const hasExporterCreditRating = Boolean(deal.tfm?.exporterCreditRating);
+    const hasExporterCreditRating = Boolean(deal.tfm?.exporterCreditRating?.trim());
 
     if (!validDealType || !validSubmissionType || !hasExporterCreditRating) {
       console.info(


### PR DESCRIPTION
# Introduction :pencil2:

Very edge case, very unlikely to happen - `deal.tfm.exporterCreditRating` could be a string with an empty space.

This PR adds `.trim()` to a boolean check for this just in case that does happen.

## Resolution :heavy_check_mark:

- Update `canSubmitToApimGift`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
