### PR TITLE
chore(DTFS2-8438): only send/create gift facilities if they do not exist

### DIFF
--- a/external-api/api-tests/v1/gift-facility.api-test.ts
+++ b/external-api/api-tests/v1/gift-facility.api-test.ts
@@ -20,6 +20,7 @@ describe('/gift', () => {
   describe('GET /facilities?ids=...', () => {
     const facilityIds = ['11111', '22222'];
     const ids = facilityIds.join(',');
+
     const mockResponseBody = {
       facilities: [
         { facilityId: facilityIds[0], status: HttpStatusCode.Ok },

--- a/external-api/api-tests/v1/gift-facility.api-test.ts
+++ b/external-api/api-tests/v1/gift-facility.api-test.ts
@@ -17,6 +17,45 @@ const { post, get } = api(app);
 describe('/gift', () => {
   const baseUrl = String(APIM_TFS_URL);
 
+  describe('GET /facilities?ids=...', () => {
+    const facilityIds = ['11111', '22222'];
+    const ids = facilityIds.join(',');
+    const mockResponseBody = {
+      facilities: [
+        { facilityId: facilityIds[0], status: HttpStatusCode.Ok },
+        { facilityId: facilityIds[1], status: HttpStatusCode.NotFound },
+      ],
+    };
+
+    describe(`when ids query parameter is provided`, () => {
+      it(`should return ${HttpStatusCode.Ok} with APIM TFS data`, async () => {
+        // Arrange
+        nock.abortPendingRequests();
+        nock.cleanAll();
+
+        nock(baseUrl).get('/v2/gift/facilities').query({ ids }).reply(HttpStatusCode.Ok, mockResponseBody);
+
+        // Act
+        const response = await get(`/gift/facilities?ids=${ids}`);
+
+        // Assert
+        expect(response.status).toEqual(HttpStatusCode.Ok);
+        expect(response.body).toEqual(mockResponseBody);
+      });
+    });
+
+    describe(`when ids query parameter is missing`, () => {
+      it(`should return ${HttpStatusCode.BadRequest}`, async () => {
+        // Act
+        const response = await get('/gift/facilities');
+
+        // Assert
+        expect(response.status).toEqual(HttpStatusCode.BadRequest);
+        expect(response.body).toEqual({ status: HttpStatusCode.BadRequest, message: 'ids query parameter is required' });
+      });
+    });
+  });
+
   describe('GET /facility/:facilityId', () => {
     const mockFacilityId = '12345';
     const url = `/v2/gift/facility/${mockFacilityId}`;

--- a/external-api/api-tests/v1/gift-facility.api-test.ts
+++ b/external-api/api-tests/v1/gift-facility.api-test.ts
@@ -12,11 +12,67 @@ dotenv.config();
 
 const { APIM_TFS_URL } = process.env;
 
-const { post } = api(app);
+const { post, get } = api(app);
 
 describe('/gift', () => {
+  const baseUrl = String(APIM_TFS_URL);
+
+  describe('GET /facility/:facilityId', () => {
+    const mockFacilityId = '12345';
+    const url = `/v2/gift/facility/${mockFacilityId}`;
+
+    describe(`when APIM TFS returns ${HttpStatusCode.Ok}`, () => {
+      it(`should return a ${HttpStatusCode.Ok} status with data received from APIM TFS`, async () => {
+        // Arrange
+        nock.abortPendingRequests();
+        nock.cleanAll();
+
+        nock(baseUrl).get(url).reply(HttpStatusCode.Ok, {});
+
+        // Act
+        const { status } = await get(`/gift/facility/${mockFacilityId}`);
+
+        // Assert
+        expect(status).toEqual(HttpStatusCode.Ok);
+      });
+    });
+
+    describe(`when APIM TFS returns ${HttpStatusCode.NotFound}`, () => {
+      it(`should return a ${HttpStatusCode.NotFound} status`, async () => {
+        // Arrange
+        nock.abortPendingRequests();
+        nock.cleanAll();
+
+        nock(baseUrl).get(url).reply(HttpStatusCode.NotFound, {});
+
+        // Act
+        const { status } = await get(`/gift/facility/${mockFacilityId}`);
+
+        // Assert
+        expect(status).toEqual(HttpStatusCode.NotFound);
+      });
+    });
+
+    describe(`when the APIM TFS endpoint returns a status that is NOT ${HttpStatusCode.Ok} or ${HttpStatusCode.NotFound}`, () => {
+      it('should return the same status from the APIM TFS endpoint', async () => {
+        // Arrange
+        nock.abortPendingRequests();
+        nock.cleanAll();
+
+        const mockStatusCode = HttpStatusCode.BadGateway;
+
+        nock(baseUrl).persist().get(url).reply(mockStatusCode, {});
+
+        // Act
+        const { status } = await get(`/gift/facility/${mockFacilityId}`);
+
+        // Assert
+        expect(status).toEqual(mockStatusCode);
+      });
+    });
+  });
+
   describe('POST /facility', () => {
-    const baseUrl = String(APIM_TFS_URL);
     const url = '/v2/gift/facility';
     const mockBody = APIM_GIFT_PAYLOADS_EXAMPLES.CREATE_FACILITY.VALID_PAYLOAD;
 

--- a/external-api/server/helpers/swagger-definitions/gift-facility.ts
+++ b/external-api/server/helpers/swagger-definitions/gift-facility.ts
@@ -1,0 +1,34 @@
+/**
+ * @openapi
+ * definitions:
+ *   GiftFacility:
+ *     type: object
+ *     properties:
+ *       facilityId:
+ *         type: string
+ *         description: The GIFT facility ID
+ *         example: 'FACILITY-001'
+ *       status:
+ *         type: integer
+ *         description: HTTP status code for the facility lookup
+ *         example: 200
+ *   GiftFacilitiesBulkResponse:
+ *     type: object
+ *     properties:
+ *       facilities:
+ *         type: array
+ *         description: Array of facility lookup results
+ *         items:
+ *           $ref: '#/definitions/GiftFacility'
+ *   GiftFacilityErrorResponse:
+ *     type: object
+ *     properties:
+ *       status:
+ *         type: integer
+ *         description: HTTP error status code
+ *         example: 400
+ *       message:
+ *         type: string
+ *         description: Error message
+ *         example: 'ids query parameter is required'
+ */

--- a/external-api/server/helpers/swagger-definitions/gift-facility.ts
+++ b/external-api/server/helpers/swagger-definitions/gift-facility.ts
@@ -3,15 +3,19 @@
  * definitions:
  *   GiftFacility:
  *     type: object
- *     properties:
- *       facilityId:
- *         type: string
- *         description: The GIFT facility ID
- *         example: 'FACILITY-001'
- *       status:
- *         type: integer
- *         description: HTTP status code for the facility lookup
- *         example: 200
+ *     description: GIFT facility payload returned by APIM
+ *     additionalProperties: true
+ *     example:
+ *       amount: 10000
+ *       creditType: Term
+ *       currency: USD
+ *       effectiveDate: '2025-01-01'
+ *       expiryDate: '2027-02-01'
+ *       facilityId: '0030000322'
+ *       name: Amazing facility
+ *       obligorUrn: '01234567'
+ *       productTypeCode: PRT003
+ *       repaymentType: Scheduled
  *   GiftFacilitiesBulkResponse:
  *     type: object
  *     properties:

--- a/external-api/server/helpers/swagger-definitions/gift-facility.ts
+++ b/external-api/server/helpers/swagger-definitions/gift-facility.ts
@@ -17,13 +17,10 @@
  *       productTypeCode: PRT003
  *       repaymentType: Scheduled
  *   GiftFacilitiesBulkResponse:
- *     type: object
- *     properties:
- *       facilities:
- *         type: array
- *         description: Array of facility lookup results
- *         items:
- *           $ref: '#/definitions/GiftFacility'
+ *     type: array
+ *     description: Array of facility lookup results
+ *     items:
+ *       $ref: '#/definitions/GiftFacility'
  *   GiftFacilityErrorResponse:
  *     type: object
  *     properties:

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -56,9 +56,15 @@ describe('get', () => {
 
   it(`should fallback to ${HttpStatusCode.InternalServerError} when axios throws without an HTTP response`, async () => {
     // Arrange
-    const mockError = new Error('Mock network error');
+    const mockResponseBody = {
+      message: `Mock response data for get facility ${mockFacilityId}`,
+    };
 
-    const expectedResponseBody = { message: `No response received from APIM TFS GIFT - get facility ${mockFacilityId} endpoint` };
+    const mockError = {
+      response: {
+        data: mockResponseBody,
+      },
+    };
 
     jest.mocked(axios).mockRejectedValueOnce(mockError);
 
@@ -75,7 +81,7 @@ describe('get', () => {
       'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
       mockFacilityId,
       HttpStatusCode.InternalServerError,
-      expectedResponseBody,
+      mockResponseBody,
       mockError,
     );
 
@@ -176,7 +182,16 @@ describe('getMany', () => {
     const ids = facilityIds.join(',');
     mockRequest.query = { ids };
 
-    const mockError = new Error('Mock network error');
+    const mockResponseBody = {
+      message: `Mock response data for get facilities ids=${ids}`,
+    };
+
+    const mockError = {
+      response: {
+        data: mockResponseBody,
+      },
+    };
+
     jest.mocked(axios).mockRejectedValueOnce(mockError);
 
     // Act
@@ -188,7 +203,7 @@ describe('getMany', () => {
       'Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o',
       ids,
       HttpStatusCode.InternalServerError,
-      { message: `No response received from APIM TFS GIFT - get facilities endpoint ids=${ids}` },
+      mockResponseBody,
       mockError,
     );
 

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -196,8 +196,7 @@ describe('getMany', () => {
       expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(mockResponse._getData()).toEqual(mockResponseData);
 
-      expect(axios).toHaveBeenCalledTimes(1);
-      expect(axios).toHaveBeenCalledWith({
+      expect(axios).toHaveBeenNthCalledWith(1, {
         method: 'GET',
         url: `${APIM_TFS_URL}v2/gift/facilities?ids=${ids}`,
         headers,

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -33,94 +33,119 @@ describe('get', () => {
     jest.resetAllMocks();
   });
 
-  it(`should return ${HttpStatusCode.Ok} when APIM TFS GIFT facility returns success`, async () => {
-    // Arrange
-    mockRequest.params = { facilityId: mockFacilityId };
+  describe('when APIM TFS GIFT facility returns success', () => {
+    it(`should return ${HttpStatusCode.Ok} with response data`, async () => {
+      // Arrange
+      const responseData = { facilityId: mockFacilityId, status: 'active' };
+      mockRequest.params = { facilityId: mockFacilityId };
 
-    jest.mocked(axios).mockResolvedValueOnce({ status: HttpStatusCode.Ok, data: {} });
+      jest.mocked(axios).mockResolvedValueOnce({ status: HttpStatusCode.Ok, data: responseData });
 
-    // Act
-    await get(mockRequest, mockResponse);
+      // Act
+      await get(mockRequest, mockResponse);
 
-    // Assert
-    expect(console.error).toHaveBeenCalledTimes(0);
+      // Assert
+      expect(console.error).toHaveBeenCalledTimes(0);
 
-    expect(axios).toHaveBeenNthCalledWith(1, {
-      method: 'GET',
-      url: `${APIM_TFS_URL}v2/gift/facility/${mockFacilityId}`,
-      headers,
+      expect(axios).toHaveBeenNthCalledWith(1, {
+        method: 'GET',
+        url: `${APIM_TFS_URL}v2/gift/facility/${mockFacilityId}`,
+        headers,
+      });
+
+      expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(mockResponse._getData()).toEqual(responseData);
     });
-
-    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Ok);
   });
 
-  it(`should fallback to ${HttpStatusCode.InternalServerError} when axios throws without an HTTP response`, async () => {
-    // Arrange
-    const mockResponseBody = {
-      message: `Mock response data for get facility ${mockFacilityId}`,
-    };
+  describe('when a APIM TFS GIFT facility is not found', () => {
+    it(`should return ${HttpStatusCode.NotFound} with response data`, async () => {
+      // Arrange
+      const responseData = { message: `Facility ${mockFacilityId} not found` };
+      mockRequest.params = { facilityId: mockFacilityId };
 
-    const mockError = {
-      response: {
-        data: mockResponseBody,
-      },
-    };
+      jest.mocked(axios).mockResolvedValueOnce({ status: HttpStatusCode.NotFound, data: responseData });
 
-    jest.mocked(axios).mockRejectedValueOnce(mockError);
+      // Act
+      await get(mockRequest, mockResponse);
 
-    // Act
-    mockRequest.params = {
-      facilityId: mockFacilityId,
-    };
-
-    await get(mockRequest, mockResponse);
-
-    // Assert
-    expect(console.error).toHaveBeenNthCalledWith(
-      1,
-      'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
-      mockFacilityId,
-      HttpStatusCode.InternalServerError,
-      mockResponseBody,
-      mockError,
-    );
-
-    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      // Assert
+      expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.NotFound);
+      expect(mockResponse._getData()).toEqual(responseData);
+    });
   });
 
-  it(`should forward non-${HttpStatusCode.Ok} and non-${HttpStatusCode.NotFound} status when APIM TFS GIFT facility returns an HTTP error response`, async () => {
-    // Arrange
-    const mockAxiosError = {
-      response: {
-        status: HttpStatusCode.BadGateway,
-        data: {
-          status: HttpStatusCode.BadGateway,
-          message: 'Mock upstream error',
-          errors: [{ code: 'UPSTREAM_FAILURE' }],
+  describe(`when axios throws without an HTTP response`, () => {
+    it(`should fallback to ${HttpStatusCode.InternalServerError}`, async () => {
+      // Arrange
+      const mockResponseBody = {
+        message: `Mock response data for get facility ${mockFacilityId}`,
+      };
+
+      const mockError = {
+        response: {
+          data: mockResponseBody,
         },
-      },
-    };
+      };
 
-    jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
+      jest.mocked(axios).mockRejectedValueOnce(mockError);
 
-    // Act
-    mockRequest.params = {
-      facilityId: mockFacilityId,
-    };
+      // Act
+      mockRequest.params = {
+        facilityId: mockFacilityId,
+      };
 
-    await get(mockRequest, mockResponse);
+      await get(mockRequest, mockResponse);
 
-    // Assert
-    expect(console.error).toHaveBeenNthCalledWith(
-      1,
-      'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
-      mockFacilityId,
-      mockAxiosError.response.status,
-      mockAxiosError.response.data,
-      mockAxiosError,
-    );
+      // Assert
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
+        mockFacilityId,
+        HttpStatusCode.InternalServerError,
+        mockResponseBody,
+        mockError,
+      );
 
-    expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+      expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    });
+  });
+
+  describe(`when APIM TFS GIFT facility returns an HTTP error response`, () => {
+    it(`should forward non-${HttpStatusCode.Ok} and non-${HttpStatusCode.NotFound} status`, async () => {
+      // Arrange
+      const mockAxiosError = {
+        response: {
+          status: HttpStatusCode.BadGateway,
+          data: {
+            status: HttpStatusCode.BadGateway,
+            message: 'Mock upstream error',
+            errors: [{ code: 'UPSTREAM_FAILURE' }],
+          },
+        },
+      };
+
+      jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
+
+      // Act
+      mockRequest.params = {
+        facilityId: mockFacilityId,
+      };
+
+      await get(mockRequest, mockResponse);
+
+      // Assert
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
+        mockFacilityId,
+        mockAxiosError.response.status,
+        mockAxiosError.response.data,
+        mockAxiosError,
+      );
+
+      expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+    });
   });
 });
 
@@ -136,113 +161,121 @@ describe('getMany', () => {
     jest.resetAllMocks();
   });
 
-  it(`should return ${HttpStatusCode.BadRequest} when ids query parameter is missing`, async () => {
-    // Act
-    await getMany(mockRequest, mockResponse);
+  describe('when ids query parameter is missing', () => {
+    it(`should return ${HttpStatusCode.BadRequest}`, async () => {
+      // Act
+      await getMany(mockRequest, mockResponse);
 
-    // Assert
-    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
-    expect(mockResponse._getData()).toEqual({ status: HttpStatusCode.BadRequest, message: 'ids query parameter is required' });
-    expect(axios).toHaveBeenCalledTimes(0);
-  });
-
-  it(`should return ${HttpStatusCode.Ok} and response data when APIM TFS returns success`, async () => {
-    // Arrange
-    const facilityIds = ['FACILITY-001', 'FACILITY-002'];
-    const ids = facilityIds.join(',');
-    const mockResponseData = {
-      facilities: [
-        { facilityId: facilityIds[0], status: HttpStatusCode.Ok },
-        { facilityId: facilityIds[1], status: HttpStatusCode.NotFound },
-      ],
-    };
-
-    mockRequest.query = { ids };
-
-    jest.mocked(axios).mockResolvedValueOnce({ status: HttpStatusCode.Ok, data: mockResponseData });
-
-    // Act
-    await getMany(mockRequest, mockResponse);
-
-    // Assert
-    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Ok);
-    expect(mockResponse._getData()).toEqual(mockResponseData);
-
-    expect(axios).toHaveBeenCalledTimes(1);
-    expect(axios).toHaveBeenCalledWith({
-      method: 'GET',
-      url: `${APIM_TFS_URL}v2/gift/facilities?ids=${ids}`,
-      headers,
+      // Assert
+      expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+      expect(mockResponse._getData()).toEqual({ status: HttpStatusCode.BadRequest, message: 'ids query parameter is required' });
+      expect(axios).toHaveBeenCalledTimes(0);
     });
   });
 
-  it(`should fallback to ${HttpStatusCode.InternalServerError} when APIM TFS throws without an HTTP response`, async () => {
-    // Arrange
-    const facilityIds = ['FACILITY-001'];
-    const ids = facilityIds.join(',');
-    mockRequest.query = { ids };
+  describe('when APIM TFS returns success', () => {
+    it(`should return ${HttpStatusCode.Ok} and response data`, async () => {
+      // Arrange
+      const facilityIds = ['FACILITY-001', 'FACILITY-002'];
+      const ids = facilityIds.join(',');
+      const mockResponseData = {
+        facilities: [
+          { facilityId: facilityIds[0], status: HttpStatusCode.Ok },
+          { facilityId: facilityIds[1], status: HttpStatusCode.NotFound },
+        ],
+      };
 
-    const mockResponseBody = {
-      message: `Mock response data for get facilities ids=${ids}`,
-    };
+      mockRequest.query = { ids };
 
-    const mockError = {
-      response: {
-        data: mockResponseBody,
-      },
-    };
+      jest.mocked(axios).mockResolvedValueOnce({ status: HttpStatusCode.Ok, data: mockResponseData });
 
-    jest.mocked(axios).mockRejectedValueOnce(mockError);
+      // Act
+      await getMany(mockRequest, mockResponse);
 
-    // Act
-    await getMany(mockRequest, mockResponse);
+      // Assert
+      expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(mockResponse._getData()).toEqual(mockResponseData);
 
-    // Assert
-    expect(console.error).toHaveBeenNthCalledWith(
-      1,
-      'Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o',
-      ids,
-      HttpStatusCode.InternalServerError,
-      mockResponseBody,
-      mockError,
-    );
-
-    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(axios).toHaveBeenCalledTimes(1);
+      expect(axios).toHaveBeenCalledWith({
+        method: 'GET',
+        url: `${APIM_TFS_URL}v2/gift/facilities?ids=${ids}`,
+        headers,
+      });
+    });
   });
 
-  it(`should forward non-${HttpStatusCode.Ok} status when APIM TFS get facilities returns an HTTP error response`, async () => {
-    // Arrange
-    const facilityIds = ['FACILITY-001', 'FACILITY-002'];
-    const ids = facilityIds.join(',');
-    mockRequest.query = { ids };
+  describe('when APIM TFS throws without an HTTP response', () => {
+    it(`should fallback to ${HttpStatusCode.InternalServerError}`, async () => {
+      // Arrange
+      const facilityIds = ['FACILITY-001'];
+      const ids = facilityIds.join(',');
+      mockRequest.query = { ids };
 
-    const mockAxiosError = {
-      response: {
-        status: HttpStatusCode.BadGateway,
-        data: {
-          status: HttpStatusCode.BadGateway,
-          message: 'Mock upstream error',
-          errors: [{ code: 'UPSTREAM_FAILURE' }],
+      const mockResponseBody = {
+        message: `Mock response data for get facilities ids=${ids}`,
+      };
+
+      const mockError = {
+        response: {
+          data: mockResponseBody,
         },
-      },
-    };
+      };
 
-    jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
+      jest.mocked(axios).mockRejectedValueOnce(mockError);
 
-    // Act
-    await getMany(mockRequest, mockResponse);
+      // Act
+      await getMany(mockRequest, mockResponse);
 
-    // Assert
-    expect(console.error).toHaveBeenNthCalledWith(
-      1,
-      'Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o',
-      ids,
-      mockAxiosError.response.status,
-      mockAxiosError.response.data,
-      mockAxiosError,
-    );
+      // Assert
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        'Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o',
+        ids,
+        HttpStatusCode.InternalServerError,
+        mockResponseBody,
+        mockError,
+      );
 
-    expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+      expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    });
+  });
+
+  describe('when APIM TFS get facilities returns an HTTP error response', () => {
+    it(`should forward non-${HttpStatusCode.Ok} status`, async () => {
+      // Arrange
+      const facilityIds = ['FACILITY-001', 'FACILITY-002'];
+      const ids = facilityIds.join(',');
+      mockRequest.query = { ids };
+
+      const mockAxiosError = {
+        response: {
+          status: HttpStatusCode.BadGateway,
+          data: {
+            status: HttpStatusCode.BadGateway,
+            message: 'Mock upstream error',
+            errors: [{ code: 'UPSTREAM_FAILURE' }],
+          },
+        },
+      };
+
+      jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
+
+      // Act
+      await getMany(mockRequest, mockResponse);
+
+      // Assert
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        'Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o',
+        ids,
+        mockAxiosError.response.status,
+        mockAxiosError.response.data,
+        mockAxiosError,
+      );
+
+      expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+    });
   });
 });
 
@@ -322,41 +355,43 @@ describe('create', () => {
     expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
   });
 
-  it(`should forward non-${HttpStatusCode.Created} status when APIM TFS GIFT facility returns an HTTP error response`, async () => {
-    // Arrange
-    const mockFacilityId = 'mock-facility-id';
-    const mockAxiosError = {
-      response: {
-        status: HttpStatusCode.BadGateway,
-        data: {
+  describe('when APIM TFS GIFT facility returns an HTTP error response', () => {
+    it(`should forward non-${HttpStatusCode.Created} status`, async () => {
+      // Arrange
+      const mockFacilityId = 'mock-facility-id';
+      const mockAxiosError = {
+        response: {
           status: HttpStatusCode.BadGateway,
-          message: 'Mock upstream error',
-          errors: [{ code: 'UPSTREAM_FAILURE' }],
+          data: {
+            status: HttpStatusCode.BadGateway,
+            message: 'Mock upstream error',
+            errors: [{ code: 'UPSTREAM_FAILURE' }],
+          },
         },
-      },
-    };
+      };
 
-    jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
+      jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
 
-    // Act
-    mockRequest.body = {
-      overview: {
-        facilityId: mockFacilityId,
-      },
-    };
+      // Act
+      mockRequest.body = {
+        overview: {
+          facilityId: mockFacilityId,
+        },
+      };
 
-    await create(mockRequest, mockResponse);
+      await create(mockRequest, mockResponse);
 
-    // Assert
-    expect(console.error).toHaveBeenNthCalledWith(
-      1,
-      'Error calling APIM TFS GIFT - create facility endpoint - facilityId %s status %s responseBody %o error %o',
-      mockFacilityId,
-      mockAxiosError.response.status,
-      mockAxiosError.response.data,
-      mockAxiosError,
-    );
+      // Assert
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        'Error calling APIM TFS GIFT - create facility endpoint - facilityId %s status %s responseBody %o error %o',
+        mockFacilityId,
+        mockAxiosError.response.status,
+        mockAxiosError.response.data,
+        mockAxiosError,
+      );
 
-    expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+      expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+    });
   });
 });

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -238,6 +238,7 @@ describe('getMany', () => {
       );
 
       expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(mockResponse._getData()).toEqual(mockResponseBody);
     });
   });
 
@@ -275,6 +276,7 @@ describe('getMany', () => {
       );
 
       expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+      expect(mockResponse._getData()).toEqual(mockAxiosError.response.data);
     });
   });
 });

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 import { HEADERS } from '@ukef/dtfs2-common';
 import { Request, Response } from 'express';
 import httpMocks, { MockRequest, MockResponse } from 'node-mocks-http';
-import { create } from './gift-facility.controller';
+import { create, get } from './gift-facility.controller';
 
 dotenv.config();
 
@@ -13,17 +13,118 @@ const headers = {
   [String(APIM_TFS_KEY)]: APIM_TFS_VALUE,
 };
 
-const mockTfsResponse = {
-  data: {},
-  status: HttpStatusCode.Created,
-};
-
 let mockRequest: MockRequest<Request>;
 let mockResponse: MockResponse<Response>;
 
 jest.mock('axios');
 
+describe('get', () => {
+  // Arrange
+  const mockFacilityId = 'mock-facility-id';
+
+  beforeEach(() => {
+    ({ req: mockRequest, res: mockResponse } = httpMocks.createMocks());
+
+    console.info = jest.fn();
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it(`should return ${HttpStatusCode.Ok} when APIM TFS GIFT facility returns success`, async () => {
+    // Arrange
+    mockRequest.params = { facilityId: mockFacilityId };
+
+    jest.mocked(axios).mockResolvedValueOnce({ status: HttpStatusCode.Ok, data: {} });
+
+    // Act
+    await get(mockRequest, mockResponse);
+
+    // Assert
+    expect(console.error).toHaveBeenCalledTimes(0);
+
+    expect(axios).toHaveBeenNthCalledWith(1, {
+      method: 'GET',
+      url: `${APIM_TFS_URL}v2/gift/facility/${mockFacilityId}`,
+      headers,
+    });
+
+    expect(mockResponse._getStatusCode()).toBe(HttpStatusCode.Ok);
+  });
+
+  it(`should fallback to ${HttpStatusCode.InternalServerError} when axios throws without an HTTP response`, async () => {
+    // Arrange
+    const mockError = new Error('Mock network error');
+
+    const expectedResponseBody = { message: `No response received from APIM TFS GIFT - get facility ${mockFacilityId} endpoint` };
+
+    jest.mocked(axios).mockRejectedValueOnce(mockError);
+
+    // Act
+    mockRequest.params = {
+      facilityId: mockFacilityId,
+    };
+
+    await get(mockRequest, mockResponse);
+
+    // Assert
+    expect(console.error).toHaveBeenNthCalledWith(
+      1,
+      'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
+      mockFacilityId,
+      HttpStatusCode.InternalServerError,
+      expectedResponseBody,
+      mockError,
+    );
+
+    expect(mockResponse._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+  });
+
+  it(`should forward non-${HttpStatusCode.Ok} and non-${HttpStatusCode.NotFound} status when APIM TFS GIFT facility returns an HTTP error response`, async () => {
+    // Arrange
+    const mockAxiosError = {
+      response: {
+        status: HttpStatusCode.BadGateway,
+        data: {
+          status: HttpStatusCode.BadGateway,
+          message: 'Mock upstream error',
+          errors: [{ code: 'UPSTREAM_FAILURE' }],
+        },
+      },
+    };
+
+    jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
+
+    // Act
+    mockRequest.params = {
+      facilityId: mockFacilityId,
+    };
+
+    await get(mockRequest, mockResponse);
+
+    // Assert
+    expect(console.error).toHaveBeenNthCalledWith(
+      1,
+      'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
+      mockFacilityId,
+      mockAxiosError.response.status,
+      mockAxiosError.response.data,
+      mockAxiosError,
+    );
+
+    expect(mockResponse._getStatusCode()).toBe(mockAxiosError.response.status);
+  });
+});
+
 describe('create', () => {
+  // Arrange
+  const mockTfsResponse = {
+    data: {},
+    status: HttpStatusCode.Created,
+  };
+
   beforeEach(() => {
     ({ req: mockRequest, res: mockResponse } = httpMocks.createMocks());
 
@@ -62,7 +163,7 @@ describe('create', () => {
     // Arrange
     const mockError = new Error('Mock network error');
     const mockFacilityId = 'mock-facility-id';
-    const expectedResponseBody = { message: 'No response received from APIM TFS GIFT facility endpoint' };
+    const expectedResponseBody = { message: 'No response received from APIM TFS GIFT - create facility endpoint' };
 
     jest.mocked(axios).mockRejectedValueOnce(mockError);
 
@@ -78,7 +179,7 @@ describe('create', () => {
     // Assert
     expect(console.error).toHaveBeenNthCalledWith(
       1,
-      'Error calling APIM TFS GIFT facility endpoint - facilityId %s status %s responseBody %o error %o',
+      'Error calling APIM TFS GIFT - create facility endpoint - facilityId %s status %s responseBody %o error %o',
       mockFacilityId,
       HttpStatusCode.InternalServerError,
       expectedResponseBody,
@@ -96,7 +197,7 @@ describe('create', () => {
         status: HttpStatusCode.BadGateway,
         data: {
           status: HttpStatusCode.BadGateway,
-          message: 'TFS upstream error',
+          message: 'Mock upstream error',
           errors: [{ code: 'UPSTREAM_FAILURE' }],
         },
       },
@@ -116,7 +217,7 @@ describe('create', () => {
     // Assert
     expect(console.error).toHaveBeenNthCalledWith(
       1,
-      'Error calling APIM TFS GIFT facility endpoint - facilityId %s status %s responseBody %o error %o',
+      'Error calling APIM TFS GIFT - create facility endpoint - facilityId %s status %s responseBody %o error %o',
       mockFacilityId,
       mockAxiosError.response.status,
       mockAxiosError.response.data,

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -264,12 +264,16 @@ describe('create', () => {
     jest.resetAllMocks();
   });
 
-  it(`should return ${HttpStatusCode.Created} without response data`, async () => {
+  it(`should return ${HttpStatusCode.Created} with response data`, async () => {
     // Arrange
     const requestBody = { test: true };
+    const responseData = { facilityId: 'FACILITY-001' };
     mockRequest.body = requestBody;
 
-    jest.mocked(axios).mockResolvedValueOnce(mockTfsResponse);
+    jest.mocked(axios).mockResolvedValueOnce({
+      ...mockTfsResponse,
+      data: responseData,
+    });
 
     // Act
     await create(mockRequest, mockResponse);
@@ -285,6 +289,7 @@ describe('create', () => {
     });
 
     expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Created);
+    expect(mockResponse._getData()).toEqual(responseData);
   });
 
   it('should fallback to 500 when axios throws without an HTTP response', async () => {

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv';
 import { HEADERS } from '@ukef/dtfs2-common';
 import { Request, Response } from 'express';
 import httpMocks, { MockRequest, MockResponse } from 'node-mocks-http';
-import { create, get } from './gift-facility.controller';
+import { create, get, getMany } from './gift-facility.controller';
 
 dotenv.config();
 
@@ -51,7 +51,7 @@ describe('get', () => {
       headers,
     });
 
-    expect(mockResponse._getStatusCode()).toBe(HttpStatusCode.Ok);
+    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Ok);
   });
 
   it(`should fallback to ${HttpStatusCode.InternalServerError} when axios throws without an HTTP response`, async () => {
@@ -79,7 +79,7 @@ describe('get', () => {
       mockError,
     );
 
-    expect(mockResponse._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
   });
 
   it(`should forward non-${HttpStatusCode.Ok} and non-${HttpStatusCode.NotFound} status when APIM TFS GIFT facility returns an HTTP error response`, async () => {
@@ -114,7 +114,120 @@ describe('get', () => {
       mockAxiosError,
     );
 
-    expect(mockResponse._getStatusCode()).toBe(mockAxiosError.response.status);
+    expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
+  });
+});
+
+describe('getMany', () => {
+  beforeEach(() => {
+    ({ req: mockRequest, res: mockResponse } = httpMocks.createMocks());
+
+    console.info = jest.fn();
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it(`should return ${HttpStatusCode.BadRequest} when ids query parameter is missing`, async () => {
+    // Act
+    await getMany(mockRequest, mockResponse);
+
+    // Assert
+    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(mockResponse._getData()).toEqual({ status: HttpStatusCode.BadRequest, message: 'ids query parameter is required' });
+    expect(axios).toHaveBeenCalledTimes(0);
+  });
+
+  it(`should return ${HttpStatusCode.Ok} and response data when APIM TFS returns success`, async () => {
+    // Arrange
+    const facilityIds = ['FACILITY-001', 'FACILITY-002'];
+    const ids = facilityIds.join(',');
+    const mockResponseData = {
+      facilities: [
+        { facilityId: facilityIds[0], status: HttpStatusCode.Ok },
+        { facilityId: facilityIds[1], status: HttpStatusCode.NotFound },
+      ],
+    };
+
+    mockRequest.query = { ids };
+
+    jest.mocked(axios).mockResolvedValueOnce({ status: HttpStatusCode.Ok, data: mockResponseData });
+
+    // Act
+    await getMany(mockRequest, mockResponse);
+
+    // Assert
+    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    expect(mockResponse._getData()).toEqual(mockResponseData);
+
+    expect(axios).toHaveBeenCalledTimes(1);
+    expect(axios).toHaveBeenCalledWith({
+      method: 'GET',
+      url: `${APIM_TFS_URL}v2/gift/facilities?ids=${ids}`,
+      headers,
+    });
+  });
+
+  it(`should fallback to ${HttpStatusCode.InternalServerError} when APIM TFS throws without an HTTP response`, async () => {
+    // Arrange
+    const facilityIds = ['FACILITY-001'];
+    const ids = facilityIds.join(',');
+    mockRequest.query = { ids };
+
+    const mockError = new Error('Mock network error');
+    jest.mocked(axios).mockRejectedValueOnce(mockError);
+
+    // Act
+    await getMany(mockRequest, mockResponse);
+
+    // Assert
+    expect(console.error).toHaveBeenNthCalledWith(
+      1,
+      'Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o',
+      ids,
+      HttpStatusCode.InternalServerError,
+      { message: `No response received from APIM TFS GIFT - get facilities endpoint ids=${ids}` },
+      mockError,
+    );
+
+    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+  });
+
+  it(`should forward non-${HttpStatusCode.Ok} status when APIM TFS get facilities returns an HTTP error response`, async () => {
+    // Arrange
+    const facilityIds = ['FACILITY-001', 'FACILITY-002'];
+    const ids = facilityIds.join(',');
+    mockRequest.query = { ids };
+
+    const mockAxiosError = {
+      response: {
+        status: HttpStatusCode.BadGateway,
+        data: {
+          status: HttpStatusCode.BadGateway,
+          message: 'Mock upstream error',
+          errors: [{ code: 'UPSTREAM_FAILURE' }],
+        },
+      },
+    };
+
+    jest.mocked(axios).mockRejectedValueOnce(mockAxiosError);
+
+    // Act
+    await getMany(mockRequest, mockResponse);
+
+    // Assert
+    expect(console.error).toHaveBeenNthCalledWith(
+      1,
+      'Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o',
+      ids,
+      mockAxiosError.response.status,
+      mockAxiosError.response.data,
+      mockAxiosError,
+    );
+
+    expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
   });
 });
 
@@ -156,7 +269,7 @@ describe('create', () => {
       data: requestBody,
     });
 
-    expect(mockResponse._getStatusCode()).toBe(HttpStatusCode.Created);
+    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.Created);
   });
 
   it('should fallback to 500 when axios throws without an HTTP response', async () => {
@@ -186,7 +299,7 @@ describe('create', () => {
       mockError,
     );
 
-    expect(mockResponse._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+    expect(mockResponse._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
   });
 
   it(`should forward non-${HttpStatusCode.Created} status when APIM TFS GIFT facility returns an HTTP error response`, async () => {
@@ -224,6 +337,6 @@ describe('create', () => {
       mockAxiosError,
     );
 
-    expect(mockResponse._getStatusCode()).toBe(mockAxiosError.response.status);
+    expect(mockResponse._getStatusCode()).toEqual(mockAxiosError.response.status);
   });
 });

--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -176,8 +176,9 @@ describe('getMany', () => {
   describe('when APIM TFS returns success', () => {
     it(`should return ${HttpStatusCode.Ok} and response data`, async () => {
       // Arrange
-      const facilityIds = ['FACILITY-001', 'FACILITY-002'];
+      const facilityIds = ['0000000001', '0000000002'];
       const ids = facilityIds.join(',');
+
       const mockResponseData = {
         facilities: [
           { facilityId: facilityIds[0], status: HttpStatusCode.Ok },
@@ -207,7 +208,7 @@ describe('getMany', () => {
   describe('when APIM TFS throws without an HTTP response', () => {
     it(`should fallback to ${HttpStatusCode.InternalServerError}`, async () => {
       // Arrange
-      const facilityIds = ['FACILITY-001'];
+      const facilityIds = ['0000000001'];
       const ids = facilityIds.join(',');
       mockRequest.query = { ids };
 
@@ -243,7 +244,7 @@ describe('getMany', () => {
   describe('when APIM TFS get facilities returns an HTTP error response', () => {
     it(`should forward non-${HttpStatusCode.Ok} status`, async () => {
       // Arrange
-      const facilityIds = ['FACILITY-001', 'FACILITY-002'];
+      const facilityIds = ['0000000001', '0000000002'];
       const ids = facilityIds.join(',');
       mockRequest.query = { ids };
 
@@ -299,7 +300,7 @@ describe('create', () => {
   it(`should return ${HttpStatusCode.Created} with response data`, async () => {
     // Arrange
     const requestBody = { test: true };
-    const responseData = { facilityId: 'FACILITY-001' };
+    const responseData = { facilityId: '0000000001' };
     mockRequest.body = requestBody;
 
     jest.mocked(axios).mockResolvedValueOnce({

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -83,7 +83,9 @@ export const get = async (req: Request, res: Response) => {
 
     console.info('✅ Successfully obtained GIFT facility %s', facilityId);
 
-    return res.sendStatus(status);
+    const responseData = 'data' in response ? response.data : undefined;
+
+    return res.status(status).send(responseData);
   } catch (error: any) {
     console.error('Error calling APIM TFS GIFT - get facility %s endpoint %o', facilityId, error);
 
@@ -106,7 +108,7 @@ export const get = async (req: Request, res: Response) => {
  * @returns response with HTTP status `code` and per-facility statuses
  */
 export const getMany = async (req: Request, res: Response) => {
-  const facilityIdsQuery = req.query?.ids ?? req.query?.facilityIds;
+  const facilityIdsQuery = req.query?.ids;
 
   const facilityIds = String(facilityIdsQuery ?? '')
     .split(',')
@@ -192,7 +194,9 @@ export const create = async (req: Request, res: Response) => {
 
     console.info('✅ Successfully created GIFT facility');
 
-    return res.sendStatus(status);
+    const responseData = 'data' in response ? response.data : undefined;
+
+    return res.status(status).send(responseData);
   } catch (error: any) {
     console.error('Error calling APIM TFS GIFT - create facility endpoint %o', error);
 

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -99,6 +99,56 @@ export const get = async (req: Request, res: Response) => {
 };
 
 /**
+ * Get multiple GIFT facilities.
+ * @param req request object
+ * @param res response object
+ * @returns response with HTTP status `code` and per-facility statuses
+ */
+export const getMany = async (req: Request, res: Response) => {
+  const facilityIdsQuery = req.query?.ids ?? req.query?.facilityIds;
+
+  const facilityIds = String(facilityIdsQuery ?? '')
+    .split(',')
+    .map((facilityId) => facilityId.trim())
+    .filter(Boolean);
+
+  if (!facilityIds.length) {
+    return res.status(HttpStatusCode.BadRequest).send({ status: HttpStatusCode.BadRequest, message: 'ids query parameter is required' });
+  }
+
+  const ids = facilityIds.join(',');
+
+  console.info('⚡️ Invoking APIM TFS GIFT - get multiple facilities endpoint - ids %s', ids);
+
+  const url = `${APIM_TFS_URL}v2/gift/facilities?ids=${ids}`;
+
+  const response = await axios({
+    method: 'GET',
+    url,
+    headers,
+  }).catch((error: any) => {
+    const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
+    const responseBody = error?.response?.data ?? { message: `No response received from APIM TFS GIFT - get facilities endpoint - ids=${ids}` };
+
+    console.error('Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o', ids, status, responseBody, error);
+
+    return {
+      status,
+    };
+  });
+
+  const { status } = response;
+
+  if (status !== HttpStatusCode.Ok) {
+    return res.sendStatus(status);
+  }
+
+  const responseData = 'data' in response ? response.data : {};
+
+  return res.status(HttpStatusCode.Ok).send(responseData);
+};
+
+/**
  * Create a GIFT facility.
  * @param req request object
  * @param res response object

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -59,7 +59,8 @@ export const get = async (req: Request, res: Response) => {
       headers,
     }).catch((error: any) => {
       const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
-      const responseBody = error?.response?.data ?? { message: `No response received from APIM TFS GIFT - get facility ${facilityId} endpoint` };
+
+      const responseBody = error?.response?.data;
 
       console.error(
         'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
@@ -128,7 +129,7 @@ export const getMany = async (req: Request, res: Response) => {
     headers,
   }).catch((error: any) => {
     const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
-    const responseBody = error?.response?.data ?? { message: `No response received from APIM TFS GIFT - get facilities endpoint - ids=${ids}` };
+    const responseBody = error?.response?.data;
 
     console.error('Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o', ids, status, responseBody, error);
 

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -137,6 +137,7 @@ export const getMany = async (req: Request, res: Response) => {
 
     return {
       status,
+      data: responseBody,
     };
   });
 

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -140,15 +140,9 @@ export const getMany = async (req: Request, res: Response) => {
     };
   });
 
-  const { status } = response;
-
-  if (status !== HttpStatusCode.Ok) {
-    return res.sendStatus(status);
-  }
-
   const responseData = 'data' in response ? response.data : {};
 
-  return res.status(HttpStatusCode.Ok).send(responseData);
+  return res.status(response.status).send(responseData);
 };
 
 /**

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -33,9 +33,69 @@ import { HEADERS } from '@ukef/dtfs2-common';
 dotenv.config();
 
 const { APIM_TFS_VALUE, APIM_TFS_KEY, APIM_TFS_URL } = process.env;
+
 const headers = {
   [HEADERS.CONTENT_TYPE.KEY]: HEADERS.CONTENT_TYPE.VALUES.JSON,
   [String(APIM_TFS_KEY)]: APIM_TFS_VALUE,
+};
+
+/**
+ * Get a GIFT facility.
+ * @param req request object
+ * @param res response object
+ * @returns response with HTTP status `code` and `data`
+ */
+export const get = async (req: Request, res: Response) => {
+  const { facilityId } = req.params;
+
+  console.info('⚡️ Invoking APIM TFS GIFT - get facility %s endpoint', facilityId);
+
+  try {
+    const url = `${APIM_TFS_URL}v2/gift/facility/${facilityId}`;
+
+    const response = await axios({
+      method: 'GET',
+      url,
+      headers,
+    }).catch((error: any) => {
+      const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
+      const responseBody = error?.response?.data ?? { message: `No response received from APIM TFS GIFT - get facility ${facilityId} endpoint` };
+
+      console.error(
+        'Error calling APIM TFS GIFT - get facility endpoint - facilityId %s status %s responseBody %o error %o',
+        facilityId,
+        status,
+        responseBody,
+        error,
+      );
+
+      return {
+        status,
+      };
+    });
+
+    const { status } = response;
+
+    if (status !== HttpStatusCode.Ok && status !== HttpStatusCode.NotFound) {
+      return res.sendStatus(status);
+    }
+
+    console.info('✅ Successfully obtained GIFT facility %s', facilityId);
+
+    return res.sendStatus(status);
+  } catch (error: any) {
+    console.error('Error calling APIM TFS GIFT - get facility %s endpoint %o', facilityId, error);
+
+    if (error?.response?.status) {
+      return res.sendStatus(error.response.status);
+    }
+
+    console.error('🚩 Error occurred during APIM TFS GIFT - get facility %s endpoint call %o', facilityId, error);
+
+    return res
+      .status(HttpStatusCode.InternalServerError)
+      .send({ status: HttpStatusCode.InternalServerError, message: `Error occurred during APIM TFS GIFT - get facility ${facilityId} endpoint call` });
+  }
 };
 
 /**
@@ -46,7 +106,7 @@ const headers = {
  */
 export const create = async (req: Request, res: Response) => {
   try {
-    console.info('⚡️ Invoking APIM TFS GIFT facility endpoint');
+    console.info('⚡️ Invoking APIM TFS GIFT - create facility endpoint');
 
     const url = `${APIM_TFS_URL}v2/gift/facility`;
     const facilityId = req.body?.overview?.facilityId;
@@ -58,10 +118,10 @@ export const create = async (req: Request, res: Response) => {
       data: req.body,
     }).catch((error: any) => {
       const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
-      const responseBody = error?.response?.data ?? { message: 'No response received from APIM TFS GIFT facility endpoint' };
+      const responseBody = error?.response?.data ?? { message: 'No response received from APIM TFS GIFT - create facility endpoint' };
 
       console.error(
-        'Error calling APIM TFS GIFT facility endpoint - facilityId %s status %s responseBody %o error %o',
+        'Error calling APIM TFS GIFT - create facility endpoint - facilityId %s status %s responseBody %o error %o',
         facilityId,
         status,
         responseBody,
@@ -83,16 +143,16 @@ export const create = async (req: Request, res: Response) => {
 
     return res.sendStatus(status);
   } catch (error: any) {
-    console.error('Error calling APIM TFS GIFT facility endpoint %o', error);
+    console.error('Error calling APIM TFS GIFT - create facility endpoint %o', error);
 
     if (error?.response?.status) {
       return res.sendStatus(error.response.status);
     }
 
-    console.error('🚩 Error occurred during GIFT facility endpoint call %o', error);
+    console.error('🚩 Error occurred during APIM TFS GIFT - create facility endpoint call %o', error);
 
     return res
       .status(HttpStatusCode.InternalServerError)
-      .send({ status: HttpStatusCode.InternalServerError, message: 'Error occurred during GIFT facility endpoint call' });
+      .send({ status: HttpStatusCode.InternalServerError, message: 'Error occurred during APIM TFS GIFT - create facility endpoint call' });
   }
 };

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -108,42 +108,56 @@ export const get = async (req: Request, res: Response) => {
  * @returns response with HTTP status `code` and per-facility statuses
  */
 export const getMany = async (req: Request, res: Response) => {
-  const facilityIdsQuery = req.query?.ids;
+  try {
+    const facilityIdsQuery = req.query?.ids;
 
-  const facilityIds = String(facilityIdsQuery ?? '')
-    .split(',')
-    .map((facilityId) => facilityId.trim())
-    .filter(Boolean);
+    const facilityIds = String(facilityIdsQuery ?? '')
+      .split(',')
+      .map((facilityId) => facilityId.trim())
+      .filter(Boolean);
 
-  if (!facilityIds.length) {
-    return res.status(HttpStatusCode.BadRequest).send({ status: HttpStatusCode.BadRequest, message: 'ids query parameter is required' });
+    const ids = facilityIds.join(',');
+
+    console.info('⚡️ Invoking APIM TFS GIFT - get multiple facilities endpoint - ids %s', ids);
+
+    if (!facilityIds.length) {
+      return res.status(HttpStatusCode.BadRequest).send({ status: HttpStatusCode.BadRequest, message: 'ids query parameter is required' });
+    }
+
+    const url = `${APIM_TFS_URL}v2/gift/facilities?ids=${ids}`;
+
+    const response = await axios({
+      method: 'GET',
+      url,
+      headers,
+    }).catch((error: any) => {
+      const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
+      const responseBody = error?.response?.data;
+
+      console.error('Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o', ids, status, responseBody, error);
+
+      return {
+        status,
+        data: responseBody,
+      };
+    });
+
+    const responseData = 'data' in response ? response.data : {};
+
+    return res.status(response.status).send(responseData);
+  } catch (error: any) {
+    console.error('Error calling APIM TFS GIFT - get facilities endpoint %o', error);
+
+    if (error?.response?.status) {
+      return res.sendStatus(error.response.status);
+    }
+
+    console.error('🚩 Error occurred during APIM TFS GIFT - get facilities endpoint call %o', error);
+
+    return res
+      .status(HttpStatusCode.InternalServerError)
+      .send({ status: HttpStatusCode.InternalServerError, message: 'Error occurred during APIM TFS GIFT - get facilities endpoint call' });
   }
-
-  const ids = facilityIds.join(',');
-
-  console.info('⚡️ Invoking APIM TFS GIFT - get multiple facilities endpoint - ids %s', ids);
-
-  const url = `${APIM_TFS_URL}v2/gift/facilities?ids=${ids}`;
-
-  const response = await axios({
-    method: 'GET',
-    url,
-    headers,
-  }).catch((error: any) => {
-    const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
-    const responseBody = error?.response?.data;
-
-    console.error('Error calling APIM TFS GIFT - get facilities endpoint - ids %s status %s responseBody %o error %o', ids, status, responseBody, error);
-
-    return {
-      status,
-      data: responseBody,
-    };
-  });
-
-  const responseData = 'data' in response ? response.data : {};
-
-  return res.status(response.status).send(responseData);
 };
 
 /**

--- a/external-api/server/v1/routes/external-apis.route.ts
+++ b/external-api/server/v1/routes/external-apis.route.ts
@@ -759,10 +759,41 @@ apiRoutes.get('/bank-holidays', bankHolidays.getBankHolidays);
 
 /**
  * @openapi
+ * /gift/facility/:facilityId:
+ *   get:
+ *     summary: Get a GIFT facility from APIM TFS's GIFT endpoint
+ *     tags: [APIM, GIFT Facility]
+ *     description: >-
+ *       Get a GIFT facility from APIM TFS's GIFT endpoint by facility ID.
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The GIFT facility ID.
+ *     responses:
+ *       200:
+ *         description: OK
+ *       400:
+ *         description: Bad request
+ *       401:
+ *         description: Unauthorised
+ *       404:
+ *         description: Not found
+ *       429:
+ *         description: Too many requests
+ *       500:
+ *         description: Internal server error
+ */
+apiRoutes.get('/gift/facility/:facilityId', giftFacility.get);
+
+/**
+ * @openapi
  * /gift/facility:
  *   post:
  *     summary: Send a facility to APIM TFS's GIFT endpoint
- *     tags: [APIM, Gift Facility]
+ *     tags: [APIM, GIFT Facility]
  *     description: >-
  *       Send a facility to APIM TFS's GIFT endpoint.
  *     responses:

--- a/external-api/server/v1/routes/external-apis.route.ts
+++ b/external-api/server/v1/routes/external-apis.route.ts
@@ -765,6 +765,7 @@ apiRoutes.get('/bank-holidays', bankHolidays.getBankHolidays);
  *     tags: [APIM, GIFT Facility]
  *     description: >-
  *       Get multiple GIFT facilities from APIM TFS's GIFT endpoint by a comma-separated list of facility IDs.
+ *       Example endpoint: /gift/facilities?ids=0000000001,0000000002
  *     parameters:
  *       - in: query
  *         name: ids
@@ -797,17 +798,19 @@ apiRoutes.get('/gift/facilities', giftFacility.getMany);
 
 /**
  * @openapi
- * /gift/facility/:facilityId:
+ * /gift/facility/{facilityId}:
  *   get:
  *     summary: Get a GIFT facility from APIM TFS's GIFT endpoint
  *     tags: [APIM, GIFT Facility]
  *     description: >-
  *       Get a GIFT facility from APIM TFS's GIFT endpoint by facility ID.
+ *       Example endpoint: /gift/facility/0000000001
  *     parameters:
  *       - in: path
  *         name: facilityId
  *         schema:
  *           type: string
+ *           example: 0000000001
  *         required: true
  *         description: The GIFT facility ID.
  *     responses:

--- a/external-api/server/v1/routes/external-apis.route.ts
+++ b/external-api/server/v1/routes/external-apis.route.ts
@@ -770,7 +770,7 @@ apiRoutes.get('/bank-holidays', bankHolidays.getBankHolidays);
  *         name: ids
  *         schema:
  *           type: string
- *           example: FACILITY-001,FACILITY-002
+ *           example: 0000000001,0000000002
  *         required: true
  *         description: Comma-separated GIFT facility IDs.
  *     responses:

--- a/external-api/server/v1/routes/external-apis.route.ts
+++ b/external-api/server/v1/routes/external-apis.route.ts
@@ -759,6 +759,44 @@ apiRoutes.get('/bank-holidays', bankHolidays.getBankHolidays);
 
 /**
  * @openapi
+ * /gift/facilities:
+ *   get:
+ *     summary: Get multiple GIFT facilities from APIM TFS's GIFT endpoint
+ *     tags: [APIM, GIFT Facility]
+ *     description: >-
+ *       Get multiple GIFT facilities from APIM TFS's GIFT endpoint by a comma-separated list of facility IDs.
+ *     parameters:
+ *       - in: query
+ *         name: ids
+ *         schema:
+ *           type: string
+ *           example: FACILITY-001,FACILITY-002
+ *         required: true
+ *         description: Comma-separated GIFT facility IDs.
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/definitions/GiftFacilitiesBulkResponse'
+ *       400:
+ *         description: Bad request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/definitions/GiftFacilityErrorResponse'
+ *       401:
+ *         description: Unauthorised
+ *       429:
+ *         description: Too many requests
+ *       500:
+ *         description: Internal server error
+ */
+apiRoutes.get('/gift/facilities', giftFacility.getMany);
+
+/**
+ * @openapi
  * /gift/facility/:facilityId:
  *   get:
  *     summary: Get a GIFT facility from APIM TFS's GIFT endpoint
@@ -785,6 +823,10 @@ apiRoutes.get('/bank-holidays', bankHolidays.getBankHolidays);
  *         description: Too many requests
  *       500:
  *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/definitions/GiftFacilityErrorResponse'
  */
 apiRoutes.get('/gift/facility/:facilityId', giftFacility.get);
 

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -372,7 +372,7 @@ describe('/v1/deals', () => {
         hasBeenIssued: true,
       };
 
-      describe('when all issued facilities are not in GIFT', async () => {
+      describe('when all issued facilities are not in GIFT', () => {
         it('should call submitFacilitiesToApimGift with all issued facilities', async () => {
           canSubmitToApimGift.mockResolvedValueOnce({
             canSubmitFacilitiesToApimGift: true,
@@ -392,7 +392,7 @@ describe('/v1/deals', () => {
         });
       });
 
-      describe('when there are no issued facilities to send to GIFT', async () => {
+      describe('when there are no issued facilities to send to GIFT', () => {
         it('should not call submitFacilitiesToApimGift', async () => {
           canSubmitToApimGift.mockResolvedValueOnce({
             canSubmitFacilitiesToApimGift: false,
@@ -406,7 +406,7 @@ describe('/v1/deals', () => {
         });
       });
 
-      describe('when some issued facilities are in GIFT, some are not', async () => {
+      describe('when some issued facilities are in GIFT, some are not', () => {
         it('should call submitFacilitiesToApimGift with the issued facilities that are not in GIFT', async () => {
           canSubmitToApimGift.mockResolvedValueOnce({
             canSubmitFacilitiesToApimGift: true,

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -24,6 +24,7 @@ const MOCK_GEF_DEAL_AIN = require('../../../server/v1/__mocks__/mock-gef-deal');
 const MOCK_GEF_DEAL_MIA = require('../../../server/v1/__mocks__/mock-gef-deal-MIA');
 const MOCK_GEF_DEAL_MIN = require('../../../server/v1/__mocks__/mock-gef-deal-MIN');
 const { MOCK_PORTAL_USERS } = require('../../../server/v1/__mocks__/mock-portal-users');
+const { MOCK_FACILITIES } = require('../../../server/v1/__mocks__/mock-facilities');
 
 const sendEmailApiSpy = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_RESPONSE));
 
@@ -359,6 +360,70 @@ describe('/v1/deals', () => {
       expect(submitFacilitiesToApimGift).toHaveBeenNthCalledWith(1, {
         deal: submittedDeal,
         facilities: mockIssuedFacilities,
+      });
+    });
+
+    describe('submitFacilitiesToApimGift only called with facilities not already in GIFT', () => {
+      const facility1 = { ...MOCK_FACILITIES[0], facilitySnapshot: { ...MOCK_FACILITIES[0], ukefFacilityId: 'FACILITY_A' }, hasBeenIssued: true };
+      const facility2 = { ...MOCK_FACILITIES[1], facilitySnapshot: { ...MOCK_FACILITIES[1], ukefFacilityId: 'FACILITY_B' }, hasBeenIssued: true };
+      const facility3 = {
+        ...(MOCK_FACILITIES[2] || MOCK_FACILITIES[0]),
+        facilitySnapshot: { ...(MOCK_FACILITIES[2] || MOCK_FACILITIES[0]), ukefFacilityId: 'FACILITY_C' },
+        hasBeenIssued: true,
+      };
+
+      describe('when all issued facilities are not in GIFT', async () => {
+        it('should call submitFacilitiesToApimGift with all issued facilities', async () => {
+          canSubmitToApimGift.mockResolvedValueOnce({
+            canSubmitFacilitiesToApimGift: true,
+            issuedFacilities: [facility1, facility2],
+            isBssEwcsDeal: true,
+            isGefDeal: false,
+          });
+
+          await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
+          const submittedDeal = canSubmitToApimGift.mock.calls[0][0];
+          expect(submitFacilitiesToApimGift).toHaveBeenNthCalledWith(1, {
+            deal: submittedDeal,
+            facilities: [facility1, facility2],
+            isBssEwcsDeal: true,
+            isGefDeal: false,
+          });
+        });
+      });
+
+      describe('when there are no issued facilities to send to GIFT', async () => {
+        it('should not call submitFacilitiesToApimGift', async () => {
+          canSubmitToApimGift.mockResolvedValueOnce({
+            canSubmitFacilitiesToApimGift: false,
+            issuedFacilities: [], // no facilities to send
+            isBssEwcsDeal: true,
+            isGefDeal: false,
+          });
+
+          await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
+          expect(submitFacilitiesToApimGift).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when some issued facilities are in GIFT, some are not', async () => {
+        it('should call submitFacilitiesToApimGift with the issued facilities that are not in GIFT', async () => {
+          canSubmitToApimGift.mockResolvedValueOnce({
+            canSubmitFacilitiesToApimGift: true,
+            issuedFacilities: [facility2, facility3], // only facility 2 and 3 are not in GIFT
+            isBssEwcsDeal: true,
+            isGefDeal: false,
+          });
+
+          await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
+          const submittedDeal = canSubmitToApimGift.mock.calls[0][0];
+          expect(submitFacilitiesToApimGift).toHaveBeenNthCalledWith(1, {
+            deal: submittedDeal,
+            facilities: [facility2, facility3],
+            isBssEwcsDeal: true,
+            isGefDeal: false,
+          });
+        });
       });
     });
   });

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -364,19 +364,36 @@ describe('/v1/deals', () => {
     });
 
     describe('submitFacilitiesToApimGift only called with facilities not already in GIFT', () => {
-      const facility1 = { ...MOCK_FACILITIES[0], facilitySnapshot: { ...MOCK_FACILITIES[0], ukefFacilityId: 'FACILITY_A' }, hasBeenIssued: true };
-      const facility2 = { ...MOCK_FACILITIES[1], facilitySnapshot: { ...MOCK_FACILITIES[1], ukefFacilityId: 'FACILITY_B' }, hasBeenIssued: true };
-      const facility3 = {
-        ...(MOCK_FACILITIES[2] || MOCK_FACILITIES[0]),
-        facilitySnapshot: { ...(MOCK_FACILITIES[2] || MOCK_FACILITIES[0]), ukefFacilityId: 'FACILITY_C' },
-        hasBeenIssued: true,
+      const mockFacility1 = {
+        ...MOCK_FACILITIES[0],
+        facilitySnapshot: {
+          ...MOCK_FACILITIES[0].facilitySnapshot,
+          ukefFacilityId: 'FACILITY_A',
+        },
+      };
+
+      const mockFacility2 = {
+        ...MOCK_FACILITIES[1],
+        facilitySnapshot: {
+          ...MOCK_FACILITIES[1].facilitySnapshot,
+          ukefFacilityId: 'FACILITY_B',
+        },
+      };
+
+      const mockFacility3 = {
+        ...MOCK_FACILITIES[2],
+        facilitySnapshot: {
+          ...MOCK_FACILITIES[2].facilitySnapshot,
+          _id: 'mock-facility-3',
+          ukefFacilityId: 'FACILITY_C',
+        },
       };
 
       describe('when all issued facilities are not in GIFT', () => {
         it('should call submitFacilitiesToApimGift with all issued facilities', async () => {
           canSubmitToApimGift.mockResolvedValueOnce({
             canSubmitFacilitiesToApimGift: true,
-            issuedFacilities: [facility1, facility2],
+            issuedFacilities: [mockFacility1, mockFacility2],
             isBssEwcsDeal: true,
             isGefDeal: false,
           });
@@ -385,7 +402,7 @@ describe('/v1/deals', () => {
           const submittedDeal = canSubmitToApimGift.mock.calls[0][0];
           expect(submitFacilitiesToApimGift).toHaveBeenNthCalledWith(1, {
             deal: submittedDeal,
-            facilities: [facility1, facility2],
+            facilities: [mockFacility1, mockFacility2],
             isBssEwcsDeal: true,
             isGefDeal: false,
           });
@@ -410,7 +427,7 @@ describe('/v1/deals', () => {
         it('should call submitFacilitiesToApimGift with the issued facilities that are not in GIFT', async () => {
           canSubmitToApimGift.mockResolvedValueOnce({
             canSubmitFacilitiesToApimGift: true,
-            issuedFacilities: [facility2, facility3], // only facility 2 and 3 are not in GIFT
+            issuedFacilities: [mockFacility2, mockFacility3], // only facility 2 and 3 are not in GIFT
             isBssEwcsDeal: true,
             isGefDeal: false,
           });
@@ -419,7 +436,7 @@ describe('/v1/deals', () => {
           const submittedDeal = canSubmitToApimGift.mock.calls[0][0];
           expect(submitFacilitiesToApimGift).toHaveBeenNthCalledWith(1, {
             deal: submittedDeal,
-            facilities: [facility2, facility3],
+            facilities: [mockFacility2, mockFacility3],
             isBssEwcsDeal: true,
             isGefDeal: false,
           });

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -1981,14 +1981,14 @@ const createGiftFacility = async (facilityData) => {
 
 /**
  * Find GIFT facilities by their IDs.
- * @param {string} facilityIds - The IDs of the facilities to find
- * @returns {Promise<object|boolean>} The found facilities if successful, otherwise false
+ * @param {string} facilityIdsQueryString - Comma-separated facility IDs to find.
+ * @returns {Promise<{ facilities: object[] }|false>} The API response payload if successful, otherwise false.
  */
-const findGiftFacilitiesById = async (facilityIds) => {
+const findGiftFacilitiesByIds = async (facilityIdsQueryString) => {
   try {
-    console.info('Calling external API "Get GIFT facilities by ID" endpoint - facilityIds %o', facilityIds);
+    console.info('Calling external API "Get GIFT facilities by ID" endpoint - facilityIds %o', facilityIdsQueryString);
 
-    const queryString = new URLSearchParams({ ids: facilityIds }).toString();
+    const queryString = new URLSearchParams({ ids: facilityIdsQueryString }).toString();
 
     const response = await axios({
       method: 'get',
@@ -2003,7 +2003,7 @@ const findGiftFacilitiesById = async (facilityIds) => {
 
     console.error(
       'Unable to get GIFT facilities from external API - facilityIds %o status %s responseBody %o error %o',
-      facilityIds,
+      facilityIdsQueryString,
       status,
       responseBody,
       error,
@@ -2103,5 +2103,5 @@ module.exports = {
   getRecordCorrectionLogDetailsById,
   getApprovedAmendments,
   createGiftFacility,
-  findGiftFacilitiesById,
+  findGiftFacilitiesByIds,
 };

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -1988,9 +1988,11 @@ const findGiftFacilitiesById = async (facilityIds) => {
   try {
     console.info('Calling external API "Get GIFT facilities by ID" endpoint - facilityIds %o', facilityIds);
 
+    const queryString = new URLSearchParams({ ids: facilityIds }).toString();
+
     const response = await axios({
-      method: 'post',
-      url: `${EXTERNAL_API_URL}/gift/facilities?ids=${facilityIds}`,
+      method: 'get',
+      url: `${EXTERNAL_API_URL}/gift/facilities?${queryString}`,
       headers: headers.external,
     });
 
@@ -2002,7 +2004,6 @@ const findGiftFacilitiesById = async (facilityIds) => {
     console.error(
       'Unable to get GIFT facilities from external API - facilityIds %o status %s responseBody %o error %o',
       facilityIds,
-      status,
       status,
       responseBody,
       error,

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -1964,12 +1964,45 @@ const createGiftFacility = async (facilityData) => {
     return response.data;
   } catch (error) {
     const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
-    const responseBody = error?.response?.data ?? { message: 'No response received from external API GIFT facility endpoint' };
+    const responseBody = error?.response?.data ?? { message: 'No response received from external API GIFT facility creation endpoint' };
 
     console.error(
       'Unable to send GIFT facility to external API - facilityId %s dealId %s status %s responseBody %o error %o',
       facilityId,
       dealId,
+      status,
+      responseBody,
+      error,
+    );
+
+    return false;
+  }
+};
+
+/**
+ * Find GIFT facilities by their IDs.
+ * @param {string} facilityIds - The IDs of the facilities to find
+ * @returns {Promise<object|boolean>} The found facilities if successful, otherwise false
+ */
+const findGiftFacilitiesById = async (facilityIds) => {
+  try {
+    console.info('Calling external API "Get GIFT facilities by ID" endpoint - facilityIds %o', facilityIds);
+
+    const response = await axios({
+      method: 'post',
+      url: `${EXTERNAL_API_URL}/gift/facilities?ids=${facilityIds}`,
+      headers: headers.external,
+    });
+
+    return response.data;
+  } catch (error) {
+    const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
+    const responseBody = error?.response?.data ?? { message: 'No response received from external API GIFT facilities endpoint' };
+
+    console.error(
+      'Unable to get GIFT facilities from external API - facilityIds %o status %s responseBody %o error %o',
+      facilityIds,
+      status,
       status,
       responseBody,
       error,
@@ -2069,4 +2102,5 @@ module.exports = {
   getRecordCorrectionLogDetailsById,
   getApprovedAmendments,
   createGiftFacility,
+  findGiftFacilitiesById,
 };

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -4,7 +4,7 @@ import { canSubmitToApimGift } from '.';
 import * as generateIssuedFacilitiesQueryStringModule from '../generate-issued-facilities-query-string';
 import * as mapFacilitiesToSendToGiftModule from '../map-facilities-to-send-to-gift';
 import { ApiTypes } from '../../../mappings/apim-gift-payloads/types';
-import { mockTfmDeal, mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility } from '../test-mocks';
+import { mockGiftFacility, mockTfmDeal, mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility } from '../test-mocks';
 
 jest.mock('../../../api', () => ({
   __esModule: true,
@@ -112,16 +112,10 @@ describe('canSubmitToApimGift', () => {
 
       it('should call findFacilitiesByDealId', async () => {
         // Arrange
-        const mockIssuedFacility = {
-          _id: '61f7a4edcf809301e78fbe53',
-          facilitySnapshot: {
-            ukefFacilityId: 'FACILITY-001',
-            hasBeenIssued: true,
-          },
-        } as unknown as TfmFacility;
+        const mockIssuedFacility = mockTfmIssuedFacility1;
 
         mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockIssuedFacility]);
-        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001');
+        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(String(mockIssuedFacility.facilitySnapshot.ukefFacilityId));
         mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
         mockMapFacilitiesToSendToGift.mockReturnValueOnce({
           facilitiesToSendToApimGift: [mockIssuedFacility],
@@ -138,7 +132,9 @@ describe('canSubmitToApimGift', () => {
         it('should return canSubmitFacilitiesToApimGift as true', async () => {
           // Arrange
           mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility]);
-          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
+          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(
+            [mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId, mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId].join(','),
+          );
           mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
           mockMapFacilitiesToSendToGift.mockReturnValueOnce({
             facilitiesToSendToApimGift: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
@@ -162,25 +158,17 @@ describe('canSubmitToApimGift', () => {
       describe('when issued facilities already exist in GIFT', () => {
         it('should return canSubmitFacilitiesToApimGift as false', async () => {
           // Arrange
-          const mockIssuedFacility1 = {
-            _id: '61f7a4edcf809301e78fbe53',
-            facilitySnapshot: {
-              ukefFacilityId: 'FACILITY-001',
-              hasBeenIssued: true,
-            },
-          } as unknown as TfmFacility;
-
-          const mockIssuedFacility2 = {
-            _id: '61f7a4edcf809301e78fbe54',
-            facilitySnapshot: {
-              ukefFacilityId: 'FACILITY-002',
-              hasBeenIssued: true,
-            },
-          } as unknown as TfmFacility;
+          const mockIssuedFacility1 = mockTfmIssuedFacility1;
+          const mockIssuedFacility2 = mockTfmIssuedFacility2;
 
           mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockIssuedFacility1, mockIssuedFacility2]);
-          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
-          mockApi.findGiftFacilitiesById.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2]);
+          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(
+            [mockIssuedFacility1.facilitySnapshot.ukefFacilityId, mockIssuedFacility2.facilitySnapshot.ukefFacilityId].join(','),
+          );
+          mockApi.findGiftFacilitiesById.mockResolvedValueOnce([
+            { ...mockGiftFacility, facilityId: String(mockIssuedFacility1.facilitySnapshot.ukefFacilityId) } as unknown as TfmFacility,
+            { ...mockGiftFacility, facilityId: String(mockIssuedFacility2.facilitySnapshot.ukefFacilityId) } as unknown as TfmFacility,
+          ]);
           mockMapFacilitiesToSendToGift.mockReturnValueOnce({
             facilitiesToSendToApimGift: [],
           });
@@ -204,7 +192,9 @@ describe('canSubmitToApimGift', () => {
         it('should return canSubmitFacilitiesToApimGift as false', async () => {
           // Arrange
           mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility]);
-          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
+          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(
+            [mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId, mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId].join(','),
+          );
           mockApi.findGiftFacilitiesById.mockResolvedValueOnce(false);
 
           // Act

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../../api', () => ({
   __esModule: true,
   default: {
     findFacilitiesByDealId: jest.fn(),
-    findGiftFacilitiesById: jest.fn(),
+    findGiftFacilitiesByIds: jest.fn(),
   },
 }));
 
@@ -35,6 +35,7 @@ jest.mock('../map-facilities-to-send-to-gift', () => ({
 
 const mockFeatureFlag = jest.mocked(isTfmApimGiftIntegrationEnabled);
 const mockApi = jest.mocked(apiModule) as jest.Mocked<ApiTypes>;
+const mockFindGiftFacilitiesByIds = mockApi.findGiftFacilitiesByIds as jest.MockedFunction<ApiTypes['findGiftFacilitiesByIds']>;
 const mockGenerateIssuedFacilitiesQueryString = jest.mocked(generateIssuedFacilitiesQueryStringModule.generateIssuedFacilitiesQueryString);
 const mockMapFacilitiesToSendToGift = jest.mocked(mapFacilitiesToSendToGiftModule.mapFacilitiesToSendToGift);
 
@@ -116,7 +117,7 @@ describe('canSubmitToApimGift', () => {
 
         mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockIssuedFacility]);
         mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(String(mockIssuedFacility.facilitySnapshot.ukefFacilityId));
-        mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
+        mockFindGiftFacilitiesByIds.mockResolvedValueOnce({ facilities: [] });
         mockMapFacilitiesToSendToGift.mockReturnValueOnce({
           facilitiesToSendToApimGift: [mockIssuedFacility],
         });
@@ -135,7 +136,7 @@ describe('canSubmitToApimGift', () => {
           mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(
             [mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId, mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId].join(','),
           );
-          mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
+          mockFindGiftFacilitiesByIds.mockResolvedValueOnce({ facilities: [] });
           mockMapFacilitiesToSendToGift.mockReturnValueOnce({
             facilitiesToSendToApimGift: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
           });
@@ -165,10 +166,12 @@ describe('canSubmitToApimGift', () => {
           mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(
             [mockIssuedFacility1.facilitySnapshot.ukefFacilityId, mockIssuedFacility2.facilitySnapshot.ukefFacilityId].join(','),
           );
-          mockApi.findGiftFacilitiesById.mockResolvedValueOnce([
-            { ...mockGiftFacility, facilityId: String(mockIssuedFacility1.facilitySnapshot.ukefFacilityId) } as unknown as TfmFacility,
-            { ...mockGiftFacility, facilityId: String(mockIssuedFacility2.facilitySnapshot.ukefFacilityId) } as unknown as TfmFacility,
-          ]);
+          mockFindGiftFacilitiesByIds.mockResolvedValueOnce({
+            facilities: [
+              { ...mockGiftFacility, facilityId: String(mockIssuedFacility1.facilitySnapshot.ukefFacilityId) } as unknown as TfmFacility,
+              { ...mockGiftFacility, facilityId: String(mockIssuedFacility2.facilitySnapshot.ukefFacilityId) } as unknown as TfmFacility,
+            ],
+          });
           mockMapFacilitiesToSendToGift.mockReturnValueOnce({
             facilitiesToSendToApimGift: [],
           });
@@ -195,7 +198,7 @@ describe('canSubmitToApimGift', () => {
           mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(
             [mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId, mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId].join(','),
           );
-          mockApi.findGiftFacilitiesById.mockResolvedValueOnce(false);
+          mockFindGiftFacilitiesByIds.mockResolvedValueOnce(false);
 
           // Act
           const result = await canSubmitToApimGift(mockDeal);
@@ -325,7 +328,7 @@ describe('canSubmitToApimGift', () => {
         expect(mockGenerateIssuedFacilitiesQueryString).not.toHaveBeenCalled();
       });
 
-      it('should NOT call findGiftFacilitiesById', async () => {
+      it('should NOT call findGiftFacilitiesByIds', async () => {
         // Arrange
         const mockDeal = {
           ...mockTfmDeal,
@@ -343,7 +346,7 @@ describe('canSubmitToApimGift', () => {
         await canSubmitToApimGift(mockDeal);
 
         // Assert
-        expect(mockApi.findGiftFacilitiesById).not.toHaveBeenCalled();
+        expect(mockApi.findGiftFacilitiesByIds).not.toHaveBeenCalled();
       });
 
       it('should NOT call mapFacilitiesToSendToGift', async () => {

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -224,6 +224,9 @@ describe('canSubmitToApimGift', () => {
           // Assert
           const expected = {
             canSubmitFacilitiesToApimGift: false,
+            issuedFacilities: [],
+            isBssEwcsDeal,
+            isGefDeal,
           };
 
           expect(result).toEqual(expected);
@@ -293,6 +296,9 @@ describe('canSubmitToApimGift', () => {
         // Assert
         const expected = {
           canSubmitFacilitiesToApimGift: false,
+          issuedFacilities: [],
+          isBssEwcsDeal: true,
+          isGefDeal: false,
         };
 
         expect(result).toEqual(expected);

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -499,6 +499,33 @@ describe('canSubmitToApimGift', () => {
         // Assert
         expect(mockGenerateIssuedFacilitiesQueryString).not.toHaveBeenCalled();
       });
+
+      it('should log that facilities could not be retrieved from TFM', async () => {
+        // Arrange
+        const mockDeal = {
+          ...mockTfmDeal,
+          dealSnapshot: {
+            ...mockTfmDeal.dealSnapshot,
+            dealType: DEAL_TYPE.BSS_EWCS,
+            submissionType: DEAL_SUBMISSION_TYPE.AIN,
+          },
+          tfm: mockTfmDeal.tfm,
+        } as TfmDeal;
+
+        const mockError = new Error('Mock API error');
+
+        mockApi.findFacilitiesByDealId.mockRejectedValueOnce(mockError);
+        const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+
+        // Act
+        await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        expect(consoleInfoSpy).toHaveBeenCalledWith(
+          'Issued facilities for deal %s cannot be submitted to APIM GIFT - failed to retrieve facilities from TFM',
+          String(mockDeal._id),
+        );
+      });
     });
   });
 });

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -134,66 +134,93 @@ describe('canSubmitToApimGift', () => {
         expect(mockApi.findFacilitiesByDealId).toHaveBeenNthCalledWith(1, mockDeal._id);
       });
 
-      it('should return canSubmitFacilitiesToApimGift as true when there are issued facilities not in GIFT', async () => {
-        // Arrange
-        mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility]);
-        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
-        mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
-        mockMapFacilitiesToSendToGift.mockReturnValueOnce({
-          facilitiesToSendToApimGift: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
+      describe('when issued facilities are not in GIFT', () => {
+        it('should return canSubmitFacilitiesToApimGift as true', async () => {
+          // Arrange
+          mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility]);
+          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
+          mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
+          mockMapFacilitiesToSendToGift.mockReturnValueOnce({
+            facilitiesToSendToApimGift: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
+          });
+
+          // Act
+          const result = await canSubmitToApimGift(mockDeal);
+
+          // Assert
+          const expected = {
+            canSubmitFacilitiesToApimGift: true,
+            issuedFacilities: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
+            isBssEwcsDeal,
+            isGefDeal,
+          };
+
+          expect(result).toEqual(expected);
         });
-
-        // Act
-        const result = await canSubmitToApimGift(mockDeal);
-
-        // Assert
-        const expected = {
-          canSubmitFacilitiesToApimGift: true,
-          issuedFacilities: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
-          isBssEwcsDeal,
-          isGefDeal,
-        };
-
-        expect(result).toEqual(expected);
       });
 
-      it('should return canSubmitFacilitiesToApimGift as false when issued facilities already exist in GIFT', async () => {
-        // Arrange
-        const mockIssuedFacility1 = {
-          _id: '61f7a4edcf809301e78fbe53',
-          facilitySnapshot: {
-            ukefFacilityId: 'FACILITY-001',
-            hasBeenIssued: true,
-          },
-        } as unknown as TfmFacility;
+      describe('when issued facilities already exist in GIFT', () => {
+        it('should return canSubmitFacilitiesToApimGift as false', async () => {
+          // Arrange
+          const mockIssuedFacility1 = {
+            _id: '61f7a4edcf809301e78fbe53',
+            facilitySnapshot: {
+              ukefFacilityId: 'FACILITY-001',
+              hasBeenIssued: true,
+            },
+          } as unknown as TfmFacility;
 
-        const mockIssuedFacility2 = {
-          _id: '61f7a4edcf809301e78fbe54',
-          facilitySnapshot: {
-            ukefFacilityId: 'FACILITY-002',
-            hasBeenIssued: true,
-          },
-        } as unknown as TfmFacility;
+          const mockIssuedFacility2 = {
+            _id: '61f7a4edcf809301e78fbe54',
+            facilitySnapshot: {
+              ukefFacilityId: 'FACILITY-002',
+              hasBeenIssued: true,
+            },
+          } as unknown as TfmFacility;
 
-        mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockIssuedFacility1, mockIssuedFacility2]);
-        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
-        mockApi.findGiftFacilitiesById.mockResolvedValueOnce([{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-002' }]);
-        mockMapFacilitiesToSendToGift.mockReturnValueOnce({
-          facilitiesToSendToApimGift: [],
+          mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockIssuedFacility1, mockIssuedFacility2]);
+          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
+          mockApi.findGiftFacilitiesById.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2]);
+          mockMapFacilitiesToSendToGift.mockReturnValueOnce({
+            facilitiesToSendToApimGift: [],
+          });
+
+          // Act
+          const result = await canSubmitToApimGift(mockDeal);
+
+          // Assert
+          const expected = {
+            canSubmitFacilitiesToApimGift: false,
+            issuedFacilities: [],
+            isBssEwcsDeal,
+            isGefDeal,
+          };
+
+          expect(result).toEqual(expected);
         });
+      });
 
-        // Act
-        const result = await canSubmitToApimGift(mockDeal);
+      describe('when the lookup of existing GIFT facilities fails', () => {
+        it('should return canSubmitFacilitiesToApimGift as false', async () => {
+          // Arrange
+          mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility]);
+          mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
+          mockApi.findGiftFacilitiesById.mockResolvedValueOnce(false);
 
-        // Assert
-        const expected = {
-          canSubmitFacilitiesToApimGift: false,
-          issuedFacilities: [],
-          isBssEwcsDeal,
-          isGefDeal,
-        };
+          // Act
+          const result = await canSubmitToApimGift(mockDeal);
 
-        expect(result).toEqual(expected);
+          // Assert
+          const expected = {
+            canSubmitFacilitiesToApimGift: false,
+            issuedFacilities: [],
+            isBssEwcsDeal,
+            isGefDeal,
+          };
+
+          expect(result).toEqual(expected);
+          expect(mockMapFacilitiesToSendToGift).not.toHaveBeenCalled();
+        });
       });
 
       describe('when no facilities are issued', () => {

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -1,12 +1,16 @@
 import { DEAL_SUBMISSION_TYPE, DEAL_TYPE, TfmDeal, TfmFacility, isTfmApimGiftIntegrationEnabled } from '@ukef/dtfs2-common';
 import apiModule from '../../../api';
-import MOCK_TFM_DEAL_AIN_SUBMITTED from '../../../__mocks__/mock-TFM-deal-AIN-submitted';
 import { canSubmitToApimGift } from '.';
+import * as generateIssuedFacilitiesQueryStringModule from '../generate-issued-facilities-query-string';
+import * as mapFacilitiesToSendToGiftModule from '../map-facilities-to-send-to-gift';
+import { ApiTypes } from '../../../mappings/apim-gift-payloads/types';
+import { mockTfmDeal, mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility } from '../test-mocks';
 
 jest.mock('../../../api', () => ({
   __esModule: true,
   default: {
     findFacilitiesByDealId: jest.fn(),
+    findGiftFacilitiesById: jest.fn(),
   },
 }));
 
@@ -19,19 +23,20 @@ jest.mock('@ukef/dtfs2-common', () => {
   };
 });
 
-const mockBaseDeal = MOCK_TFM_DEAL_AIN_SUBMITTED as unknown as TfmDeal;
+jest.mock('../generate-issued-facilities-query-string', () => ({
+  __esModule: true,
+  generateIssuedFacilitiesQueryString: jest.fn(),
+}));
 
-const mockTfmObject = {
-  parties: {
-    buyer: {
-      partyUrn: 'Mock party URN',
-    },
-  },
-  exporterCreditRating: 'Acceptable (B+)',
-};
+jest.mock('../map-facilities-to-send-to-gift', () => ({
+  __esModule: true,
+  mapFacilitiesToSendToGift: jest.fn(),
+}));
 
-const mockedFeatureFlag = isTfmApimGiftIntegrationEnabled as jest.MockedFunction<typeof isTfmApimGiftIntegrationEnabled>;
-const mockedFindFacilitiesByDealId = apiModule.findFacilitiesByDealId as jest.MockedFunction<typeof apiModule.findFacilitiesByDealId>;
+const mockFeatureFlag = jest.mocked(isTfmApimGiftIntegrationEnabled);
+const mockApi = jest.mocked(apiModule) as jest.Mocked<ApiTypes>;
+const mockGenerateIssuedFacilitiesQueryString = jest.mocked(generateIssuedFacilitiesQueryStringModule.generateIssuedFacilitiesQueryString);
+const mockMapFacilitiesToSendToGift = jest.mocked(mapFacilitiesToSendToGiftModule.mapFacilitiesToSendToGift);
 
 describe('canSubmitToApimGift', () => {
   beforeEach(() => {
@@ -40,12 +45,12 @@ describe('canSubmitToApimGift', () => {
 
   describe('when APIM/GIFT integration feature flag is disabled', () => {
     beforeEach(() => {
-      mockedFeatureFlag.mockReturnValue(false);
+      mockFeatureFlag.mockReturnValue(false);
     });
 
     it('should return canSubmitFacilitiesToApimGift as false', async () => {
       // Act
-      const result = await canSubmitToApimGift(mockBaseDeal);
+      const result = await canSubmitToApimGift(mockTfmDeal);
 
       // Assert
       const expected = {
@@ -57,16 +62,16 @@ describe('canSubmitToApimGift', () => {
 
     it('should NOT call findFacilitiesByDealId', async () => {
       // Act
-      await canSubmitToApimGift(mockBaseDeal);
+      await canSubmitToApimGift(mockTfmDeal);
 
       // Assert
-      expect(mockedFindFacilitiesByDealId).not.toHaveBeenCalled();
+      expect(mockApi.findFacilitiesByDealId).not.toHaveBeenCalled();
     });
   });
 
   describe('when APIM/GIFT integration feature flag is enabled', () => {
     beforeEach(() => {
-      mockedFeatureFlag.mockReturnValue(true);
+      mockFeatureFlag.mockReturnValue(true);
     });
 
     describe.each([
@@ -96,43 +101,47 @@ describe('canSubmitToApimGift', () => {
       },
     ])('when the deal is $dealType, submission type is $submissionType', ({ dealType, submissionType, isBssEwcsDeal, isGefDeal }) => {
       const mockDeal = {
-        ...mockBaseDeal,
+        ...mockTfmDeal,
         dealSnapshot: {
-          ...mockBaseDeal.dealSnapshot,
+          ...mockTfmDeal.dealSnapshot,
           dealType,
           submissionType,
         },
-        tfm: mockTfmObject,
+        tfm: mockTfmDeal.tfm,
       } as TfmDeal;
 
       it('should call findFacilitiesByDealId', async () => {
         // Arrange
-        mockedFindFacilitiesByDealId.mockResolvedValueOnce([]);
+        const mockIssuedFacility = {
+          _id: '61f7a4edcf809301e78fbe53',
+          facilitySnapshot: {
+            ukefFacilityId: 'FACILITY-001',
+            hasBeenIssued: true,
+          },
+        } as unknown as TfmFacility;
+
+        mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockIssuedFacility]);
+        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001');
+        mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
+        mockMapFacilitiesToSendToGift.mockReturnValueOnce({
+          facilitiesToSendToApimGift: [mockIssuedFacility],
+        });
 
         // Act
         await canSubmitToApimGift(mockDeal);
 
         // Assert
-        expect(mockedFindFacilitiesByDealId).toHaveBeenCalledTimes(1);
-        expect(mockedFindFacilitiesByDealId).toHaveBeenCalledWith(mockDeal._id);
+        expect(mockApi.findFacilitiesByDealId).toHaveBeenNthCalledWith(1, mockDeal._id);
       });
 
-      it('should return canSubmitFacilitiesToApimGift as true and only issued facilities when there is at least one issued facility', async () => {
+      it('should return canSubmitFacilitiesToApimGift as true when there are issued facilities not in GIFT', async () => {
         // Arrange
-        const mockFacilitiesResponse: TfmFacility[] = [
-          {
-            facilitySnapshot: {
-              hasBeenIssued: true,
-            },
-          } as unknown as TfmFacility,
-          {
-            facilitySnapshot: {
-              hasBeenIssued: false,
-            },
-          } as unknown as TfmFacility,
-        ];
-
-        mockedFindFacilitiesByDealId.mockResolvedValueOnce(mockFacilitiesResponse);
+        mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockUnissuedFacility]);
+        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
+        mockApi.findGiftFacilitiesById.mockResolvedValueOnce([]);
+        mockMapFacilitiesToSendToGift.mockReturnValueOnce({
+          facilitiesToSendToApimGift: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
+        });
 
         // Act
         const result = await canSubmitToApimGift(mockDeal);
@@ -140,7 +149,46 @@ describe('canSubmitToApimGift', () => {
         // Assert
         const expected = {
           canSubmitFacilitiesToApimGift: true,
-          issuedFacilities: [mockFacilitiesResponse[0]],
+          issuedFacilities: [mockTfmIssuedFacility1, mockTfmIssuedFacility2],
+          isBssEwcsDeal,
+          isGefDeal,
+        };
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should return canSubmitFacilitiesToApimGift as false when issued facilities already exist in GIFT', async () => {
+        // Arrange
+        const mockIssuedFacility1 = {
+          _id: '61f7a4edcf809301e78fbe53',
+          facilitySnapshot: {
+            ukefFacilityId: 'FACILITY-001',
+            hasBeenIssued: true,
+          },
+        } as unknown as TfmFacility;
+
+        const mockIssuedFacility2 = {
+          _id: '61f7a4edcf809301e78fbe54',
+          facilitySnapshot: {
+            ukefFacilityId: 'FACILITY-002',
+            hasBeenIssued: true,
+          },
+        } as unknown as TfmFacility;
+
+        mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockIssuedFacility1, mockIssuedFacility2]);
+        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce('FACILITY-001,FACILITY-002');
+        mockApi.findGiftFacilitiesById.mockResolvedValueOnce([{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-002' }]);
+        mockMapFacilitiesToSendToGift.mockReturnValueOnce({
+          facilitiesToSendToApimGift: [],
+        });
+
+        // Act
+        const result = await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        const expected = {
+          canSubmitFacilitiesToApimGift: false,
+          issuedFacilities: [],
           isBssEwcsDeal,
           isGefDeal,
         };
@@ -151,15 +199,7 @@ describe('canSubmitToApimGift', () => {
       describe('when no facilities are issued', () => {
         it('should return canSubmitFacilitiesToApimGift as false', async () => {
           // Arrange
-          const mockFacilitiesResponse: TfmFacility[] = [
-            {
-              facilitySnapshot: {
-                hasBeenIssued: false,
-              },
-            } as unknown as TfmFacility,
-          ];
-
-          mockedFindFacilitiesByDealId.mockResolvedValueOnce(mockFacilitiesResponse);
+          mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockUnissuedFacility]);
 
           // Act
           const result = await canSubmitToApimGift(mockDeal);
@@ -167,9 +207,6 @@ describe('canSubmitToApimGift', () => {
           // Assert
           const expected = {
             canSubmitFacilitiesToApimGift: false,
-            issuedFacilities: [],
-            isBssEwcsDeal,
-            isGefDeal,
           };
 
           expect(result).toEqual(expected);
@@ -188,13 +225,13 @@ describe('canSubmitToApimGift', () => {
       },
     ])('when the deal is $dealType, submission type is $submissionType', ({ dealType, submissionType }) => {
       const mockDeal = {
-        ...mockBaseDeal,
+        ...mockTfmDeal,
         dealSnapshot: {
-          ...mockBaseDeal.dealSnapshot,
+          ...mockTfmDeal.dealSnapshot,
           dealType,
           submissionType,
         },
-        tfm: mockTfmObject,
+        tfm: mockTfmDeal.tfm,
       } as TfmDeal;
 
       it('should return canSubmitFacilitiesToApimGift as false', async () => {
@@ -214,7 +251,7 @@ describe('canSubmitToApimGift', () => {
         await canSubmitToApimGift(mockDeal);
 
         // Assert
-        expect(mockedFindFacilitiesByDealId).not.toHaveBeenCalled();
+        expect(mockApi.findFacilitiesByDealId).not.toHaveBeenCalled();
       });
     });
 
@@ -222,16 +259,16 @@ describe('canSubmitToApimGift', () => {
       it('should return canSubmitFacilitiesToApimGift as false', async () => {
         // Arrange
         const mockDeal = {
-          ...mockBaseDeal,
+          ...mockTfmDeal,
           dealSnapshot: {
-            ...mockBaseDeal.dealSnapshot,
+            ...mockTfmDeal.dealSnapshot,
             dealType: DEAL_TYPE.BSS_EWCS,
             submissionType: DEAL_SUBMISSION_TYPE.AIN,
           },
-          tfm: mockTfmObject,
+          tfm: mockTfmDeal.tfm,
         } as TfmDeal;
 
-        mockedFindFacilitiesByDealId.mockResolvedValue([]);
+        mockApi.findFacilitiesByDealId.mockResolvedValue([mockUnissuedFacility]);
 
         // Act
         const result = await canSubmitToApimGift(mockDeal);
@@ -239,12 +276,72 @@ describe('canSubmitToApimGift', () => {
         // Assert
         const expected = {
           canSubmitFacilitiesToApimGift: false,
-          issuedFacilities: [],
-          isBssEwcsDeal: true,
-          isGefDeal: false,
         };
 
         expect(result).toEqual(expected);
+      });
+
+      it('should NOT call generateIssuedFacilitiesQueryString', async () => {
+        // Arrange
+        const mockDeal = {
+          ...mockTfmDeal,
+          dealSnapshot: {
+            ...mockTfmDeal.dealSnapshot,
+            dealType: DEAL_TYPE.BSS_EWCS,
+            submissionType: DEAL_SUBMISSION_TYPE.AIN,
+          },
+          tfm: mockTfmDeal.tfm,
+        } as TfmDeal;
+
+        mockApi.findFacilitiesByDealId.mockResolvedValue([mockUnissuedFacility]);
+
+        // Act
+        await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        expect(mockGenerateIssuedFacilitiesQueryString).not.toHaveBeenCalled();
+      });
+
+      it('should NOT call findGiftFacilitiesById', async () => {
+        // Arrange
+        const mockDeal = {
+          ...mockTfmDeal,
+          dealSnapshot: {
+            ...mockTfmDeal.dealSnapshot,
+            dealType: DEAL_TYPE.BSS_EWCS,
+            submissionType: DEAL_SUBMISSION_TYPE.AIN,
+          },
+          tfm: mockTfmDeal.tfm,
+        } as TfmDeal;
+
+        mockApi.findFacilitiesByDealId.mockResolvedValue([mockUnissuedFacility]);
+
+        // Act
+        await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        expect(mockApi.findGiftFacilitiesById).not.toHaveBeenCalled();
+      });
+
+      it('should NOT call mapFacilitiesToSendToGift', async () => {
+        // Arrange
+        const mockDeal = {
+          ...mockTfmDeal,
+          dealSnapshot: {
+            ...mockTfmDeal.dealSnapshot,
+            dealType: DEAL_TYPE.BSS_EWCS,
+            submissionType: DEAL_SUBMISSION_TYPE.AIN,
+          },
+          tfm: mockTfmDeal.tfm,
+        } as TfmDeal;
+
+        mockApi.findFacilitiesByDealId.mockResolvedValue([mockUnissuedFacility]);
+
+        // Act
+        await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        expect(mockMapFacilitiesToSendToGift).not.toHaveBeenCalled();
       });
     });
 
@@ -253,16 +350,16 @@ describe('canSubmitToApimGift', () => {
       ({ partyUrn }) => {
         // Arrange
         const mockDeal = {
-          ...mockBaseDeal,
+          ...mockTfmDeal,
           dealSnapshot: {
-            ...mockBaseDeal.dealSnapshot,
+            ...mockTfmDeal.dealSnapshot,
             dealType: DEAL_TYPE.BSS_EWCS,
             submissionType: DEAL_SUBMISSION_TYPE.AIN,
           },
           tfm: {
-            ...mockTfmObject,
+            ...mockTfmDeal.tfm,
             parties: {
-              ...mockTfmObject.parties,
+              ...mockTfmDeal.tfm.parties,
               buyer: {
                 partyUrn,
               },
@@ -271,7 +368,7 @@ describe('canSubmitToApimGift', () => {
         } as TfmDeal;
 
         it('should return canSubmitFacilitiesToApimGift as false', async () => {
-          mockedFindFacilitiesByDealId.mockResolvedValue([]);
+          mockApi.findFacilitiesByDealId.mockResolvedValue([]);
 
           // Act
           const result = await canSubmitToApimGift(mockDeal);
@@ -289,7 +386,7 @@ describe('canSubmitToApimGift', () => {
           await canSubmitToApimGift(mockDeal);
 
           // Assert
-          expect(mockedFindFacilitiesByDealId).not.toHaveBeenCalled();
+          expect(mockApi.findFacilitiesByDealId).not.toHaveBeenCalled();
         });
       },
     );
@@ -299,14 +396,14 @@ describe('canSubmitToApimGift', () => {
       ({ exporterCreditRating }) => {
         // Arrange
         const mockDeal = {
-          ...mockBaseDeal,
+          ...mockTfmDeal,
           dealSnapshot: {
-            ...mockBaseDeal.dealSnapshot,
+            ...mockTfmDeal.dealSnapshot,
             dealType: DEAL_TYPE.GEF,
             submissionType: DEAL_SUBMISSION_TYPE.AIN,
           },
           tfm: {
-            ...mockTfmObject,
+            ...mockTfmDeal.tfm,
             exporterCreditRating,
           },
         } as TfmDeal;
@@ -328,33 +425,56 @@ describe('canSubmitToApimGift', () => {
           await canSubmitToApimGift(mockDeal);
 
           // Assert
-          expect(mockedFindFacilitiesByDealId).not.toHaveBeenCalled();
+          expect(mockApi.findFacilitiesByDealId).not.toHaveBeenCalled();
         });
       },
     );
 
     describe('when api.findFacilitiesByDealId throws an error', () => {
-      it('should swallow the error and return issuedFacilities as an empty array', async () => {
+      it('should swallow the error and return canSubmitFacilitiesToApimGift as false', async () => {
         // Arrange
         const mockDeal = {
-          ...mockBaseDeal,
+          ...mockTfmDeal,
           dealSnapshot: {
-            ...mockBaseDeal.dealSnapshot,
+            ...mockTfmDeal.dealSnapshot,
             dealType: DEAL_TYPE.BSS_EWCS,
             submissionType: DEAL_SUBMISSION_TYPE.AIN,
           },
-          tfm: mockTfmObject,
+          tfm: mockTfmDeal.tfm,
         } as TfmDeal;
 
         const mockError = new Error('Mock API error');
 
-        mockedFindFacilitiesByDealId.mockRejectedValueOnce(mockError);
+        mockApi.findFacilitiesByDealId.mockRejectedValueOnce(mockError);
 
         // Act
         const result = await canSubmitToApimGift(mockDeal);
 
         // Assert
-        expect(result.issuedFacilities).toEqual([]);
+        expect(result.canSubmitFacilitiesToApimGift).toEqual(false);
+      });
+
+      it('should NOT call generateIssuedFacilitiesQueryString', async () => {
+        // Arrange
+        const mockDeal = {
+          ...mockTfmDeal,
+          dealSnapshot: {
+            ...mockTfmDeal.dealSnapshot,
+            dealType: DEAL_TYPE.BSS_EWCS,
+            submissionType: DEAL_SUBMISSION_TYPE.AIN,
+          },
+          tfm: mockTfmDeal.tfm,
+        } as TfmDeal;
+
+        const mockError = new Error('Mock API error');
+
+        mockApi.findFacilitiesByDealId.mockRejectedValueOnce(mockError);
+
+        // Act
+        await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        expect(mockGenerateIssuedFacilitiesQueryString).not.toHaveBeenCalled();
       });
     });
   });

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -90,6 +90,7 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
   }
 
   let facilities: TfmFacility[] = [];
+  let findFacilitiesByDealIdFailed = false;
 
   try {
     // Get TFM facilities by deal ID.
@@ -98,6 +99,7 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
     facilities = Array.isArray(response) ? response : [];
   } catch {
     // Swallow errors and default facilities to an empty array
+    findFacilitiesByDealIdFailed = true;
     facilities = [];
   }
 
@@ -110,7 +112,11 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
   const validCoreChecks = validDealType && validSubmissionType && issuedFacilities.length > 0;
 
   if (!validCoreChecks) {
-    console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - no issued facilities', dealId);
+    if (findFacilitiesByDealIdFailed) {
+      console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - failed to retrieve facilities from TFM', dealId);
+    } else {
+      console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - no issued facilities', dealId);
+    }
 
     return {
       canSubmitFacilitiesToApimGift: false,

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -137,7 +137,7 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
 
   return {
     canSubmitFacilitiesToApimGift: facilitiesToSendToApimGift.length > 0,
-    issuedFacilities: facilitiesToSendToApimGift, // TODO: rename issuedFacilities.
+    issuedFacilities: facilitiesToSendToApimGift,
     isBssEwcsDeal,
     isGefDeal,
   };

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -128,9 +128,9 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
 
   console.info('Issued facilities for deal %s could be submitted to APIM GIFT', dealId);
 
-  const issuedFacilityIds = generateIssuedFacilitiesQueryString(issuedFacilities);
+  const issuedFacilitiesQueryString = generateIssuedFacilitiesQueryString(issuedFacilities);
 
-  const giftFacilitiesResponse = await api.findGiftFacilitiesById(issuedFacilityIds);
+  const giftFacilitiesResponse = await api.findGiftFacilitiesByIds(issuedFacilitiesQueryString);
 
   if (giftFacilitiesResponse === false) {
     console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - failed to retrieve existing facilities from GIFT', dealId);
@@ -143,16 +143,20 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
     };
   }
 
+  const giftFacilities = Array.isArray(giftFacilitiesResponse.facilities) ? giftFacilitiesResponse.facilities : [];
+
   const { facilitiesToSendToApimGift, facilityIds } = mapFacilitiesToSendToGift({
     dealId,
-    giftFacilities: giftFacilitiesResponse,
+    giftFacilities,
     issuedTfmFacilities: issuedFacilities,
   });
 
   if (facilitiesToSendToApimGift.length === 0) {
     console.info('No issued facilities for deal %s can be submitted to APIM GIFT - facilities already exist in GIFT', dealId);
   } else {
-    console.info('Issued facilities %s for deal %s can be submitted to APIM GIFT', facilityIds, dealId);
+    const facilityIdsForLog = facilityIds ?? generateIssuedFacilitiesQueryString(facilitiesToSendToApimGift);
+
+    console.info('Issued facilities %s for deal %s can be submitted to APIM GIFT', facilityIdsForLog, dealId);
   }
 
   return {

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -123,6 +123,17 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
 
   const giftFacilitiesResponse = await api.findGiftFacilitiesById(issuedFacilityIds);
 
+  if (giftFacilitiesResponse === false) {
+    console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - failed to retrieve existing facilities from GIFT', dealId);
+
+    return {
+      canSubmitFacilitiesToApimGift: false,
+      issuedFacilities: [],
+      isBssEwcsDeal,
+      isGefDeal,
+    };
+  }
+
   const { facilitiesToSendToApimGift } = mapFacilitiesToSendToGift({
     dealId,
     giftFacilities: giftFacilitiesResponse,

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -1,7 +1,9 @@
 import { DEAL_SUBMISSION_TYPE, isTfmApimGiftIntegrationEnabled, TfmDeal, TfmFacility } from '@ukef/dtfs2-common';
 import apiModule from '../../../api';
 import { getDealTypeFlags } from '../../../mappings/apim-gift-payloads/create-facility/get-deal-type-flags';
+import { mapFacilitiesToSendToGift } from '../map-facilities-to-send-to-gift';
 import { ApiTypes } from '../../../mappings/apim-gift-payloads/types';
+import { generateIssuedFacilitiesQueryString } from '../generate-issued-facilities-query-string';
 
 const { AIN, MIN } = DEAL_SUBMISSION_TYPE;
 
@@ -22,100 +24,121 @@ type CanSubmitFacilitiesToApimGiftReturnShape = {
  * @returns {CanSubmitFacilitiesToApimGiftReturnShape} An object indicating whether the deal can be submitted and relevant details.
  */
 export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacilitiesToApimGiftReturnShape> => {
-  console.info('Checking if issued facilities for deal %s can be submitted to APIM GIFT', deal?._id);
+  const dealId = String(deal?._id);
+
+  console.info('Checking if issued facilities for deal %s can be submitted to APIM GIFT', dealId);
 
   const api = apiModule as ApiTypes;
 
-  if (isTfmApimGiftIntegrationEnabled()) {
-    const { dealType, submissionType } = deal.dealSnapshot;
-
-    const { isBssEwcsDeal, isGefDeal } = getDealTypeFlags(dealType);
-
-    const validDealType = isBssEwcsDeal || isGefDeal;
-    const validSubmissionType = submissionType === AIN || submissionType === MIN;
-
-    /**
-     * NOTE: During first BSS/EWCS/GEF deal submission, deal.tfm.exporterCreditRating will never exist.
-     * This is only populated when a TFM Underwriter user adds a credit rating via the "Underwriting" section of a TFM deal.
-     *
-     * BSS/EWCS/GEF should only send facilities to APIM/GIFT if the buyer party URN is populated.
-     *
-     * Therefore, for the first submission of a BSS/EWCS deal, we should return canSubmitFacilitiesToApimGift as false.
-     */
-    const hasExporterCreditRating = Boolean(deal.tfm?.exporterCreditRating?.trim());
-
-    if (!validDealType || !validSubmissionType || !hasExporterCreditRating) {
-      console.info(
-        'Issued facilities for deal %s cannot be submitted to APIM GIFT - invalid deal type, submission type, or missing exporter credit rating',
-        deal?._id,
-      );
-
-      return {
-        canSubmitFacilitiesToApimGift: false,
-      };
-    }
-
-    /**
-     * NOTE: During first BSS/EWCS deal submission, tfm.parties.buyer?.partyUrn will always be an empty string.
-     *
-     * The buyer party URN is populated in TFM - after the first deal submission.
-     * BSS/EWCS should only send facilities to APIM/GIFT if the buyer party URN is populated.
-     *
-     * Therefore, for the first submission of a BSS/EWCS deal, we should return canSubmitFacilitiesToApimGift as false.
-     * For GEF deals, there is no requirement for a buyer party URN to be populated to submit facilities to APIM/GIFT, so GEF deals can submit facilities on the first submission.
-     * This is an edge case but this is future proofed, and is important to prevent attempts to submit facilities to APIM/GIFT when the buyer party URN is not populated as this will cause errors in the APIM/GIFT integration.
-     * Once the buyer party URN is populated after the first submission, BSS/EWCS deals can submit facilities to APIM/GIFT on subsequent submissions as normal.
-     */
-    const hasBuyerPartyUrn = Boolean(deal.tfm.parties.buyer?.partyUrn);
-
-    const isValidBssEwcsDeal = isBssEwcsDeal && hasBuyerPartyUrn;
-
-    if (!isValidBssEwcsDeal && !isGefDeal) {
-      console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - invalid BSS/EWCS or GEF deal', deal?._id);
-
-      return {
-        canSubmitFacilitiesToApimGift: false,
-      };
-    }
-
-    let facilities: TfmFacility[] = [];
-
-    try {
-      const dealId = deal._id.toString();
-
-      const response = await api.findFacilitiesByDealId(dealId);
-
-      facilities = Array.isArray(response) ? response : [];
-    } catch {
-      // Swallow errors and default facilities to an empty array
-      facilities = [];
-    }
-
-    let issuedFacilities: TfmFacility[] = [];
-
-    if (Array.isArray(facilities)) {
-      issuedFacilities = facilities.filter((facility) => Boolean(facility.facilitySnapshot?.hasBeenIssued));
-    }
-
-    const canSubmitFacilitiesToApimGift = validDealType && validSubmissionType && issuedFacilities.length > 0;
-
-    if (!canSubmitFacilitiesToApimGift) {
-      console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - no issued facilities', deal?._id);
-    } else {
-      console.info('Issued facilities for deal %s can be submitted to APIM GIFT', deal?._id);
-    }
+  if (!isTfmApimGiftIntegrationEnabled()) {
+    console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - feature flag disabled', dealId);
 
     return {
-      canSubmitFacilitiesToApimGift,
-      issuedFacilities,
-      isBssEwcsDeal,
-      isGefDeal,
+      canSubmitFacilitiesToApimGift: false,
     };
   }
 
-  console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - feature flag disabled', deal?._id);
+  const { dealType, submissionType } = deal.dealSnapshot;
+
+  const { isBssEwcsDeal, isGefDeal } = getDealTypeFlags(dealType);
+
+  const validDealType = isBssEwcsDeal || isGefDeal;
+  const validSubmissionType = submissionType === AIN || submissionType === MIN;
+
+  /**
+   * NOTE: During first BSS/EWCS/GEF deal submission, deal.tfm.exporterCreditRating will never exist.
+   * This is only populated when a TFM Underwriter user adds a credit rating via the "Underwriting" section of a TFM deal.
+   *
+   * BSS/EWCS/GEF should only send facilities to APIM/GIFT if the buyer party URN is populated.
+   *
+   * Therefore, for the first submission of a BSS/EWCS deal, we should return canSubmitFacilitiesToApimGift as false.
+   */
+  const hasExporterCreditRating = Boolean(deal.tfm?.exporterCreditRating?.trim());
+
+  if (!validDealType || !validSubmissionType || !hasExporterCreditRating) {
+    console.info(
+      'Issued facilities for deal %s cannot be submitted to APIM GIFT - invalid deal type, submission type, or missing exporter credit rating',
+      dealId,
+    );
+
+    return {
+      canSubmitFacilitiesToApimGift: false,
+    };
+  }
+
+  /**
+   * NOTE: During first BSS/EWCS deal submission, tfm.parties.buyer?.partyUrn will always be an empty string.
+   *
+   * The buyer party URN is populated in TFM - after the first deal submission.
+   * BSS/EWCS should only send facilities to APIM/GIFT if the buyer party URN is populated.
+   *
+   * Therefore, for the first submission of a BSS/EWCS deal, we should return canSubmitFacilitiesToApimGift as false.
+   * For GEF deals, there is no requirement for a buyer party URN to be populated to submit facilities to APIM/GIFT, so GEF deals can submit facilities on the first submission.
+   * This is an edge case but this is future proofed, and is important to prevent attempts to submit facilities to APIM/GIFT when the buyer party URN is not populated as this will cause errors in the APIM/GIFT integration.
+   * Once the buyer party URN is populated after the first submission, BSS/EWCS deals can submit facilities to APIM/GIFT on subsequent submissions as normal.
+   */
+  const hasBuyerPartyUrn = Boolean(deal.tfm.parties.buyer?.partyUrn);
+
+  const isValidBssEwcsDeal = isBssEwcsDeal && hasBuyerPartyUrn;
+
+  if (!isValidBssEwcsDeal && !isGefDeal) {
+    console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - invalid BSS/EWCS or GEF deal', dealId);
+
+    return {
+      canSubmitFacilitiesToApimGift: false,
+    };
+  }
+
+  let facilities: TfmFacility[] = [];
+
+  try {
+    // Get TFM facilities by deal ID.
+    const response = await api.findFacilitiesByDealId(dealId);
+
+    facilities = Array.isArray(response) ? response : [];
+  } catch {
+    // Swallow errors and default facilities to an empty array
+    facilities = [];
+  }
+
+  let issuedFacilities: TfmFacility[] = [];
+
+  if (Array.isArray(facilities)) {
+    issuedFacilities = facilities.filter((facility) => Boolean(facility.facilitySnapshot?.hasBeenIssued));
+  }
+
+  const validCoreChecks = validDealType && validSubmissionType && issuedFacilities.length > 0;
+
+  if (!validCoreChecks) {
+    console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - no issued facilities', dealId);
+
+    return {
+      canSubmitFacilitiesToApimGift: false,
+    };
+  }
+
+  console.info('Issued facilities for deal %s could be submitted to APIM GIFT', dealId);
+
+  const issuedFacilityIds = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+  const giftFacilitiesResponse = await api.findGiftFacilitiesById(issuedFacilityIds);
+
+  const { facilitiesToSendToApimGift } = mapFacilitiesToSendToGift({
+    dealId,
+    giftFacilities: giftFacilitiesResponse,
+    issuedTfmFacilities: issuedFacilities,
+  });
+
+  if (facilitiesToSendToApimGift.length === 0) {
+    console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - facilities already exist in GIFT', dealId);
+  } else {
+    console.info('Issued facilities for deal %s can be submitted to APIM GIFT', dealId);
+  }
 
   return {
-    canSubmitFacilitiesToApimGift: false,
+    canSubmitFacilitiesToApimGift: facilitiesToSendToApimGift.length > 0,
+    issuedFacilities: facilitiesToSendToApimGift, // TODO: rename issuedFacilities.
+    isBssEwcsDeal,
+    isGefDeal,
   };
 };

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -143,16 +143,16 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
     };
   }
 
-  const { facilitiesToSendToApimGift } = mapFacilitiesToSendToGift({
+  const { facilitiesToSendToApimGift, facilityIds } = mapFacilitiesToSendToGift({
     dealId,
     giftFacilities: giftFacilitiesResponse,
     issuedTfmFacilities: issuedFacilities,
   });
 
   if (facilitiesToSendToApimGift.length === 0) {
-    console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - facilities already exist in GIFT', dealId);
+    console.info('No issued facilities for deal %s can be submitted to APIM GIFT - facilities already exist in GIFT', dealId);
   } else {
-    console.info('Issued facilities for deal %s can be submitted to APIM GIFT', dealId);
+    console.info('Issued facilities %s for deal %s can be submitted to APIM GIFT', facilityIds, dealId);
   }
 
   return {

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -114,6 +114,9 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
 
     return {
       canSubmitFacilitiesToApimGift: false,
+      issuedFacilities: [],
+      isBssEwcsDeal,
+      isGefDeal,
     };
   }
 

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.test.ts
@@ -1,0 +1,113 @@
+import { ObjectId } from 'mongodb';
+import { TfmFacility } from '@ukef/dtfs2-common';
+import { mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3, mockTfmIssuedFacility4 } from '../test-mocks';
+import { generateIssuedFacilitiesQueryString } from '.';
+
+describe('generateIssuedFacilitiesQueryString', () => {
+  describe('when multiple facilities are provided', () => {
+    it('should return comma-separated string of facility IDs', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
+
+      // Act
+      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+      // Assert
+      const expected = 'FACILITY-001,FACILITY-002,FACILITY-003';
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should preserve order of facilities in query string', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility3, mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+
+      // Act
+      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+      // Assert
+      expect(result).toEqual('FACILITY-003,FACILITY-001,FACILITY-002');
+    });
+
+    it('should handle mixed facility ID formats', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility4, mockTfmIssuedFacility2];
+
+      // Act
+      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+      // Assert
+      const expected = 'FACILITY-001,0030012345,FACILITY-002';
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a single facility is provided', () => {
+    it('should return the facility ID without trailing comma', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1];
+
+      // Act
+      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+      // Assert
+      const expected = 'FACILITY-001';
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when no facilities are provided', () => {
+    it('should return an empty string', () => {
+      // Arrange
+      const issuedFacilities: TfmFacility[] = [];
+
+      // Act
+      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+      // Assert
+      expect(result).toEqual('');
+    });
+  });
+
+  describe('when facilities have numeric facility IDs', () => {
+    it('should convert facility IDs to string format', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility4];
+
+      // Act
+      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+      // Assert
+      const expected = mockTfmIssuedFacility4.facilitySnapshot.ukefFacilityId;
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when facilities have special characters in IDs', () => {
+    it('should preserve special characters in facility IDs', () => {
+      // Arrange
+      const mockUkefFacilityIdWithSpecialChars = 'FAC-001-TEST/2024';
+
+      const mockFacility = {
+        _id: new ObjectId('61f7a4edcf809301e78fbe57'),
+        facilitySnapshot: {
+          ukefFacilityId: mockUkefFacilityIdWithSpecialChars,
+          hasBeenIssued: true,
+        },
+        tfm: {},
+      } as unknown as TfmFacility;
+      const issuedFacilities = [mockTfmIssuedFacility1, mockFacility];
+
+      // Act
+      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
+
+      // Assert
+      const expected = `FACILITY-001,${mockUkefFacilityIdWithSpecialChars}`;
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.test.ts
@@ -85,21 +85,6 @@ describe('generateIssuedFacilitiesQueryString', () => {
     });
   });
 
-  describe('when facilities have numeric facility IDs', () => {
-    it('should convert facility IDs to string format', () => {
-      // Arrange
-      const issuedFacilities = [mockTfmIssuedFacility4];
-
-      // Act
-      const result = generateIssuedFacilitiesQueryString(issuedFacilities);
-
-      // Assert
-      const expected = mockTfmIssuedFacility4.facilitySnapshot.ukefFacilityId;
-
-      expect(result).toEqual(expected);
-    });
-  });
-
   describe('when facilities have special characters in IDs', () => {
     it('should preserve special characters in facility IDs', () => {
       // Arrange

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.test.ts
@@ -13,7 +13,11 @@ describe('generateIssuedFacilitiesQueryString', () => {
       const result = generateIssuedFacilitiesQueryString(issuedFacilities);
 
       // Assert
-      const expected = 'FACILITY-001,FACILITY-002,FACILITY-003';
+      const expected = [
+        mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility3.facilitySnapshot.ukefFacilityId,
+      ].join(',');
 
       expect(result).toEqual(expected);
     });
@@ -26,7 +30,13 @@ describe('generateIssuedFacilitiesQueryString', () => {
       const result = generateIssuedFacilitiesQueryString(issuedFacilities);
 
       // Assert
-      expect(result).toEqual('FACILITY-003,FACILITY-001,FACILITY-002');
+      const expected = [
+        mockTfmIssuedFacility3.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId,
+      ].join(',');
+
+      expect(result).toEqual(expected);
     });
 
     it('should handle mixed facility ID formats', () => {
@@ -37,7 +47,11 @@ describe('generateIssuedFacilitiesQueryString', () => {
       const result = generateIssuedFacilitiesQueryString(issuedFacilities);
 
       // Assert
-      const expected = 'FACILITY-001,0030012345,FACILITY-002';
+      const expected = [
+        mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility4.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId,
+      ].join(',');
 
       expect(result).toEqual(expected);
     });
@@ -52,7 +66,7 @@ describe('generateIssuedFacilitiesQueryString', () => {
       const result = generateIssuedFacilitiesQueryString(issuedFacilities);
 
       // Assert
-      const expected = 'FACILITY-001';
+      const expected = mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId;
 
       expect(result).toEqual(expected);
     });
@@ -105,7 +119,7 @@ describe('generateIssuedFacilitiesQueryString', () => {
       const result = generateIssuedFacilitiesQueryString(issuedFacilities);
 
       // Assert
-      const expected = `FACILITY-001,${mockUkefFacilityIdWithSpecialChars}`;
+      const expected = `${mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId},${mockUkefFacilityIdWithSpecialChars}`;
 
       expect(result).toEqual(expected);
     });

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/generate-issued-facilities-query-string/index.ts
@@ -1,0 +1,9 @@
+import { TfmFacility } from '@ukef/dtfs2-common';
+
+/**
+ * Generates a query string of facility IDs.
+ * @param {TfmFacility[]} issuedFacilities - TFM facilities.
+ * @returns {string} A comma-separated string of facility IDs.
+ */
+export const generateIssuedFacilitiesQueryString = (issuedFacilities: TfmFacility[]): string =>
+  issuedFacilities.map((facility) => facility.facilitySnapshot.ukefFacilityId).join(',');

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/index.ts
@@ -1,2 +1,3 @@
 export * from './can-submit-to-apim-gift';
+export * from './map-facilities-to-send-to-gift';
 export * from './submit-facilities-to-apim-gift';

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
@@ -1,0 +1,312 @@
+import { TfmFacility } from '@ukef/dtfs2-common';
+import { hasId, mapFacilitiesToSendToGift } from '.';
+import { mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3 } from '../test-mocks';
+
+const MOCK_DEAL_ID = '61f7a4edcf809301e78fbe41';
+
+describe('hasId', () => {
+  describe('when object has facilityId property', () => {
+    it('should return true', () => {
+      // Arrange
+      const obj = { facilityId: 'FACILITY-001' };
+
+      // Act
+      const result = hasId(obj);
+
+      // Assert
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('when object does not have facilityId property', () => {
+    it('should return false', () => {
+      // Arrange
+      const obj = { someOtherProperty: 'value' };
+
+      // Act
+      const result = hasId(obj);
+
+      // Assert
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('when object has facilityId property with non-string value', () => {
+    it('should return true', () => {
+      // Arrange
+      const obj = { facilityId: 12345 };
+
+      // Act
+      const result = hasId(obj);
+
+      // Assert
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('when object is empty', () => {
+    it('should return false', () => {
+      // Arrange
+      const obj = {};
+
+      // Act
+      const result = hasId(obj);
+
+      // Assert
+      expect(result).toEqual(false);
+    });
+  });
+});
+
+describe('mapFacilitiesToSendToGift', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'info').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('when no facilities exist in GIFT', () => {
+    it('should return all issued TFM facilities', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse = false;
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
+    });
+
+    it('should log that all facilities can be submitted', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse = false;
+      const consoleInfoSpy = jest.spyOn(console, 'info');
+
+      // Act
+      mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+        2,
+        'No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT',
+        MOCK_DEAL_ID,
+      );
+    });
+
+    it('should return empty array when no issued facilities provided', () => {
+      // Arrange
+      const issuedFacilities: TfmFacility[] = [];
+      const giftFacilitiesResponse = false;
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(result.facilitiesToSendToApimGift).toEqual([]);
+    });
+  });
+
+  describe('when all issued facilities exist in GIFT', () => {
+    it('should return an empty array', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-002' }];
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(result.facilitiesToSendToApimGift).toEqual([]);
+    });
+
+    it('should log that all facilities already exist in GIFT', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-002' }];
+      const consoleInfoSpy = jest.spyOn(console, 'info');
+
+      // Act
+      mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'All issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, [
+        'FACILITY-001',
+        'FACILITY-002',
+      ]);
+    });
+  });
+
+  describe('when some issued facilities exist in GIFT', () => {
+    it('should return only the facilities that do not exist in GIFT', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
+      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }];
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      const expected = [mockTfmIssuedFacility2, mockTfmIssuedFacility3];
+
+      expect(result.facilitiesToSendToApimGift).toEqual(expected);
+    });
+
+    it('should log facilities that exist in GIFT', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
+      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }];
+      const consoleInfoSpy = jest.spyOn(console, 'info');
+
+      // Act
+      mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'Some issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, ['FACILITY-001']);
+    });
+
+    it('should log facilities that do not exist in GIFT', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
+      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }];
+      const consoleInfoSpy = jest.spyOn(console, 'info');
+
+      // Act
+      mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(3, 'Some issued facilities for deal %s do not exist in GIFT: %o', MOCK_DEAL_ID, [
+        'FACILITY-002',
+        'FACILITY-003',
+      ]);
+    });
+
+    it('should return correct facilities when multiple exist in GIFT', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
+      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-003' }];
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      const expected = [mockTfmIssuedFacility2];
+
+      expect(result.facilitiesToSendToApimGift).toEqual(expected);
+    });
+  });
+
+  describe('when giftFacilities is an empty array', () => {
+    it('should return all issued facilities', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse: object[] = [];
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
+    });
+
+    it('should log that all facilities can be submitted', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse: object[] = [];
+      const consoleInfoSpy = jest.spyOn(console, 'info');
+
+      // Act
+      mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+        2,
+        'No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT',
+        MOCK_DEAL_ID,
+      );
+    });
+  });
+
+  describe('when giftFacilities response has no facilityId property', () => {
+    it('should treat facilities without facilityId as not present', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse = [{ someOtherProperty: 'FACILITY-001' }, { anotherProperty: 'FACILITY-002' }];
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
+    });
+  });
+
+  describe('logging behavior', () => {
+    it('should always log the initial mapping message', () => {
+      // Arrange
+      const consoleInfoSpy = jest.spyOn(console, 'info');
+
+      // Act
+      mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: false,
+        issuedTfmFacilities: [],
+      });
+
+      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(1, 'Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', MOCK_DEAL_ID);
+    });
+  });
+});

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
@@ -1,17 +1,14 @@
 import { TfmFacility } from '@ukef/dtfs2-common';
 import { hasId, mapFacilitiesToSendToGift } from '.';
-import { mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3 } from '../test-mocks';
+import { mockGiftFacility, mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3 } from '../test-mocks';
 
 const MOCK_DEAL_ID = '61f7a4edcf809301e78fbe41';
 
 describe('hasId', () => {
   describe('when object has facilityId property', () => {
     it('should return true', () => {
-      // Arrange
-      const obj = { facilityId: 'FACILITY-001' };
-
       // Act
-      const result = hasId(obj);
+      const result = hasId(mockGiftFacility);
 
       // Assert
       expect(result).toEqual(true);
@@ -145,7 +142,10 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should return an empty array', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse = [{ facilityId: '0000000001' }, { facilityId: '0000000002' }];
+      const giftFacilitiesResponse = [
+        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) },
+        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId) },
+      ];
 
       // Act
       const result = mapFacilitiesToSendToGift({
@@ -161,7 +161,10 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should log that all facilities already exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse = [{ facilityId: '0000000001' }, { facilityId: '0000000002' }];
+      const giftFacilitiesResponse = [
+        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) },
+        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId) },
+      ];
       const consoleInfoSpy = jest.spyOn(console, 'info');
 
       // Act
@@ -173,8 +176,8 @@ describe('mapFacilitiesToSendToGift', () => {
 
       // Assert
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'All issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, [
-        '0000000001',
-        '0000000002',
+        mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId,
       ]);
     });
   });
@@ -183,7 +186,7 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should return only the facilities that do not exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: '0000000001' }];
+      const giftFacilitiesResponse = [{ ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) }];
 
       // Act
       const result = mapFacilitiesToSendToGift({
@@ -201,7 +204,7 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should log facilities that exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: '0000000001' }];
+      const giftFacilitiesResponse = [{ ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) }];
       const consoleInfoSpy = jest.spyOn(console, 'info');
 
       // Act
@@ -212,13 +215,15 @@ describe('mapFacilitiesToSendToGift', () => {
       });
 
       // Assert
-      expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'Some issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, ['0000000001']);
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'Some issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, [
+        mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId,
+      ]);
     });
 
     it('should log facilities that do not exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: '0000000001' }];
+      const giftFacilitiesResponse = [{ ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) }];
       const consoleInfoSpy = jest.spyOn(console, 'info');
 
       // Act
@@ -230,15 +235,18 @@ describe('mapFacilitiesToSendToGift', () => {
 
       // Assert
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(3, 'Some issued facilities for deal %s do not exist in GIFT: %o', MOCK_DEAL_ID, [
-        '0000000002',
-        '0000000003',
+        mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId,
+        mockTfmIssuedFacility3.facilitySnapshot.ukefFacilityId,
       ]);
     });
 
     it('should return correct facilities when multiple exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: '0000000001' }, { facilityId: '0000000003' }];
+      const giftFacilitiesResponse = [
+        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) },
+        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility3.facilitySnapshot.ukefFacilityId) },
+      ];
 
       // Act
       const result = mapFacilitiesToSendToGift({

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
@@ -1,14 +1,14 @@
 import { TfmFacility } from '@ukef/dtfs2-common';
-import { hasId, mapFacilitiesToSendToGift } from '.';
+import { hasGiftFacilityId, mapFacilitiesToSendToGift } from '.';
 import { mockGiftFacility, mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3 } from '../test-mocks';
 
 const MOCK_DEAL_ID = '61f7a4edcf809301e78fbe41';
 
-describe('hasId', () => {
+describe('hasGiftFacilityId', () => {
   describe('when object has facilityId property', () => {
     it('should return true', () => {
       // Act
-      const result = hasId(mockGiftFacility);
+      const result = hasGiftFacilityId(mockGiftFacility);
 
       // Assert
       expect(result).toEqual(true);
@@ -21,7 +21,7 @@ describe('hasId', () => {
       const obj = { someOtherProperty: 'value' };
 
       // Act
-      const result = hasId(obj);
+      const result = hasGiftFacilityId(obj);
 
       // Assert
       expect(result).toEqual(false);
@@ -34,7 +34,7 @@ describe('hasId', () => {
       const obj = { facilityId: 12345 };
 
       // Act
-      const result = hasId(obj);
+      const result = hasGiftFacilityId(obj);
 
       // Assert
       expect(result).toEqual(true);
@@ -47,7 +47,7 @@ describe('hasId', () => {
       const obj = {};
 
       // Act
-      const result = hasId(obj);
+      const result = hasGiftFacilityId(obj);
 
       // Assert
       expect(result).toEqual(false);
@@ -56,9 +56,11 @@ describe('hasId', () => {
 });
 
 describe('mapFacilitiesToSendToGift', () => {
+  let consoleInfoSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(console, 'info').mockImplementation();
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation();
   });
 
   afterEach(() => {
@@ -66,7 +68,7 @@ describe('mapFacilitiesToSendToGift', () => {
   });
 
   describe('when GIFT facility lookup fails', () => {
-    it('should return all issued TFM facilities', () => {
+    it('should return no facilities to send and log both mapping and failure messages', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
       const giftFacilitiesResponse = false;
@@ -79,23 +81,13 @@ describe('mapFacilitiesToSendToGift', () => {
       });
 
       // Assert
-      expect(result.facilitiesToSendToApimGift).toEqual([]);
-    });
+      const expected = {
+        facilitiesToSendToApimGift: [],
+        facilityIds: [],
+      };
 
-    it('should log that facilities will not be submitted', () => {
-      // Arrange
-      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse = false;
-      const consoleInfoSpy = jest.spyOn(console, 'info');
-
-      // Act
-      mapFacilitiesToSendToGift({
-        dealId: MOCK_DEAL_ID,
-        giftFacilities: giftFacilitiesResponse,
-        issuedTfmFacilities: issuedFacilities,
-      });
-
-      // Assert
+      expect(result).toEqual(expected);
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(1, 'Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', MOCK_DEAL_ID);
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(
         2,
         'Failed to retrieve existing GIFT facilities for deal %s - no issued facilities will be submitted to APIM GIFT',
@@ -103,25 +95,37 @@ describe('mapFacilitiesToSendToGift', () => {
       );
     });
 
-    it('should return empty array when no issued facilities provided', () => {
-      // Arrange
-      const issuedFacilities: TfmFacility[] = [];
-      const giftFacilitiesResponse = false;
+    describe('when no issued facilities provided', () => {
+      it('should return empty array and log when no issued facilities provided', () => {
+        // Arrange
+        const issuedFacilities: TfmFacility[] = [];
+        const giftFacilitiesResponse = false;
 
-      // Act
-      const result = mapFacilitiesToSendToGift({
-        dealId: MOCK_DEAL_ID,
-        giftFacilities: giftFacilitiesResponse,
-        issuedTfmFacilities: issuedFacilities,
+        // Act
+        const result = mapFacilitiesToSendToGift({
+          dealId: MOCK_DEAL_ID,
+          giftFacilities: giftFacilitiesResponse,
+          issuedTfmFacilities: issuedFacilities,
+        });
+
+        // Assert
+        expect(result.facilitiesToSendToApimGift).toEqual([]);
+        expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+          1,
+          'Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT',
+          MOCK_DEAL_ID,
+        );
+        expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+          2,
+          'Failed to retrieve existing GIFT facilities for deal %s - no issued facilities will be submitted to APIM GIFT',
+          MOCK_DEAL_ID,
+        );
       });
-
-      // Assert
-      expect(result.facilitiesToSendToApimGift).toEqual([]);
     });
   });
 
   describe('when no facilities exist in GIFT', () => {
-    it('should return all issued TFM facilities', () => {
+    it('should return all issued TFM facilities and log mapping and all-can-submit messages', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
       const giftFacilitiesResponse: object[] = [];
@@ -135,11 +139,17 @@ describe('mapFacilitiesToSendToGift', () => {
 
       // Assert
       expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(1, 'Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', MOCK_DEAL_ID);
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+        2,
+        'No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT',
+        MOCK_DEAL_ID,
+      );
     });
   });
 
   describe('when all issued facilities exist in GIFT', () => {
-    it('should return an empty array', () => {
+    it('should return an empty array and log mapping and all-exist messages', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
       const giftFacilitiesResponse = [
@@ -156,25 +166,7 @@ describe('mapFacilitiesToSendToGift', () => {
 
       // Assert
       expect(result.facilitiesToSendToApimGift).toEqual([]);
-    });
-
-    it('should log that all facilities already exist in GIFT', () => {
-      // Arrange
-      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse = [
-        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) },
-        { ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId) },
-      ];
-      const consoleInfoSpy = jest.spyOn(console, 'info');
-
-      // Act
-      mapFacilitiesToSendToGift({
-        dealId: MOCK_DEAL_ID,
-        giftFacilities: giftFacilitiesResponse,
-        issuedTfmFacilities: issuedFacilities,
-      });
-
-      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(1, 'Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', MOCK_DEAL_ID);
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'All issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, [
         mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId,
         mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId,
@@ -183,7 +175,7 @@ describe('mapFacilitiesToSendToGift', () => {
   });
 
   describe('when some issued facilities exist in GIFT', () => {
-    it('should return only the facilities that do not exist in GIFT', () => {
+    it('should return only the facilities that do not exist in GIFT and log mapping, some-exist, and some-not-exist messages', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
       const giftFacilitiesResponse = [{ ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) }];
@@ -199,46 +191,22 @@ describe('mapFacilitiesToSendToGift', () => {
       const expected = [mockTfmIssuedFacility2, mockTfmIssuedFacility3];
 
       expect(result.facilitiesToSendToApimGift).toEqual(expected);
-    });
+      expect(result.facilityIds).toEqual([
+        String(mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId),
+        String(mockTfmIssuedFacility3.facilitySnapshot.ukefFacilityId),
+      ]);
 
-    it('should log facilities that exist in GIFT', () => {
-      // Arrange
-      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) }];
-      const consoleInfoSpy = jest.spyOn(console, 'info');
-
-      // Act
-      mapFacilitiesToSendToGift({
-        dealId: MOCK_DEAL_ID,
-        giftFacilities: giftFacilitiesResponse,
-        issuedTfmFacilities: issuedFacilities,
-      });
-
-      // Assert
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(1, 'Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', MOCK_DEAL_ID);
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'Some issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, [
         mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId,
       ]);
-    });
-
-    it('should log facilities that do not exist in GIFT', () => {
-      // Arrange
-      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ ...mockGiftFacility, facilityId: String(mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId) }];
-      const consoleInfoSpy = jest.spyOn(console, 'info');
-
-      // Act
-      mapFacilitiesToSendToGift({
-        dealId: MOCK_DEAL_ID,
-        giftFacilities: giftFacilitiesResponse,
-        issuedTfmFacilities: issuedFacilities,
-      });
-
-      // Assert
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(3, 'Some issued facilities for deal %s do not exist in GIFT: %o', MOCK_DEAL_ID, [
         mockTfmIssuedFacility2.facilitySnapshot.ukefFacilityId,
         mockTfmIssuedFacility3.facilitySnapshot.ukefFacilityId,
       ]);
     });
+
+    // (Redundant with above, merged into one test)
 
     it('should return correct facilities when multiple exist in GIFT', () => {
       // Arrange
@@ -262,47 +230,8 @@ describe('mapFacilitiesToSendToGift', () => {
     });
   });
 
-  describe('when giftFacilities is an empty array', () => {
-    it('should return all issued facilities', () => {
-      // Arrange
-      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse: object[] = [];
-
-      // Act
-      const result = mapFacilitiesToSendToGift({
-        dealId: MOCK_DEAL_ID,
-        giftFacilities: giftFacilitiesResponse,
-        issuedTfmFacilities: issuedFacilities,
-      });
-
-      // Assert
-      expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
-    });
-
-    it('should log that all facilities can be submitted', () => {
-      // Arrange
-      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse: object[] = [];
-      const consoleInfoSpy = jest.spyOn(console, 'info');
-
-      // Act
-      mapFacilitiesToSendToGift({
-        dealId: MOCK_DEAL_ID,
-        giftFacilities: giftFacilitiesResponse,
-        issuedTfmFacilities: issuedFacilities,
-      });
-
-      // Assert
-      expect(consoleInfoSpy).toHaveBeenNthCalledWith(
-        2,
-        'No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT',
-        MOCK_DEAL_ID,
-      );
-    });
-  });
-
   describe('when giftFacilities response has no facilityId property', () => {
-    it('should treat facilities without facilityId as not present', () => {
+    it('should treat facilities without facilityId as not present and log mapping and all-can-submit messages', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
       const giftFacilitiesResponse = [{ someOtherProperty: '0000000002' }, { anotherProperty: '0000000002' }];
@@ -316,14 +245,17 @@ describe('mapFacilitiesToSendToGift', () => {
 
       // Assert
       expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(1, 'Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', MOCK_DEAL_ID);
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(
+        2,
+        'No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT',
+        MOCK_DEAL_ID,
+      );
     });
   });
 
   describe('logging behavior', () => {
-    it('should always log the initial mapping message', () => {
-      // Arrange
-      const consoleInfoSpy = jest.spyOn(console, 'info');
-
+    it('should always log the initial mapping message, even for empty input', () => {
       // Act
       mapFacilitiesToSendToGift({
         dealId: MOCK_DEAL_ID,

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
@@ -206,8 +206,6 @@ describe('mapFacilitiesToSendToGift', () => {
       ]);
     });
 
-    // (Redundant with above, merged into one test)
-
     it('should return correct facilities when multiple exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
@@ -68,7 +68,7 @@ describe('mapFacilitiesToSendToGift', () => {
     jest.restoreAllMocks();
   });
 
-  describe('when no facilities exist in GIFT', () => {
+  describe('when GIFT facility lookup fails', () => {
     it('should return all issued TFM facilities', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
@@ -82,10 +82,10 @@ describe('mapFacilitiesToSendToGift', () => {
       });
 
       // Assert
-      expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
+      expect(result.facilitiesToSendToApimGift).toEqual([]);
     });
 
-    it('should log that all facilities can be submitted', () => {
+    it('should log that facilities will not be submitted', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
       const giftFacilitiesResponse = false;
@@ -101,7 +101,7 @@ describe('mapFacilitiesToSendToGift', () => {
       // Assert
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(
         2,
-        'No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT',
+        'Failed to retrieve existing GIFT facilities for deal %s - no issued facilities will be submitted to APIM GIFT',
         MOCK_DEAL_ID,
       );
     });
@@ -123,11 +123,29 @@ describe('mapFacilitiesToSendToGift', () => {
     });
   });
 
+  describe('when no facilities exist in GIFT', () => {
+    it('should return all issued TFM facilities', () => {
+      // Arrange
+      const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
+      const giftFacilitiesResponse: object[] = [];
+
+      // Act
+      const result = mapFacilitiesToSendToGift({
+        dealId: MOCK_DEAL_ID,
+        giftFacilities: giftFacilitiesResponse,
+        issuedTfmFacilities: issuedFacilities,
+      });
+
+      // Assert
+      expect(result.facilitiesToSendToApimGift).toEqual(issuedFacilities);
+    });
+  });
+
   describe('when all issued facilities exist in GIFT', () => {
     it('should return an empty array', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-002' }];
+      const giftFacilitiesResponse = [{ facilityId: '0000000001' }, { facilityId: '0000000002' }];
 
       // Act
       const result = mapFacilitiesToSendToGift({
@@ -143,7 +161,7 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should log that all facilities already exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-002' }];
+      const giftFacilitiesResponse = [{ facilityId: '0000000001' }, { facilityId: '0000000002' }];
       const consoleInfoSpy = jest.spyOn(console, 'info');
 
       // Act
@@ -155,8 +173,8 @@ describe('mapFacilitiesToSendToGift', () => {
 
       // Assert
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'All issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, [
-        'FACILITY-001',
-        'FACILITY-002',
+        '0000000001',
+        '0000000002',
       ]);
     });
   });
@@ -165,7 +183,7 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should return only the facilities that do not exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }];
+      const giftFacilitiesResponse = [{ facilityId: '0000000001' }];
 
       // Act
       const result = mapFacilitiesToSendToGift({
@@ -183,7 +201,7 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should log facilities that exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }];
+      const giftFacilitiesResponse = [{ facilityId: '0000000001' }];
       const consoleInfoSpy = jest.spyOn(console, 'info');
 
       // Act
@@ -194,13 +212,13 @@ describe('mapFacilitiesToSendToGift', () => {
       });
 
       // Assert
-      expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'Some issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, ['FACILITY-001']);
+      expect(consoleInfoSpy).toHaveBeenNthCalledWith(2, 'Some issued facilities for deal %s already exist in GIFT: %o', MOCK_DEAL_ID, ['0000000001']);
     });
 
     it('should log facilities that do not exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }];
+      const giftFacilitiesResponse = [{ facilityId: '0000000001' }];
       const consoleInfoSpy = jest.spyOn(console, 'info');
 
       // Act
@@ -212,15 +230,15 @@ describe('mapFacilitiesToSendToGift', () => {
 
       // Assert
       expect(consoleInfoSpy).toHaveBeenNthCalledWith(3, 'Some issued facilities for deal %s do not exist in GIFT: %o', MOCK_DEAL_ID, [
-        'FACILITY-002',
-        'FACILITY-003',
+        '0000000002',
+        '0000000003',
       ]);
     });
 
     it('should return correct facilities when multiple exist in GIFT', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2, mockTfmIssuedFacility3];
-      const giftFacilitiesResponse = [{ facilityId: 'FACILITY-001' }, { facilityId: 'FACILITY-003' }];
+      const giftFacilitiesResponse = [{ facilityId: '0000000001' }, { facilityId: '0000000003' }];
 
       // Act
       const result = mapFacilitiesToSendToGift({
@@ -301,7 +319,7 @@ describe('mapFacilitiesToSendToGift', () => {
       // Act
       mapFacilitiesToSendToGift({
         dealId: MOCK_DEAL_ID,
-        giftFacilities: false,
+        giftFacilities: [],
         issuedTfmFacilities: [],
       });
 

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.test.ts
@@ -305,7 +305,7 @@ describe('mapFacilitiesToSendToGift', () => {
     it('should treat facilities without facilityId as not present', () => {
       // Arrange
       const issuedFacilities = [mockTfmIssuedFacility1, mockTfmIssuedFacility2];
-      const giftFacilitiesResponse = [{ someOtherProperty: 'FACILITY-001' }, { anotherProperty: 'FACILITY-002' }];
+      const giftFacilitiesResponse = [{ someOtherProperty: '0000000002' }, { anotherProperty: '0000000002' }];
 
       // Act
       const result = mapFacilitiesToSendToGift({

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.ts
@@ -8,6 +8,7 @@ type MapFacilitiesToSendToGiftParams = {
 
 type MapFacilitiesToSendToGiftReturnShape = {
   facilitiesToSendToApimGift: TfmFacility[];
+  facilityIds?: string[];
 };
 
 type GiftFacility = {
@@ -15,11 +16,11 @@ type GiftFacility = {
 };
 
 /**
- * Type guard to check if an object is a GiftFacility.
+ * Type guard to check if an object is a GiftFacility / has a GIFT facilityId property.
  * @param facility - The object to check.
  * @returns True if the object has a facilityId property, false otherwise.
  */
-export const hasId = (facility: object): facility is GiftFacility => 'facilityId' in facility;
+export const hasGiftFacilityId = (facility: object): facility is GiftFacility => 'facilityId' in facility;
 
 /**
  * Map issued TFM facilities to determine which can be sent to APIM GIFT based on whether they already exist in GIFT.
@@ -41,10 +42,11 @@ export const mapFacilitiesToSendToGift = ({
 
     return {
       facilitiesToSendToApimGift: [],
+      facilityIds: [],
     };
   }
 
-  const giftFacilityIds = new Set(giftFacilities.filter(hasId).map((facility) => String(facility.facilityId)));
+  const giftFacilityIds = new Set(giftFacilities.filter(hasGiftFacilityId).map((facility) => String(facility.facilityId)));
 
   if (giftFacilityIds.size === 0) {
     console.info('No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT', dealId);
@@ -62,13 +64,14 @@ export const mapFacilitiesToSendToGift = ({
   const facilitiesNotInGift = issuedTfmFacilities.filter(({ facilitySnapshot: { ukefFacilityId } }) => !giftFacilityIds.has(String(ukefFacilityId)));
 
   const facilitiesInGiftIds = facilitiesInGift.map((facility) => facility.facilitySnapshot.ukefFacilityId);
-  const facilitiesNotInGiftIds = facilitiesNotInGift.map((facility) => facility.facilitySnapshot.ukefFacilityId);
+  const facilitiesNotInGiftIds = facilitiesNotInGift.map((facility) => String(facility.facilitySnapshot.ukefFacilityId));
 
   if (facilitiesInGiftIds.length === issuedTfmFacilities.length) {
     console.info('All issued facilities for deal %s already exist in GIFT: %o', dealId, facilitiesInGiftIds);
 
     return {
       facilitiesToSendToApimGift: [],
+      facilityIds: [],
     };
   }
 
@@ -80,5 +83,6 @@ export const mapFacilitiesToSendToGift = ({
 
   return {
     facilitiesToSendToApimGift: facilitiesNotInGift,
+    facilityIds: facilitiesNotInGiftIds,
   };
 };

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.ts
@@ -1,0 +1,76 @@
+import { TfmFacility } from '@ukef/dtfs2-common';
+
+type MapFacilitiesToSendToGiftParams = {
+  dealId: string;
+  giftFacilities: object[] | false;
+  issuedTfmFacilities: TfmFacility[];
+};
+
+type MapFacilitiesToSendToGiftReturnShape = {
+  facilitiesToSendToApimGift: TfmFacility[];
+};
+
+type GiftFacility = {
+  facilityId: string;
+};
+
+/**
+ * Type guard to check if an object is a GiftFacility.
+ * @param facility - The object to check.
+ * @returns True if the object has a facilityId property, false otherwise.
+ */
+export const hasId = (facility: object): facility is GiftFacility => 'facilityId' in facility;
+
+/**
+ * Map issued TFM facilities to determine which can be sent to APIM GIFT based on whether they already exist in GIFT.
+ * @param {MapFacilitiesToSendToGiftParams} params - An object containing the deal ID, facilities found in GIFT, and issued TFM facilities.
+ * @param {string} params.dealId - The ID of the deal for logging purposes.
+ * @param {object[] | false} params.giftFacilities - The facilities found in GIFT for the deal, or false if the GIFT lookup failed.
+ * @param {TfmFacility[]} params.issuedTfmFacilities - The issued TFM facilities for the deal.
+ * @returns {MapFacilitiesToSendToGiftReturnShape} An object containing the facilities that can be sent to APIM GIFT (i.e., those that do not already exist in GIFT).
+ */
+export const mapFacilitiesToSendToGift = ({
+  dealId,
+  giftFacilities,
+  issuedTfmFacilities,
+}: MapFacilitiesToSendToGiftParams): MapFacilitiesToSendToGiftReturnShape => {
+  console.info('Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', dealId);
+
+  const giftFacilityIds = new Set(Array.isArray(giftFacilities) ? giftFacilities.filter(hasId).map((facility) => String(facility.facilityId)) : []);
+
+  if (giftFacilityIds.size === 0) {
+    console.info('No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT', dealId);
+
+    return {
+      facilitiesToSendToApimGift: issuedTfmFacilities,
+    };
+  }
+
+  /**
+   * Some GIFT facilities found with the provided IDs.
+   * Only facilities that are NOT in GIFT can be sent to APIM GIFT.
+   */
+  const facilitiesInGift = issuedTfmFacilities.filter(({ facilitySnapshot: { ukefFacilityId } }) => giftFacilityIds.has(String(ukefFacilityId)));
+  const facilitiesNotInGift = issuedTfmFacilities.filter(({ facilitySnapshot: { ukefFacilityId } }) => !giftFacilityIds.has(String(ukefFacilityId)));
+
+  const facilitiesInGiftIds = facilitiesInGift.map((facility) => facility.facilitySnapshot.ukefFacilityId);
+  const facilitiesNotInGiftIds = facilitiesNotInGift.map((facility) => facility.facilitySnapshot.ukefFacilityId);
+
+  if (facilitiesInGiftIds.length === issuedTfmFacilities.length) {
+    console.info('All issued facilities for deal %s already exist in GIFT: %o', dealId, facilitiesInGiftIds);
+
+    return {
+      facilitiesToSendToApimGift: [],
+    };
+  }
+
+  console.info('Some issued facilities for deal %s already exist in GIFT: %o', dealId, facilitiesInGiftIds);
+
+  if (facilitiesNotInGiftIds.length) {
+    console.info('Some issued facilities for deal %s do not exist in GIFT: %o', dealId, facilitiesNotInGiftIds);
+  }
+
+  return {
+    facilitiesToSendToApimGift: facilitiesNotInGift,
+  };
+};

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/map-facilities-to-send-to-gift/index.ts
@@ -36,7 +36,15 @@ export const mapFacilitiesToSendToGift = ({
 }: MapFacilitiesToSendToGiftParams): MapFacilitiesToSendToGiftReturnShape => {
   console.info('Mapping issued facilities for deal %s to determine if any should be sent to APIM GIFT', dealId);
 
-  const giftFacilityIds = new Set(Array.isArray(giftFacilities) ? giftFacilities.filter(hasId).map((facility) => String(facility.facilityId)) : []);
+  if (giftFacilities === false) {
+    console.info('Failed to retrieve existing GIFT facilities for deal %s - no issued facilities will be submitted to APIM GIFT', dealId);
+
+    return {
+      facilitiesToSendToApimGift: [],
+    };
+  }
+
+  const giftFacilityIds = new Set(giftFacilities.filter(hasId).map((facility) => String(facility.facilityId)));
 
   if (giftFacilityIds.size === 0) {
     console.info('No facilities found in APIM GIFT for deal %s - all issued facilities can be submitted to APIM GIFT', dealId);

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/test-mocks/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/test-mocks/index.ts
@@ -1,0 +1,68 @@
+import { ObjectId } from 'bson';
+import { TfmFacility, DEAL_SUBMISSION_TYPE, DEAL_TYPE, TfmDeal } from '@ukef/dtfs2-common';
+import MOCK_TFM_DEAL_AIN_SUBMITTED from '../../../__mocks__/mock-TFM-deal-AIN-submitted';
+
+const mockBaseDeal = MOCK_TFM_DEAL_AIN_SUBMITTED as unknown as TfmDeal;
+
+const mockTfmObject = {
+  parties: {
+    buyer: {
+      partyUrn: 'Mock party URN',
+    },
+  },
+  exporterCreditRating: 'Acceptable (B+)',
+};
+
+export const mockTfmDeal = {
+  ...mockBaseDeal,
+  dealSnapshot: {
+    ...mockBaseDeal.dealSnapshot,
+    dealType: DEAL_TYPE.BSS_EWCS,
+    submissionType: DEAL_SUBMISSION_TYPE.AIN,
+  },
+  tfm: mockTfmObject,
+} as TfmDeal;
+
+export const mockTfmIssuedFacility1 = {
+  _id: new ObjectId('61f7a4edcf809301e78fbe53'),
+  facilitySnapshot: {
+    ukefFacilityId: 'FACILITY-001',
+    hasBeenIssued: true,
+  },
+  tfm: {},
+} as unknown as TfmFacility;
+
+export const mockTfmIssuedFacility2 = {
+  _id: new ObjectId('61f7a4edcf809301e78fbe54'),
+  facilitySnapshot: {
+    ukefFacilityId: 'FACILITY-002',
+    hasBeenIssued: true,
+  },
+  tfm: {},
+} as unknown as TfmFacility;
+
+export const mockTfmIssuedFacility3 = {
+  _id: new ObjectId('61f7a4edcf809301e78fbe55'),
+  facilitySnapshot: {
+    ukefFacilityId: 'FACILITY-003',
+    hasBeenIssued: true,
+  },
+  tfm: {},
+} as unknown as TfmFacility;
+
+export const mockTfmIssuedFacility4 = {
+  _id: new ObjectId('61f7a4edcf809301e78fbe56'),
+  facilitySnapshot: {
+    ukefFacilityId: '0030012345',
+    hasBeenIssued: true,
+  },
+  tfm: {},
+} as unknown as TfmFacility;
+
+export const mockUnissuedFacility = {
+  _id: '61f7a4edcf809301e78fbe55',
+  facilitySnapshot: {
+    ukefFacilityId: 'FACILITY-003',
+    hasBeenIssued: false,
+  },
+} as unknown as TfmFacility;

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/test-mocks/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/test-mocks/index.ts
@@ -24,36 +24,36 @@ export const mockTfmDeal = {
 } as TfmDeal;
 
 export const mockTfmIssuedFacility1 = {
-  _id: new ObjectId('61f7a4edcf809301e78fbe53'),
+  _id: new ObjectId('61f7a4edcf809301e78fbe51'),
   facilitySnapshot: {
-    ukefFacilityId: 'FACILITY-001',
+    ukefFacilityId: '0000000001',
     hasBeenIssued: true,
   },
   tfm: {},
 } as unknown as TfmFacility;
 
 export const mockTfmIssuedFacility2 = {
-  _id: new ObjectId('61f7a4edcf809301e78fbe54'),
+  _id: new ObjectId('61f7a4edcf809301e78fbe52'),
   facilitySnapshot: {
-    ukefFacilityId: 'FACILITY-002',
+    ukefFacilityId: '0000000002',
     hasBeenIssued: true,
   },
   tfm: {},
 } as unknown as TfmFacility;
 
 export const mockTfmIssuedFacility3 = {
-  _id: new ObjectId('61f7a4edcf809301e78fbe55'),
+  _id: new ObjectId('61f7a4edcf809301e78fbe53'),
   facilitySnapshot: {
-    ukefFacilityId: 'FACILITY-003',
+    ukefFacilityId: '0000000003',
     hasBeenIssued: true,
   },
   tfm: {},
 } as unknown as TfmFacility;
 
 export const mockTfmIssuedFacility4 = {
-  _id: new ObjectId('61f7a4edcf809301e78fbe56'),
+  _id: new ObjectId('61f7a4edcf809301e78fbe54'),
   facilitySnapshot: {
-    ukefFacilityId: '0030012345',
+    ukefFacilityId: '0000000004',
     hasBeenIssued: true,
   },
   tfm: {},
@@ -62,7 +62,7 @@ export const mockTfmIssuedFacility4 = {
 export const mockUnissuedFacility = {
   _id: '61f7a4edcf809301e78fbe55',
   facilitySnapshot: {
-    ukefFacilityId: 'FACILITY-003',
+    ukefFacilityId: '0000000005',
     hasBeenIssued: false,
   },
 } as unknown as TfmFacility;

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/test-mocks/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/test-mocks/index.ts
@@ -66,3 +66,16 @@ export const mockUnissuedFacility = {
     hasBeenIssued: false,
   },
 } as unknown as TfmFacility;
+
+export const mockGiftFacility = {
+  amount: 10000,
+  creditType: 'Term',
+  currency: 'USD',
+  effectiveDate: '2025-01-01',
+  expiryDate: '2027-02-01',
+  facilityId: '0030000322',
+  name: 'Amazing facility',
+  obligorUrn: '01234567',
+  productTypeCode: 'PRT003',
+  repaymentType: 'Scheduled',
+};

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
@@ -7,10 +7,14 @@ type FindFacilitiesByDealIdErrorResponse = {
   data: unknown;
 };
 
+type FindGiftFacilitiesByIdSuccessResponse = {
+  facilities: object[];
+};
+
 export type ApiTypes = {
   createGiftFacility: (facility: ApimGiftFacilityCreationPayload) => Promise<TfmFacility> | false;
   findFacilitiesByDealId: (dealId: string) => Promise<TfmFacility[] | FindFacilitiesByDealIdErrorResponse>;
-  findGiftFacilitiesById: (facilityIdsQueryString: string) => Promise<TfmFacility[] | false>;
+  findGiftFacilitiesByIds: (facilityIdsQueryString: string) => Promise<FindGiftFacilitiesByIdSuccessResponse | false>;
   getCreditRiskRatings: () => Promise<CreditRiskRating[]> | false;
   getFacilityCategories: () => Promise<FacilityCategory[]> | false;
 };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
@@ -10,6 +10,7 @@ type FindFacilitiesByDealIdErrorResponse = {
 export type ApiTypes = {
   createGiftFacility: (facility: ApimGiftFacilityCreationPayload) => Promise<TfmFacility> | false;
   findFacilitiesByDealId: (dealId: string) => Promise<TfmFacility[] | FindFacilitiesByDealIdErrorResponse>;
+  findGiftFacilitiesById: (facilityIds: string) => Promise<object[] | false>;
   getCreditRiskRatings: () => Promise<CreditRiskRating[]> | false;
   getFacilityCategories: () => Promise<FacilityCategory[]> | false;
 };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
@@ -10,7 +10,7 @@ type FindFacilitiesByDealIdErrorResponse = {
 export type ApiTypes = {
   createGiftFacility: (facility: ApimGiftFacilityCreationPayload) => Promise<TfmFacility> | false;
   findFacilitiesByDealId: (dealId: string) => Promise<TfmFacility[] | FindFacilitiesByDealIdErrorResponse>;
-  findGiftFacilitiesById: (facilityIds: string) => Promise<TfmFacility[] | false>;
+  findGiftFacilitiesById: (facilityIdsQueryString: string) => Promise<TfmFacility[] | false>;
   getCreditRiskRatings: () => Promise<CreditRiskRating[]> | false;
   getFacilityCategories: () => Promise<FacilityCategory[]> | false;
 };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/api.ts
@@ -10,7 +10,7 @@ type FindFacilitiesByDealIdErrorResponse = {
 export type ApiTypes = {
   createGiftFacility: (facility: ApimGiftFacilityCreationPayload) => Promise<TfmFacility> | false;
   findFacilitiesByDealId: (dealId: string) => Promise<TfmFacility[] | FindFacilitiesByDealIdErrorResponse>;
-  findGiftFacilitiesById: (facilityIds: string) => Promise<object[] | false>;
+  findGiftFacilitiesById: (facilityIds: string) => Promise<TfmFacility[] | false>;
   getCreditRiskRatings: () => Promise<CreditRiskRating[]> | false;
   getFacilityCategories: () => Promise<FacilityCategory[]> | false;
 };


### PR DESCRIPTION
# Introduction :pencil2:

DTFS should only send requests to APIM TFS, to create issued GIFT facilities, if the facilities do not already exist in GIFT.

This PR introduces that check.

## Resolution :heavy_check_mark:

- External API:
  - Create new endpoint, controller `GET /facilities?ids=123,456`
  - Update swagger definitions
  - Add/update tests.
- TFM API:
  - Add new `api.js` method to call the new External API endpoint, `findGiftFacilitiesById`.
  - Create new helpers/mappers:
    - `generateIssuedFacilitiesQueryString`
    - `mapFacilitiesToSendToGift`
  - Update `canSubmitToApimGift` to call `api.findGiftFacilitiesById` and `mapFacilitiesToSendToGift`
- Add/update API tests.

## Miscellaneous :heavy_plus_sign:

- Various renaming, test improvements.
- Various logging improvements.
- Update `canSubmitToApimGift` to have a `dealId` const. Move a condition to the top for improved readability.
- Create some DRY test mocks for APIM GIFT integration.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
