### PR TITLE
chore(DTFS2-8432): acbs amendment condition, readability, documentation improvements

### DIFF
--- a/dtfs-central-api/server/services/portal/facility-amendment.service.ts
+++ b/dtfs-central-api/server/services/portal/facility-amendment.service.ts
@@ -53,11 +53,11 @@ export class PortalFacilityAmendmentService {
   /**
    * Upserts the portal amendment draft on a facility
    *
-   * @param updateStatusParams
-   * @param updateStatusParams.dealId - the deal Id the facility exists on
-   * @param updateStatusParams.facilityId - the facility Id the amendment is for
-   * @param updateStatusParams.amendment - the amendment to upsert
-   * @param updateStatusParams.auditDetails - the users audit details
+   * @param params
+   * @param params.dealId - the deal Id the facility exists on
+   * @param params.facilityId - the facility Id the amendment is for
+   * @param params.amendment - the amendment to upsert
+   * @param params.auditDetails - the users audit details
    */
   public static async upsertPortalFacilityAmendmentDraft({
     dealId,

--- a/gef-ui/templates/includes/application-preview/application-sub-navigation.njk
+++ b/gef-ui/templates/includes/application-preview/application-sub-navigation.njk
@@ -1,4 +1,4 @@
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 
 {% set applicationNotice = 
    {
@@ -34,9 +34,9 @@
 %}
 
 {% if isPortalAmendmentsFeatureFlagEnabled %}
-   {% set items = [applicationNotice, amendments, activity] %}
+  {% set items = [applicationNotice, amendments, activity] %}
 {% else %}
-   {% set items = [applicationNotice, activity] %}
+  {% set items = [applicationNotice, activity] %}
 {% endif %}
 
   <div class="govuk-grid-row">
@@ -46,7 +46,7 @@
          items: items,
          attributes: {
           'data-cy': 'application-preview-sub-navigation'
-        }
-         }) }}
+         }
+      }) }}
     </div>
   </div>

--- a/libs/common/src/helpers/can-submit-to-acbs.test.ts
+++ b/libs/common/src/helpers/can-submit-to-acbs.test.ts
@@ -238,7 +238,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment, true);
+        const response = canSendToAcbs({ amendment: mockAmendment, isTaskUpdate: true });
 
         // Assert
         expect(response).toBeFalsy();

--- a/libs/common/src/helpers/can-submit-to-acbs.test.ts
+++ b/libs/common/src/helpers/can-submit-to-acbs.test.ts
@@ -13,7 +13,7 @@ describe('canSendToAcbs', () => {
         } as PortalFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -27,7 +27,7 @@ describe('canSendToAcbs', () => {
         } as PortalFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -42,7 +42,7 @@ describe('canSendToAcbs', () => {
         } as PortalFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -64,7 +64,7 @@ describe('canSendToAcbs', () => {
         } as PortalFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -83,7 +83,7 @@ describe('canSendToAcbs', () => {
         } as PortalFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -104,7 +104,7 @@ describe('canSendToAcbs', () => {
         } as PortalFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeTruthy();
@@ -125,7 +125,7 @@ describe('canSendToAcbs', () => {
         } as PortalFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeTruthy();
@@ -141,7 +141,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -155,7 +155,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -170,7 +170,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -188,7 +188,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -204,7 +204,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -221,7 +221,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -255,7 +255,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeTruthy();
@@ -272,7 +272,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeTruthy();
@@ -400,7 +400,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeFalsy();
@@ -464,7 +464,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment);
+        const response = canSendToAcbs({ amendment: mockAmendment });
 
         // Assert
         expect(response).toBeTruthy();
@@ -477,7 +477,7 @@ describe('canSendToAcbs', () => {
         } as TfmFacilityAmendmentWithUkefId;
 
         // Act
-        const response = canSendToAcbs(mockAmendment, true);
+        const response = canSendToAcbs({ amendment: mockAmendment, isTaskUpdate: true });
 
         // Assert
         expect(response).toBeFalsy();

--- a/libs/common/src/helpers/can-submit-to-acbs.ts
+++ b/libs/common/src/helpers/can-submit-to-acbs.ts
@@ -32,7 +32,7 @@ export const canSendToAcbs = ({ amendment, isTaskUpdate = false }: CanSendToAcbs
   // Amendment type
   const isPortalAmendment = amendment.type === AMENDMENT_TYPES.PORTAL;
 
-  // Ensure at least one of the attribute has been amended
+  // Ensure at least one of the attributes has been amended
   const hasBeenAmended = amendment.changeCoverEndDate || amendment.changeFacilityValue;
 
   /**
@@ -54,7 +54,7 @@ export const canSendToAcbs = ({ amendment, isTaskUpdate = false }: CanSendToAcbs
 
   // Manual amendment - TFM only
   if (isAmendmentManual && !isPortalAmendment) {
-    // Bank Decision
+    // Bank decision
     const submitted = amendment.bankDecision?.submitted;
     const decision = amendment.bankDecision?.decision;
 

--- a/libs/common/src/helpers/can-submit-to-acbs.ts
+++ b/libs/common/src/helpers/can-submit-to-acbs.ts
@@ -2,6 +2,11 @@ import { AMENDMENT_TYPES, AMENDMENT_BANK_DECISION, TFM_AMENDMENT_STATUS, PORTAL_
 import { PortalFacilityAmendmentWithUkefId, TfmFacilityAmendmentWithUkefId } from '../types';
 import { isAmendmentDeclined } from './is-amendment-declined';
 
+type CanSendToAcbsParams = {
+  amendment: PortalFacilityAmendmentWithUkefId | TfmFacilityAmendmentWithUkefId;
+  isTaskUpdate?: boolean;
+};
+
 /**
  * Determines if an amendment can be sent to ACBS based on its type, status, user involvement, and amendment details.
  *
@@ -19,10 +24,10 @@ import { isAmendmentDeclined } from './is-amendment-declined';
  * If the amendment update is part of a task update, it should not be sent to ACBS, hence the `isTaskUpdate` flag is used to prevent that.
  *
  * @param amendment - The amendment object, either PortalFacilityAmendmentWithUkefId or TfmFacilityAmendmentWithUkefId.
- * @param isTaskUpdate - Optional flag indicating if the amendment update is part of a task update.
+ * @param isTaskUpdate - Optional flag indicating if the amendment update is part of a task update. Defaults to false.
  * @returns `true` if the amendment meets all criteria to be sent to ACBS, otherwise `false`.
  */
-export const canSendToAcbs = (amendment: PortalFacilityAmendmentWithUkefId | TfmFacilityAmendmentWithUkefId, isTaskUpdate = false) => {
+export const canSendToAcbs = ({ amendment, isTaskUpdate = false }: CanSendToAcbsParams) => {
   // Amendment type
   const isPortalAmendment = amendment.type === AMENDMENT_TYPES.PORTAL;
 

--- a/libs/common/src/helpers/can-submit-to-acbs.ts
+++ b/libs/common/src/helpers/can-submit-to-acbs.ts
@@ -26,7 +26,7 @@ type CanSendToAcbsParams = {
  * @param params - An object containing the amendment and an optional flag for task updates.
  * @param params.amendment - The amendment object, either PortalFacilityAmendmentWithUkefId or TfmFacilityAmendmentWithUkefId.
  * @param params.isTaskUpdate - Optional flag indicating if the amendment update is part of a task update. Defaults to false.
- * @returns {Boolean} `true` if the amendment meets all criteria to be sent to ACBS, otherwise `false`.
+ * @returns {boolean} `true` if the amendment meets all criteria to be sent to ACBS, otherwise `false`.
  */
 export const canSendToAcbs = ({ amendment, isTaskUpdate = false }: CanSendToAcbsParams) => {
   // Amendment type

--- a/libs/common/src/helpers/can-submit-to-acbs.ts
+++ b/libs/common/src/helpers/can-submit-to-acbs.ts
@@ -23,9 +23,10 @@ type CanSendToAcbsParams = {
  *
  * If the amendment update is part of a task update, it should not be sent to ACBS, hence the `isTaskUpdate` flag is used to prevent that.
  *
- * @param amendment - The amendment object, either PortalFacilityAmendmentWithUkefId or TfmFacilityAmendmentWithUkefId.
- * @param isTaskUpdate - Optional flag indicating if the amendment update is part of a task update. Defaults to false.
- * @returns `true` if the amendment meets all criteria to be sent to ACBS, otherwise `false`.
+ * @param params - An object containing the amendment and an optional flag for task updates.
+ * @param params.amendment - The amendment object, either PortalFacilityAmendmentWithUkefId or TfmFacilityAmendmentWithUkefId.
+ * @param params.isTaskUpdate - Optional flag indicating if the amendment update is part of a task update. Defaults to false.
+ * @returns {Boolean} `true` if the amendment meets all criteria to be sent to ACBS, otherwise `false`.
  */
 export const canSendToAcbs = ({ amendment, isTaskUpdate = false }: CanSendToAcbsParams) => {
   // Amendment type

--- a/portal-ui/templates/_macros/dashboard-sub-nav.njk
+++ b/portal-ui/templates/_macros/dashboard-sub-nav.njk
@@ -1,4 +1,4 @@
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 
 {% macro render(params) %}
 

--- a/portal-ui/templates/contract/components/contract-tabs.njk
+++ b/portal-ui/templates/contract/components/contract-tabs.njk
@@ -1,4 +1,4 @@
-{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 
 {% macro render(params) %}
   {% set id = params.deal._id %}

--- a/portal-ui/templates/utilisation-report-service/previous-reports/_macros/report-reconciliation-status.njk
+++ b/portal-ui/templates/utilisation-report-service/previous-reports/_macros/report-reconciliation-status.njk
@@ -1,4 +1,5 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
 {% macro render(params) %}
   {% set status = params.status %}
   {% set displayStatus = params.displayStatus %}
@@ -11,5 +12,5 @@
     attributes: {
     'data-cy': 'utilisation-report-reconciliation-status'
     }
-    }) }}
+  }) }}
 {% endmacro %}

--- a/portal-ui/templates/utilisation-report-service/previous-reports/_macros/report-reconciliation-status.njk
+++ b/portal-ui/templates/utilisation-report-service/previous-reports/_macros/report-reconciliation-status.njk
@@ -10,7 +10,7 @@
     text: displayStatus,
     classes: tagColourClass,
     attributes: {
-    'data-cy': 'utilisation-report-reconciliation-status'
+      'data-cy': 'utilisation-report-reconciliation-status'
     }
   }) }}
 {% endmacro %}

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -161,7 +161,7 @@ describe('updated facility amendment API call', () => {
       );
 
       expect(canSendToAcbs).toHaveBeenCalledTimes(1);
-      expect(canSendToAcbs).toHaveBeenCalledWith(MOCK_AMENDMENT, false);
+      expect(canSendToAcbs).toHaveBeenCalledWith({ amendment: MOCK_AMENDMENT, isTaskUpdate: false });
     });
   });
 
@@ -204,7 +204,7 @@ describe('updated facility amendment API call', () => {
 
         // Assert
         expect(canSendToAcbs).toHaveBeenCalledTimes(1);
-        expect(canSendToAcbs).toHaveBeenCalledWith(MOCK_AMENDMENT, true);
+        expect(canSendToAcbs).toHaveBeenCalledWith({ amendment: MOCK_AMENDMENT, isTaskUpdate: true });
       });
     });
 
@@ -236,7 +236,7 @@ describe('updated facility amendment API call', () => {
 
         // Assert
         expect(canSendToAcbs).toHaveBeenCalledTimes(1);
-        expect(canSendToAcbs).toHaveBeenCalledWith(MOCK_AMENDMENT, true);
+        expect(canSendToAcbs).toHaveBeenCalledWith({ amendment: MOCK_AMENDMENT, isTaskUpdate: true });
       });
     });
 
@@ -254,7 +254,7 @@ describe('updated facility amendment API call', () => {
 
         // Assert
         expect(canSendToAcbs).toHaveBeenCalledTimes(1);
-        expect(canSendToAcbs).toHaveBeenCalledWith(MOCK_AMENDMENT, false);
+        expect(canSendToAcbs).toHaveBeenCalledWith({ amendment: MOCK_AMENDMENT, isTaskUpdate: false });
       });
     });
   });

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -31,6 +31,7 @@ const {
   MOCK_TASKS,
   TASKS_UPDATE_MOCK_REQUEST,
 } = require('../__mocks__/mock-amendment-tasks-assign-by-team');
+
 const { MOCK_FACILITIES } = require('../__mocks__/mock-facilities');
 const { MOCK_BSS_EWCS_DEAL } = require('../__mocks__/mock-deal');
 
@@ -81,6 +82,7 @@ afterEach(() => {
 describe('updated facility amendment API call', () => {
   let getTasksAssignedToUserByGroupMock;
 
+  // TODO: extract into own file/test?
   describe('getTasksAssignedToUserByGroup', () => {
     it('should call getTasksAssignedToUserByGroup if request contains leadUnderwriter', async () => {
       // Arrange

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -405,11 +405,11 @@ const updateFacilityAmendment = async (req, res) => {
         // Amend facility TFM properties
         await amendIssuedFacility(amendment, facility, tfmDeal, generateTfmAuditDetails(req.user._id));
 
-        // Amendment email notification to PDC
-        await internalAmendmentEmail(ukefFacilityId);
-
         // Submit to ACBS
         if (canSendToAcbs({ amendment, isTaskUpdate })) {
+          // Amendment email notification to PDC
+          await internalAmendmentEmail(ukefFacilityId);
+
           // Amend facility ACBS records
           acbs.amendAcbsFacility(amendment, facility, deal);
         }
@@ -479,12 +479,11 @@ const sendAmendmentToAcbs = async (req, res) => {
         };
       }
 
-      // Amendment null & property existence check
       if (facility._id && amendment && tfmDeal.tfm) {
-        // Amendment email notification to PDC
-        await internalAmendmentEmail(ukefFacilityId);
-
         if (canSendToAcbs({ amendment })) {
+          // Amendment email notification to PDC
+          await internalAmendmentEmail(ukefFacilityId);
+
           // Amend facility ACBS records
           acbs.amendAcbsFacility(amendment, facility, deal);
         }

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -243,6 +243,7 @@ const updateFacilityAmendment = async (req, res) => {
 
   // set to true if payload contains updateTfmLastUpdated else null
   const tfmLastUpdated = payload.updateTfmLastUpdated;
+
   // default isTaskUpdate to false, set to true if payload contains taskUpdate.updateTask
   let isTaskUpdate = false;
 
@@ -335,14 +336,14 @@ const updateFacilityAmendment = async (req, res) => {
 
       // Amendment null & property existence check
       if (facility._id && amendment && tfmDeal.tfm) {
-        // TFM Facility update + ACBS Interaction
-        if (canSendToAcbs(amendment, isTaskUpdate)) {
-          // Amend facility TFM properties
-          await amendIssuedFacility(amendment, facility, tfmDeal, generateTfmAuditDetails(req.user._id));
+        // Amend facility TFM properties
+        await amendIssuedFacility(amendment, facility, tfmDeal, generateTfmAuditDetails(req.user._id));
 
-          // Amendment email notification to PDC
-          await internalAmendmentEmail(ukefFacilityId);
+        // Amendment email notification to PDC
+        await internalAmendmentEmail(ukefFacilityId);
 
+        // Submit to ACBS
+        if (canSendToAcbs({ amendment, isTaskUpdate })) {
           // Amend facility ACBS records
           acbs.amendAcbsFacility(amendment, facility, deal);
         }
@@ -384,7 +385,7 @@ const sendAmendmentToAcbs = async (req, res) => {
     if (amendmentId && facilityId) {
       let amendment = await api.getAmendmentById(facilityId, amendmentId);
 
-      // Fetch facility object
+      // Fetch facility
       const facility = await api.findOneFacility(facilityId);
       const { ukefFacilityId } = facility.facilitySnapshot;
 
@@ -413,10 +414,10 @@ const sendAmendmentToAcbs = async (req, res) => {
 
       // Amendment null & property existence check
       if (facility._id && amendment && tfmDeal.tfm) {
-        // TFM Facility update + ACBS Interaction
-        if (canSendToAcbs(amendment)) {
-          // Amendment email notification to PDC
-          await internalAmendmentEmail(ukefFacilityId);
+        // Amendment email notification to PDC
+        await internalAmendmentEmail(ukefFacilityId);
+
+        if (canSendToAcbs({ amendment })) {
           // Amend facility ACBS records
           acbs.amendAcbsFacility(amendment, facility, deal);
         }

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -22,6 +22,14 @@ const {
 } = require('../helpers/amendment.helpers');
 const CONSTANTS = require('../../constants');
 
+/**
+ * Sends amendment-related notification emails when eligible.
+ *
+ * @param {string} amendmentId - The amendment identifier.
+ * @param {string} facilityId - The facility identifier.
+ * @param {import('@ukef/dtfs2-common').AuditDetails} auditDetails - Audit details for update calls.
+ * @returns {Promise<void>} Resolves when email checks and sends are complete.
+ */
 const sendAmendmentEmail = async (amendmentId, facilityId, auditDetails) => {
   try {
     const amendment = await api.getAmendmentById(facilityId, amendmentId);
@@ -29,6 +37,7 @@ const sendAmendmentEmail = async (amendmentId, facilityId, auditDetails) => {
     // if amendment exists and if automaticApprovalEmail field is present
     if (amendmentEmailEligible(amendment)) {
       const { dealSnapshot } = await api.findOneDeal(amendment.dealId);
+
       if (dealSnapshot) {
         // gets portal user to ensure latest details
         const user = await api.findPortalUserById(dealSnapshot.maker._id);
@@ -36,21 +45,25 @@ const sendAmendmentEmail = async (amendmentId, facilityId, auditDetails) => {
         // if automaticApprovalEmail and !automaticApprovalEmailSent (email not sent before)
         if (amendment?.automaticApprovalEmail && !amendment?.automaticApprovalEmailSent) {
           const automaticAmendmentVariables = { user, dealSnapshot, amendment, facilityId, amendmentId };
+
           // sends email and updates flag if sent
           await sendAutomaticAmendmentEmail(automaticAmendmentVariables, auditDetails);
         }
         if (amendment?.ukefDecision?.managersDecisionEmail && !amendment?.ukefDecision?.managersDecisionEmailSent) {
           // if managers decision email to be sent and not already sent
           const ukefDecisionAmendmentVariables = { user, dealSnapshot, amendment, facilityId, amendmentId };
+
           await sendManualDecisionAmendmentEmail(ukefDecisionAmendmentVariables, auditDetails);
         }
         if (amendment?.bankDecision?.banksDecisionEmail && !amendment?.bankDecision?.banksDecisionEmailSent) {
           const bankDecisionAmendmentVariables = { user, dealSnapshot, amendment, facilityId, amendmentId };
+
           await sendManualBankDecisionEmail(bankDecisionAmendmentVariables, auditDetails);
         }
         // if first amendment task email has not already been sent
         if (amendment?.sendFirstTaskEmail && !amendment?.firstTaskEmailSent) {
           const firstTaskVariables = { amendment, dealSnapshot, facilityId, amendmentId };
+
           await sendFirstTaskEmail(firstTaskVariables, auditDetails);
         }
       }
@@ -60,12 +73,20 @@ const sendAmendmentEmail = async (amendmentId, facilityId, auditDetails) => {
   }
 };
 
-// function to update tfm deals lastUpdated once amendment complete
+/**
+ * Updates `tfm.lastUpdated` on the related deal after amendment completion.
+ *
+ * @param {string} amendmentId - The amendment identifier.
+ * @param {string} facilityId - The facility identifier.
+ * @param {import('@ukef/dtfs2-common').AuditDetails} auditDetails - Audit details for deal update.
+ * @returns {Promise<object|null>} Updated deal response, or null when no update is possible.
+ */
 const updateTFMDealLastUpdated = async (amendmentId, facilityId, auditDetails) => {
   const amendment = await api.getAmendmentById(facilityId, amendmentId);
 
   if (amendment?.dealId) {
     const { dealId } = amendment;
+
     const payload = {
       tfm: {
         lastUpdated: new Date().valueOf(),
@@ -76,6 +97,7 @@ const updateTFMDealLastUpdated = async (amendmentId, facilityId, auditDetails) =
       return api.updateDeal({ dealId, dealUpdate: payload, auditDetails });
     } catch (error) {
       console.error('Error updated tfm deal lastUpdated - amendment completed %o', error);
+
       return null;
     }
   }
@@ -83,7 +105,14 @@ const updateTFMDealLastUpdated = async (amendmentId, facilityId, auditDetails) =
   return null;
 };
 
-// creates tfm object in latest amendment with completed mapping for displaying amendment changes in tfm
+/**
+ * Builds and stores computed TFM amendment values on the amendment record.
+ *
+ * @param {string} amendmentId - The amendment identifier.
+ * @param {string} facilityId - The facility identifier.
+ * @param {import('@ukef/dtfs2-common').AuditDetails} auditDetails - Audit details for amendment update.
+ * @returns {Promise<object|null>} The computed `tfm` object, or null when generation fails.
+ */
 const createAmendmentTFMObject = async (amendmentId, facilityId, auditDetails) => {
   try {
     // gets latest amendment value and dates
@@ -92,12 +121,15 @@ const createAmendmentTFMObject = async (amendmentId, facilityId, auditDetails) =
     const facility = await api.findOneFacility(facilityId);
 
     let tfmToAdd = {};
+
     // populates array with latest value/exposure and date/tenor values
     tfmToAdd = await addLatestAmendmentValue(tfmToAdd, latestValueResponse, facilityId);
     tfmToAdd = await addLatestAmendmentCoverEndDate(tfmToAdd, latestCoverEndDateResponse, facilityId);
 
     let latestFacilityEndDateResponse;
+
     const isFacilityEndDateEnabled = isGefFacility(facility.facilitySnapshot.type);
+
     if (isFacilityEndDateEnabled) {
       latestFacilityEndDateResponse = await api.getLatestCompletedAmendmentFacilityEndDate(facilityId);
       tfmToAdd = await addLatestAmendmentFacilityEndDate(tfmToAdd, latestFacilityEndDateResponse);
@@ -111,16 +143,26 @@ const createAmendmentTFMObject = async (amendmentId, facilityId, auditDetails) =
     return tfmToAdd;
   } catch (error) {
     console.error('TFM-API - unable to add TFM object to amendment %o', error);
+
     return null;
   }
 };
 
+/**
+ * Gets an amendment by facility ID and amendment ID.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @returns {Promise<import('express').Response>} HTTP response containing amendment data when found.
+ */
 const getAmendmentById = async (req, res) => {
   const { facilityId, amendmentId } = req.params;
   const amendment = await api.getAmendmentById(facilityId, amendmentId);
+
   if (amendment) {
     return res.status(200).send(amendment);
   }
+
   return res.status(422).send({ data: 'Unable to get the amendment by Id' });
 };
 
@@ -131,7 +173,9 @@ const getAmendmentById = async (req, res) => {
  */
 const getAmendmentByFacilityId = async (req, res) => {
   const { facilityId, amendmentIdOrStatus, type } = req.params;
+
   let amendment;
+
   switch (amendmentIdOrStatus) {
     case AMENDMENT_QUERY_STATUSES.IN_PROGRESS:
       amendment = (await api.getAmendmentInProgress(facilityId)).data;
@@ -146,6 +190,7 @@ const getAmendmentByFacilityId = async (req, res) => {
       } else {
         amendment = await api.getCompletedAmendment(facilityId);
       }
+
       break;
     default:
       if (ObjectId.isValid(amendmentIdOrStatus)) {
@@ -154,15 +199,26 @@ const getAmendmentByFacilityId = async (req, res) => {
         amendment = await api.getAmendmentByFacilityId(facilityId);
       }
   }
+
   if (amendment) {
     return res.status(200).send(amendment);
   }
+
   return res.status(422).send({ data: 'Unable to get the amendment by facilityId' });
 };
 
+/**
+ * Gets amendments for a deal, optionally filtered by query status and type.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @returns {Promise<import('express').Response>} HTTP response containing amendment data when found.
+ */
 const getAmendmentsByDealId = async (req, res) => {
   const { dealId, status, type } = req.params;
+
   let amendment;
+
   switch (status) {
     case AMENDMENT_QUERY_STATUSES.IN_PROGRESS:
       amendment = await api.getAmendmentInProgressByDealId(dealId);
@@ -173,6 +229,7 @@ const getAmendmentsByDealId = async (req, res) => {
       } else {
         amendment = await api.getCompletedAmendmentByDealId(dealId);
       }
+
       break;
     case AMENDMENT_QUERY_STATUSES.APPROVED:
       amendment = await api.getApprovedAmendments(dealId);
@@ -182,9 +239,11 @@ const getAmendmentsByDealId = async (req, res) => {
         amendment = await api.getAmendmentsByDealId(dealId);
       }
   }
+
   if (amendment) {
     return res.status(200).send(amendment);
   }
+
   return res.status(422).send({ data: 'Unable to get the amendments by deal Id' });
 };
 
@@ -195,13 +254,17 @@ const getAmendmentsByDealId = async (req, res) => {
  */
 const getAllAmendments = async (req, res) => {
   const { status } = req.params;
+
   let amendment;
+
   if (status === AMENDMENT_QUERY_STATUSES.IN_PROGRESS) {
     amendment = await api.getAllAmendmentsInProgress();
   }
+
   if (amendment) {
     return res.status(200).send(amendment);
   }
+
   return res.status(422).send({ data: 'Unable to fetch amendments' });
 };
 
@@ -212,10 +275,13 @@ const getAllAmendments = async (req, res) => {
  */
 const createFacilityAmendment = async (req, res) => {
   const { facilityId } = req.body;
+
   const { amendmentId } = await api.createFacilityAmendment(facilityId, generateTfmAuditDetails(req.user._id));
+
   if (amendmentId) {
     return res.status(200).send({ amendmentId });
   }
+
   return res.status(422).send({ data: 'Unable to create amendment' });
 };
 
@@ -355,6 +421,7 @@ const updateFacilityAmendment = async (req, res) => {
     }
   } catch (error) {
     console.error('Unable to update amendment %o', error);
+
     return res.status(400).send({ data: 'Unable to update amendment' });
   }
 
@@ -427,6 +494,7 @@ const sendAmendmentToAcbs = async (req, res) => {
     }
   } catch (error) {
     console.error('Unable to send amendment to ACBS %o', error);
+
     return res.status(HttpStatusCode.BadGateway).send({ data: 'Unable to send amendment to ACBS' });
   }
 

--- a/trade-finance-manager-ui/templates/_macros/success-banner.njk
+++ b/trade-finance-manager-ui/templates/_macros/success-banner.njk
@@ -1,4 +1,4 @@
-{%- from "moj/components/banner/macro.njk" import mojBanner -%}
+{% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% macro render(message) %}
 

--- a/trade-finance-manager-ui/templates/case/activity/_macros/cancellation-activity-html.njk
+++ b/trade-finance-manager-ui/templates/case/activity/_macros/cancellation-activity-html.njk
@@ -1,4 +1,4 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro render(activity) %}
   {% set bankRequestDate = activity.bankRequestDate | formatUnixTimestamp('d MMMM yyyy') | dashIfEmpty%}

--- a/trade-finance-manager-ui/templates/case/activity/activity.njk
+++ b/trade-finance-manager-ui/templates/case/activity/activity.njk
@@ -1,8 +1,8 @@
-{%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
+{% from "moj/components/timeline/macro.njk" import mojTimeline %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% import './_macros/deal-submitted.njk' as dealSubmitted %}
 {% import './_macros/activity-comment-filter.njk' as activityCommentFilter %}
 {% import '../amendments/_macros/amendment-in-progress-bar.njk' as amendmentInProgressBar %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% import  "./_macros/cancellation-activity-html.njk" as cancellationActivityHtml %}
 
 {% extends "case/case.njk" %}
@@ -31,6 +31,7 @@
     hasAmendmentInProgressSubmittedFromPim: hasAmendmentInProgressSubmittedFromPim,
     amendmentsInProgressSubmittedFromPim: amendmentsInProgressSubmittedFromPim
   } %}
+
   {{ amendmentInProgressBar.render(amendmentBarParams) }}
 
   <div class="govuk-grid-row" data-cy="case-activity">

--- a/trade-finance-manager-ui/templates/case/amendments/_macros/summary-table.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/_macros/summary-table.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro render(amendment) %}
   {% set rows = [] %}

--- a/trade-finance-manager-ui/templates/case/facility/_macros/add-amendment.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/add-amendment.njk
@@ -13,6 +13,7 @@
       {% if showAmendmentButton === true %}
         <form method="post" data-cy="form">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
           {{ govukButton({
             text: "Add an amendment request",
             attributes: {

--- a/trade-finance-manager-ui/templates/case/facility/_macros/amendment-details.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/amendment-details.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% import '../../amendments/_macros/amendment-ukef-decision-summary.njk' as summaryDetails %}
 {% import '../../amendments/_macros/amendment-future-effective-date-facility-bar.njk' as amendmentFutureEffectiveDateFacilityBar %}
 {% import './amendment-eligibility-criteria.njk' as eligibilityCriteria %}
@@ -16,12 +16,13 @@
         
         {% if amendment.futureEffectiveDatePortalAmendment %}
           <div class="govuk-!-padding-bottom-6">
-          {% set amendmentFutureEffectiveDateFacilityBarParams = {
-            futureEffectiveDatePortalAmendment: futureEffectiveDatePortalAmendment,
-            isOnAmendmentTab: true,
-            amendmentIndex: loop.index
-          } %}
-          {{ amendmentFutureEffectiveDateFacilityBar.render(amendmentFutureEffectiveDateFacilityBarParams) }}
+            {% set amendmentFutureEffectiveDateFacilityBarParams = {
+              futureEffectiveDatePortalAmendment: futureEffectiveDatePortalAmendment,
+              isOnAmendmentTab: true,
+              amendmentIndex: loop.index
+            } %}
+
+            {{ amendmentFutureEffectiveDateFacilityBar.render(amendmentFutureEffectiveDateFacilityBarParams) }}
           </div>
         {% endif %}
 
@@ -71,7 +72,9 @@
                 attributes: { "data-cy": "amendment--details-"+loop.index+"-banks-decision" }
               }) }}
             {% endset %}
+
             {% set bankDecision = { html: banksDecisionHtml, rowspan: 2, classes: "gov-table__grey-table-column gov-table_cell-vertical-align-middle" } %}
+
             {% set defaultCoverEndDate = (defaultCoverEndDate.push(bankDecision), defaultCoverEndDate) %}
           {% endif %}
 
@@ -99,6 +102,7 @@
 
           {% if amendment.requireUkefApproval === 'Yes' %}
             {% set banksDecisionHtml = '' %}
+
             {% if amendment.changeCoverEndDate === false %}
               {% set banksDecisionHtml %}
                 {{ govukTag({
@@ -108,7 +112,9 @@
                 }) }}
               {% endset %}
             {% endif %}
+
             {% set bankDecision = { html: banksDecisionHtml, classes: "gov-table__grey-table-column gov-table_cell-vertical-align-middle", rowspan: 2 } %}
+
             {% set defaultFacilityValue = (defaultFacilityValue.push(bankDecision), defaultFacilityValue) %}
           {% endif %}
 
@@ -150,6 +156,7 @@
             }
           ]
         %}
+
         {% if amendment.requireUkefApproval === 'Yes' %}
           {% set bankDecision = { text: "Bank's decision" } %}
           {% set head = (head.push(bankDecision), head) %}

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.njk
@@ -5,7 +5,7 @@
 {% import './parties-key-value-array-grid-row.njk' as keyValueArrayGridRow %}
 {% import './parties-edit-unique-reference-link.njk' as uniqueReferenceNumberEditLink %}
 {% import '../../_macros/supplier-type.njk' as supplierType %}
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro render(params) %}
   {% set deal = params.deal %}

--- a/trade-finance-manager-ui/templates/case/parties/parties.njk
+++ b/trade-finance-manager-ui/templates/case/parties/parties.njk
@@ -8,7 +8,7 @@
 {% import '../amendments/_macros/amendment-in-progress-bar.njk' as amendmentInProgressBar %}
 
 {% extends "case/case.njk" %}
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% block pageTitle -%}
   Deal {{ deal.details.ukefDealId }} - Parties

--- a/trade-finance-manager-ui/templates/deals/_macros/deals-table.njk
+++ b/trade-finance-manager-ui/templates/deals/_macros/deals-table.njk
@@ -1,4 +1,4 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% import '../../_macros/table-heading.njk' as tableHeading %}
 
 {% macro render(params) %}

--- a/trade-finance-manager-ui/templates/facilities/_macros/facilities-table.njk
+++ b/trade-finance-manager-ui/templates/facilities/_macros/facilities-table.njk
@@ -1,4 +1,4 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% import '../../_macros/table-heading.njk' as tableHeading %}
 
 {% macro render(params) %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/fee-record-status.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/fee-record-status.njk
@@ -1,4 +1,4 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro render(params) %}
   {% set status = params.status %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-status.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-status.njk
@@ -1,4 +1,4 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% macro render(params) %}
   {% set status = params.status %}
   {% set displayStatus = params.displayStatus %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/record-correction-status.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/record-correction-status.njk
@@ -1,4 +1,4 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro render(params) %}
   {% set status = params.status %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-status.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-status.njk
@@ -1,4 +1,4 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro render(params) %}
   {% set status = params.status %}


### PR DESCRIPTION
# Introduction :pencil2:

In preparation for DTFS sending amendments to APIM/GIFT (as well as ACBS), this PR updates a nested condition.

Also introduces various readability and documentation improvements.

## Resolution :heavy_check_mark:

- Update `canSendToAcbs` to have object structured params.
- Update `updateFacilityAmendment` and `sendAmendmentToAcbs` so that TFM data updates are not dependant on `canSendToAcbs`.
  - Note: this now matches TFM deal submission controller. This is where APIM/GIFT amendments will be sent.

## Miscellaneous :heavy_plus_sign:

- Align some nunjucks imports and formatting.
- Minor readability improvements.
- Add some missing documentation.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
