### PR TITLE
fix(DTFS2-8451): get gift facilities - handle 404 response

### DIFF
--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -427,6 +427,7 @@ const findFacilitiesByDealId = async (dealId) => {
 
     if (!isValidDealId) {
       console.error('findFacilitiesByDealId: Invalid deal id %s', dealId);
+
       return { status: 400, data: 'Invalid deal id' };
     }
 
@@ -1981,8 +1982,9 @@ const createGiftFacility = async (facilityData) => {
 
 /**
  * Find GIFT facilities by their IDs.
+ * NOTE: If no GIFT facilities are found, APIM returns a 404. This is a valid status.
  * @param {string} facilityIdsQueryString - Comma-separated facility IDs to find.
- * @returns {Promise<{ facilities: object[] }|false>} The API response payload if successful, otherwise false.
+ * @returns {Promise<{ facilities: object[] }|false>} The API response payload if successful. A 404 is treated as no facilities found and returns an empty `facilities` array. Other failures return false.
  */
 const findGiftFacilitiesByIds = async (facilityIdsQueryString) => {
   try {
@@ -2000,6 +2002,14 @@ const findGiftFacilitiesByIds = async (facilityIdsQueryString) => {
   } catch (error) {
     const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
     const responseBody = error?.response?.data ?? { message: 'No response received from external API GIFT facilities endpoint' };
+
+    if (status === HttpStatusCode.NotFound) {
+      console.info('No GIFT facilities found for ids %o', facilityIdsQueryString);
+
+      return {
+        facilities: [],
+      };
+    }
 
     console.error(
       'Unable to get GIFT facilities from external API - facilityIds %o status %s responseBody %o error %o',

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -129,6 +129,22 @@ describe('canSubmitToApimGift', () => {
         expect(mockApi.findFacilitiesByDealId).toHaveBeenNthCalledWith(1, mockDeal._id);
       });
 
+      it('should call api.findGiftFacilitiesByIds with the expected query string', async () => {
+        // Arrange
+        const expectedQueryString = [mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId].join(',');
+
+        mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1]);
+        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(expectedQueryString);
+        mockFindGiftFacilitiesByIds.mockResolvedValueOnce({ facilities: [] });
+        mockMapFacilitiesToSendToGift.mockReturnValueOnce({ facilitiesToSendToApimGift: [mockTfmIssuedFacility1] });
+
+        // Act
+        await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        expect(mockApi.findGiftFacilitiesByIds).toHaveBeenNthCalledWith(1, expectedQueryString);
+      });
+
       describe('when issued facilities are not in GIFT', () => {
         it('should return canSubmitFacilitiesToApimGift as true', async () => {
           // Arrange

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -28,8 +28,6 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
 
   console.info('Checking if issued facilities for deal %s can be submitted to APIM GIFT', dealId);
 
-  const api = apiModule as ApiTypes;
-
   if (!isTfmApimGiftIntegrationEnabled()) {
     console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - feature flag disabled', dealId);
 
@@ -37,6 +35,8 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
       canSubmitFacilitiesToApimGift: false,
     };
   }
+
+  const api = apiModule as ApiTypes;
 
   const { dealType, submissionType } = deal.dealSnapshot;
 


### PR DESCRIPTION
# Introduction :pencil2:

APIM TFS [has been updated](https://github.com/UK-Export-Finance/tfs-api/pull/1369/changes) so that if no GIFT facilities are found, a 404 is returned.

This PR updates DTFS's API call for this, so that a 404 is an acceptable status.

## Resolution :heavy_check_mark:

Update TFM API's `api.findGiftFacilitiesByIds` to accept 404 statuses.

## Miscellaneous :heavy_plus_sign:

- Minor readability improvements.
- Add a unit test.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
