### PR TITLE
chore(DTFS2-8453): part-4 gef-ui happy path api-tests

### DIFF
--- a/gef-ui/api-tests/application-submission.api-test.js
+++ b/gef-ui/api-tests/application-submission.api-test.js
@@ -2,18 +2,33 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const dealId = '123';
 
 const { get, post } = createApi(app);
 
 describe('application submission routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+    api.updateApplication.mockResolvedValue({});
+    api.setApplicationStatus.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/submit', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/submit`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,7 +37,6 @@ describe('application submission routes', () => {
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/submit`),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/automatic-cover.api-test.js
+++ b/gef-ui/api-tests/automatic-cover.api-test.js
@@ -2,18 +2,30 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const dealId = '123';
 
 const { get, post } = createApi(app);
 
 describe('automatic cover routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.updateApplication.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/automatic-cover', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -21,8 +33,8 @@ describe('automatic cover routes', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/automatic-cover`),
       whitelistedRoles: [MAKER],
-      successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
+      successCode: 302,
+      successHeaders: { location: `/gef/application-details/${dealId}/eligible-automatic-cover` },
     });
   });
 });

--- a/gef-ui/api-tests/common-tests/role-validation-api-tests.js
+++ b/gef-ui/api-tests/common-tests/role-validation-api-tests.js
@@ -2,7 +2,20 @@ jest.mock('../../server/services/api', () => ({
   ...jest.requireActual('../../server/services/api'),
   validateToken: () => true,
   validateBank: () => ({ isValid: true }),
+  getApplication: jest.fn(),
+  getFacilities: jest.fn(),
+  getFacility: jest.fn(),
+  createFacility: jest.fn(),
+  updateFacility: jest.fn(),
+  deleteFacility: jest.fn(),
+  updateApplication: jest.fn(),
+  getUserDetails: jest.fn(),
+  setApplicationStatus: jest.fn(),
+  getCompanyByRegistrationNumber: jest.fn(),
+  getMandatoryCriteria: jest.fn(),
+  cloneApplication: jest.fn(),
 }));
+
 jest.mock('@ukef/dtfs2-common', () => ({
   ...jest.requireActual('@ukef/dtfs2-common'),
   verify: jest.fn((req, res, next) => next()),

--- a/gef-ui/api-tests/eligible-automatic-cover.api-test.js
+++ b/gef-ui/api-tests/eligible-automatic-cover.api-test.js
@@ -13,7 +13,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/eligible-automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,7 +21,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/ineligible-automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -31,7 +29,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get('/ineligible-gef', {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/facility-confirm-deletion.api-test.js
+++ b/gef-ui/api-tests/facility-confirm-deletion.api-test.js
@@ -2,6 +2,10 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_ISSUED_FACILITY } = require('../server/utils/mocks/mock-facilities');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get, post } = createApi(app);
 
@@ -9,12 +13,21 @@ const dealId = '123';
 const facilityId = '111';
 
 describe('facility confirm deletion routes', () => {
+  beforeEach(() => {
+    api.getFacility.mockResolvedValue(cloneMock(MOCK_ISSUED_FACILITY));
+    api.deleteFacility.mockResolvedValue({});
+    api.updateApplication.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/facilities/:facilityId/confirm-deletion', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/facilities/${facilityId}/confirm-deletion`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,8 +35,8 @@ describe('facility confirm deletion routes', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/facilities/${facilityId}/confirm-deletion`),
       whitelistedRoles: [MAKER],
-      successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
+      successCode: 302,
+      successHeaders: { location: `/gef/application-details/${dealId}` },
     });
   });
 });

--- a/gef-ui/api-tests/supporting-information.api-test.js
+++ b/gef-ui/api-tests/supporting-information.api-test.js
@@ -2,6 +2,10 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get, post } = createApi(app);
 
@@ -9,12 +13,21 @@ const dealId = '123';
 const documentType = 'manual-inclusion-questionnaire';
 
 describe('supporting information routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/supporting-information/document/:documentType', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/supporting-information/document/${documentType}`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -23,7 +36,6 @@ describe('supporting information routes', () => {
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/supporting-information/document/${documentType}`),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });


### PR DESCRIPTION
# Introduction :pencil2:

This PR refactors the GEF-UI API tests to remove
`disableHappyPath: true // TODO DTFS2-6697: remove and test happy path`
by mocking the required API calls and enabling coverage of the happy path tests.

#### Please note: This is a large refactor, so I will be creating smaller PRs to deliver this incrementally.

## Resolution :heavy_check_mark:

## Resolution :heavy_check_mark:

List all changes made to the codebase.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
