### PR TITLE
chore(DTFS2-8453): part-4 gef-ui happy path api-tests

### DIFF
--- a/gef-ui/api-tests/application-submission.api-test.js
+++ b/gef-ui/api-tests/application-submission.api-test.js
@@ -2,18 +2,33 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const dealId = '123';
 
 const { get, post } = createApi(app);
 
 describe('application submission routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+    api.updateApplication.mockResolvedValue({});
+    api.setApplicationStatus.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/submit', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/submit`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,7 +37,6 @@ describe('application submission routes', () => {
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/submit`),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/automatic-cover.api-test.js
+++ b/gef-ui/api-tests/automatic-cover.api-test.js
@@ -2,18 +2,30 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const dealId = '123';
 
 const { get, post } = createApi(app);
 
 describe('automatic cover routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.updateApplication.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/automatic-cover', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -21,8 +33,8 @@ describe('automatic cover routes', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/automatic-cover`),
       whitelistedRoles: [MAKER],
-      successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
+      successCode: 302,
+      successHeaders: { location: `/gef/application-details/${dealId}/eligible-automatic-cover` },
     });
   });
 });

--- a/gef-ui/api-tests/common-tests/role-validation-api-tests.js
+++ b/gef-ui/api-tests/common-tests/role-validation-api-tests.js
@@ -2,7 +2,20 @@ jest.mock('../../server/services/api', () => ({
   ...jest.requireActual('../../server/services/api'),
   validateToken: () => true,
   validateBank: () => ({ isValid: true }),
+  getApplication: jest.fn(),
+  getFacilities: jest.fn(),
+  getFacility: jest.fn(),
+  createFacility: jest.fn(),
+  updateFacility: jest.fn(),
+  deleteFacility: jest.fn(),
+  updateApplication: jest.fn(),
+  getUserDetails: jest.fn(),
+  setApplicationStatus: jest.fn(),
+  getCompanyByRegistrationNumber: jest.fn(),
+  getMandatoryCriteria: jest.fn(),
+  cloneApplication: jest.fn(),
 }));
+
 jest.mock('@ukef/dtfs2-common', () => ({
   ...jest.requireActual('@ukef/dtfs2-common'),
   verify: jest.fn((req, res, next) => next()),

--- a/gef-ui/api-tests/common-tests/role-validation-api-tests.js
+++ b/gef-ui/api-tests/common-tests/role-validation-api-tests.js
@@ -2,7 +2,12 @@ jest.mock('../../server/services/api', () => ({
   ...jest.requireActual('../../server/services/api'),
   validateToken: () => true,
   validateBank: () => ({ isValid: true }),
+  getApplication: jest.fn(),
+  getFacilities: jest.fn(),
+  getUserDetails: jest.fn(),
+  getPortalAmendmentsOnDeal: jest.fn(),
 }));
+
 jest.mock('@ukef/dtfs2-common', () => ({
   ...jest.requireActual('@ukef/dtfs2-common'),
   verify: jest.fn((req, res, next) => next()),

--- a/gef-ui/api-tests/eligible-automatic-cover.api-test.js
+++ b/gef-ui/api-tests/eligible-automatic-cover.api-test.js
@@ -1,19 +1,38 @@
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  verify: jest.fn((req, res, next) => next()),
+}));
+
 const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get } = createApi(app);
 
 const dealId = '123';
 
 describe('eligible automatic cover routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+    api.getPortalAmendmentsOnDeal.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/eligible-automatic-cover', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/eligible-automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,7 +41,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/ineligible-automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -31,7 +49,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get('/ineligible-gef', {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/eligible-automatic-cover.api-test.js
+++ b/gef-ui/api-tests/eligible-automatic-cover.api-test.js
@@ -13,7 +13,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/eligible-automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,7 +21,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/ineligible-automatic-cover`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -31,7 +29,6 @@ describe('eligible automatic cover routes', () => {
       makeRequestWithHeaders: (headers) => get('/ineligible-gef', {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/facility-confirm-deletion.api-test.js
+++ b/gef-ui/api-tests/facility-confirm-deletion.api-test.js
@@ -2,6 +2,10 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_ISSUED_FACILITY } = require('../server/utils/mocks/mock-facilities');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get, post } = createApi(app);
 
@@ -9,12 +13,21 @@ const dealId = '123';
 const facilityId = '111';
 
 describe('facility confirm deletion routes', () => {
+  beforeEach(() => {
+    api.getFacility.mockResolvedValue(cloneMock(MOCK_ISSUED_FACILITY));
+    api.deleteFacility.mockResolvedValue({});
+    api.updateApplication.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/facilities/:facilityId/confirm-deletion', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/facilities/${facilityId}/confirm-deletion`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,8 +35,8 @@ describe('facility confirm deletion routes', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/facilities/${facilityId}/confirm-deletion`),
       whitelistedRoles: [MAKER],
-      successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
+      successCode: 302,
+      successHeaders: { location: `/gef/application-details/${dealId}` },
     });
   });
 });

--- a/gef-ui/api-tests/supporting-information.api-test.js
+++ b/gef-ui/api-tests/supporting-information.api-test.js
@@ -2,6 +2,10 @@ const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get, post } = createApi(app);
 
@@ -9,12 +13,21 @@ const dealId = '123';
 const documentType = 'manual-inclusion-questionnaire';
 
 describe('supporting information routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/supporting-information/document/:documentType', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/supporting-information/document/${documentType}`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -23,7 +36,6 @@ describe('supporting information routes', () => {
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/supporting-information/document/${documentType}`),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/trade-finance-manager-api/server/v1/api.js
+++ b/trade-finance-manager-api/server/v1/api.js
@@ -427,6 +427,7 @@ const findFacilitiesByDealId = async (dealId) => {
 
     if (!isValidDealId) {
       console.error('findFacilitiesByDealId: Invalid deal id %s', dealId);
+
       return { status: 400, data: 'Invalid deal id' };
     }
 
@@ -1981,8 +1982,9 @@ const createGiftFacility = async (facilityData) => {
 
 /**
  * Find GIFT facilities by their IDs.
+ * NOTE: If no GIFT facilities are found, APIM returns a 404. This is a valid status.
  * @param {string} facilityIdsQueryString - Comma-separated facility IDs to find.
- * @returns {Promise<{ facilities: object[] }|false>} The API response payload if successful, otherwise false.
+ * @returns {Promise<{ facilities: object[] }|false>} The API response payload if successful. A 404 is treated as no facilities found and returns an empty `facilities` array. Other failures return false.
  */
 const findGiftFacilitiesByIds = async (facilityIdsQueryString) => {
   try {
@@ -2000,6 +2002,14 @@ const findGiftFacilitiesByIds = async (facilityIdsQueryString) => {
   } catch (error) {
     const status = error?.response?.status ?? HttpStatusCode.InternalServerError;
     const responseBody = error?.response?.data ?? { message: 'No response received from external API GIFT facilities endpoint' };
+
+    if (status === HttpStatusCode.NotFound) {
+      console.info('No GIFT facilities found for ids %o', facilityIdsQueryString);
+
+      return {
+        facilities: [],
+      };
+    }
 
     console.error(
       'Unable to get GIFT facilities from external API - facilityIds %o status %s responseBody %o error %o',

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.test.ts
@@ -129,6 +129,22 @@ describe('canSubmitToApimGift', () => {
         expect(mockApi.findFacilitiesByDealId).toHaveBeenNthCalledWith(1, mockDeal._id);
       });
 
+      it('should call api.findGiftFacilitiesByIds with the expected query string', async () => {
+        // Arrange
+        const expectedQueryString = [mockTfmIssuedFacility1.facilitySnapshot.ukefFacilityId].join(',');
+
+        mockApi.findFacilitiesByDealId.mockResolvedValueOnce([mockTfmIssuedFacility1]);
+        mockGenerateIssuedFacilitiesQueryString.mockReturnValueOnce(expectedQueryString);
+        mockFindGiftFacilitiesByIds.mockResolvedValueOnce({ facilities: [] });
+        mockMapFacilitiesToSendToGift.mockReturnValueOnce({ facilitiesToSendToApimGift: [mockTfmIssuedFacility1] });
+
+        // Act
+        await canSubmitToApimGift(mockDeal);
+
+        // Assert
+        expect(mockApi.findGiftFacilitiesByIds).toHaveBeenNthCalledWith(1, expectedQueryString);
+      });
+
       describe('when issued facilities are not in GIFT', () => {
         it('should return canSubmitFacilitiesToApimGift as true', async () => {
           // Arrange

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/can-submit-to-apim-gift/index.ts
@@ -28,8 +28,6 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
 
   console.info('Checking if issued facilities for deal %s can be submitted to APIM GIFT', dealId);
 
-  const api = apiModule as ApiTypes;
-
   if (!isTfmApimGiftIntegrationEnabled()) {
     console.info('Issued facilities for deal %s cannot be submitted to APIM GIFT - feature flag disabled', dealId);
 
@@ -37,6 +35,8 @@ export const canSubmitToApimGift = async (deal: TfmDeal): Promise<CanSubmitFacil
       canSubmitFacilitiesToApimGift: false,
     };
   }
+
+  const api = apiModule as ApiTypes;
 
   const { dealType, submissionType } = deal.dealSnapshot;
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
@@ -99,8 +99,6 @@ describe('createFacility', () => {
         ukefFacilityId: String(facilitySnapshot.ukefFacilityId),
       }),
       accrualSchedules: mapAccrualSchedules({
-        effectiveDate: String(tfm.facilityGuaranteeDates?.guaranteeCommencementDate),
-        maturityDate: String(tfm.facilityGuaranteeDates?.guaranteeExpiryDate),
         dayCountBasis: Number(facilitySnapshot.dayCountBasis),
         feeFrequency: facilitySnapshot.feeFrequency,
         feeType: facilitySnapshot.feeType,
@@ -114,17 +112,13 @@ describe('createFacility', () => {
           isBssEwcsDeal,
           isGefDeal,
         }),
-        startDate: String(tfm.facilityGuaranteeDates?.guaranteeCommencementDate),
-        exitDate: String(tfm.facilityGuaranteeDates?.guaranteeExpiryDate),
       }),
       obligations: mapObligations({
         bssSubtypeName: isBssEwcsDeal ? String(facilitySnapshot.bondType) : undefined,
         currency: facilitySnapshot.currency.id,
-        effectiveDate: String(tfm.facilityGuaranteeDates?.guaranteeCommencementDate),
         isBssEwcsDeal,
         facilityType: facilitySnapshot.type,
         isGefDeal,
-        maturityDate: String(tfm.facilityGuaranteeDates?.guaranteeExpiryDate),
         ukefExposure: Number(tfm.ukefExposure),
       }),
       riskDetails: await mapRiskDetails({

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
@@ -111,8 +111,6 @@ export const createFacility = async ({
       ukefFacilityId,
     }),
     accrualSchedules: mapAccrualSchedules({
-      effectiveDate,
-      maturityDate: expiryDate,
       dayCountBasis,
       feeFrequency,
       feeType,
@@ -122,17 +120,13 @@ export const createFacility = async ({
       isBssEwcsDeal,
       isGefDeal,
       partyUrns,
-      startDate: effectiveDate,
-      exitDate: expiryDate,
     }),
     obligations: mapObligations({
       bssSubtypeName,
       currency,
-      effectiveDate,
       isBssEwcsDeal,
       facilityType,
       isGefDeal,
-      maturityDate: expiryDate,
       ukefExposure: facilityAmount,
     }),
     riskDetails: await mapRiskDetails({

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.test.ts
@@ -10,31 +10,24 @@ describe('mapAccrualSchedules', () => {
   it('should return an array with a mapped accrual schedule', () => {
     // Arrange
     const dayCountBasis = 360;
-    const effectiveDate = '2024-01-01';
     const feeFrequency = 'Monthly';
     const feeType = 'At maturity';
     const guaranteeFeePayableToUkef = '7.0200%';
-    const maturityDate = '2025-01-01';
 
     // Act
     const result = mapAccrualSchedules({
       dayCountBasis,
-      effectiveDate,
       feeFrequency,
       feeType,
       guaranteeFeePayableToUkef,
-      maturityDate,
     });
 
     // Assert
     const expected = [
       {
         accrualScheduleTypeCode: DEFAULTS.ACCRUAL_SCHEDULE.TYPE_CODE,
-        accrualEffectiveDate: effectiveDate,
-        accrualMaturityDate: maturityDate,
         accrualFrequencyCode: mapFrequencyCode(feeFrequency, feeType),
         accrualDayBasisCode: mapDayBasisCode(dayCountBasis),
-        firstCycleAccrualEndDate: maturityDate,
         baseRate: DEFAULTS.ACCRUAL_SCHEDULE.BASE_RATE,
         spreadRate: mapSpreadRate(guaranteeFeePayableToUkef),
         additionalRate: DEFAULTS.ACCRUAL_SCHEDULE.ADDITIONAL_RATE,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.ts
@@ -8,40 +8,26 @@ const { DEFAULTS } = APIM_GIFT_INTEGRATION;
 
 type MapAccrualSchedulesParams = {
   dayCountBasis: number;
-  effectiveDate: string;
   feeFrequency: string;
   feeType: string;
   guaranteeFeePayableToUkef: string | null;
-  maturityDate: string;
 };
 
 /**
  * Maps the facility "accrual schedules"
  * @param params - The parameters required to map the accrual schedules, including:
  * @param {number} params.dayCountBasis - The facility's day count basis, used to map to GIFT day basis code.
- * @param {string} params.effectiveDate - The facility's effective date, used as the accrual effective date.
  * @param {string} params.feeFrequency - The facility's fee frequency, used to map to GIFT accrual frequency code.
  * @param {string} params.feeType - The facility's fee type, used to determine special handling for "At maturity" option.
  * @param {string | null} params.guaranteeFeePayableToUkef - The guarantee fee payable to UKEF, used as the spread rate in the accrual schedule.
- * @param {string} params.maturityDate - The facility's maturity date, used as the accrual maturity date and first cycle accrual end date.
  * @returns {ApimAccrualSchedule[]} - Mapped accrual schedules for the APIM GIFT payload.
  */
-export const mapAccrualSchedules = ({
-  dayCountBasis,
-  effectiveDate,
-  feeFrequency,
-  feeType,
-  guaranteeFeePayableToUkef,
-  maturityDate,
-}: MapAccrualSchedulesParams): ApimAccrualSchedule[] => {
+export const mapAccrualSchedules = ({ dayCountBasis, feeFrequency, feeType, guaranteeFeePayableToUkef }: MapAccrualSchedulesParams): ApimAccrualSchedule[] => {
   const accrualSchedules = [
     {
       accrualScheduleTypeCode: DEFAULTS.ACCRUAL_SCHEDULE.TYPE_CODE,
-      accrualEffectiveDate: effectiveDate,
-      accrualMaturityDate: maturityDate,
       accrualFrequencyCode: mapFrequencyCode(feeFrequency, feeType),
       accrualDayBasisCode: mapDayBasisCode(dayCountBasis),
-      firstCycleAccrualEndDate: maturityDate,
       baseRate: DEFAULTS.ACCRUAL_SCHEDULE.BASE_RATE,
       spreadRate: mapSpreadRate(guaranteeFeePayableToUkef),
       additionalRate: DEFAULTS.ACCRUAL_SCHEDULE.ADDITIONAL_RATE,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.test.ts
@@ -4,9 +4,6 @@ import { mapCounterparties } from '.';
 const { DEFAULTS } = APIM_GIFT_INTEGRATION;
 
 describe('mapCounterparties', () => {
-  const startDate = '2024-01-28';
-  const exitDate = '2026-02-14';
-
   describe('when isBssEwcsDeal is true', () => {
     const isBssEwcsDeal = true;
     const isGefDeal = false;
@@ -23,16 +20,12 @@ describe('mapCounterparties', () => {
           isBssEwcsDeal,
           isGefDeal,
           partyUrns: mockPartyUrns,
-          startDate,
-          exitDate,
         });
 
         // Assert
         const expected = [
           {
             counterpartyUrn: mockPartyUrns.bondGiver,
-            startDate,
-            exitDate,
             roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.BSS.BOND_GIVER,
           },
         ];
@@ -53,16 +46,12 @@ describe('mapCounterparties', () => {
           isBssEwcsDeal,
           isGefDeal,
           partyUrns: mockPartyUrns,
-          startDate,
-          exitDate,
         });
 
         // Assert
         const expected = [
           {
             counterpartyUrn: mockPartyUrns.bondBeneficiary,
-            startDate,
-            exitDate,
             roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.BSS.BOND_BENEFICIARY,
           },
         ];
@@ -84,22 +73,16 @@ describe('mapCounterparties', () => {
           isBssEwcsDeal,
           isGefDeal,
           partyUrns: mockPartyUrns,
-          startDate,
-          exitDate,
         });
 
         // Assert
         const expected = [
           {
             counterpartyUrn: mockPartyUrns.bondGiver,
-            startDate,
-            exitDate,
             roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.BSS.BOND_GIVER,
           },
           {
             counterpartyUrn: mockPartyUrns.bondBeneficiary,
-            startDate,
-            exitDate,
             roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.BSS.BOND_BENEFICIARY,
           },
         ];
@@ -118,8 +101,6 @@ describe('mapCounterparties', () => {
           isBssEwcsDeal,
           isGefDeal,
           partyUrns: mockPartyUrns,
-          startDate,
-          exitDate,
         });
 
         // Assert
@@ -144,16 +125,12 @@ describe('mapCounterparties', () => {
           isBssEwcsDeal,
           isGefDeal,
           partyUrns: mockPartyUrns,
-          startDate,
-          exitDate,
         });
 
         // Assert
         const expected = [
           {
             counterpartyUrn: mockPartyUrns.issuingBank,
-            startDate,
-            exitDate,
             roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.GEF.ISSUING_BANK,
           },
         ];
@@ -172,8 +149,6 @@ describe('mapCounterparties', () => {
           isBssEwcsDeal,
           isGefDeal,
           partyUrns: mockPartyUrns,
-          startDate,
-          exitDate,
         });
 
         // Assert
@@ -192,8 +167,6 @@ describe('mapCounterparties', () => {
         isBssEwcsDeal,
         isGefDeal,
         partyUrns: {},
-        startDate,
-        exitDate,
       });
 
       // Assert

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.ts
@@ -7,8 +7,6 @@ type MapCounterpartiesParams = {
   isBssEwcsDeal: boolean;
   isGefDeal: boolean;
   partyUrns: PartyUrns;
-  startDate: string;
-  exitDate: string;
 };
 
 /**
@@ -19,19 +17,15 @@ type MapCounterpartiesParams = {
  * @param {boolean} params.isBssEwcsDeal - If the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - If the deal is a GEF deal.
  * @param {PartyUrns} params.partyUrns - The party URNs.
- * @param {string} params.startDate - The start date of the facility (from TFM "facilityGuaranteeDates").
- * @param {string} params.exitDate - The exit date of the facility (from TFM "facilityGuaranteeDates").
  * @returns {ApimGiftCounterparty[]} Mapped counterparties array for the APIM GIFT payload.
  */
-export const mapCounterparties = ({ isBssEwcsDeal, isGefDeal, partyUrns, startDate, exitDate }: MapCounterpartiesParams): ApimGiftCounterparty[] => {
+export const mapCounterparties = ({ isBssEwcsDeal, isGefDeal, partyUrns }: MapCounterpartiesParams): ApimGiftCounterparty[] => {
   const counterparties: ApimGiftCounterparty[] = [];
 
   if (isBssEwcsDeal) {
     if (partyUrns.bondGiver) {
       counterparties.push({
         counterpartyUrn: partyUrns.bondGiver,
-        startDate,
-        exitDate,
         roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.BSS.BOND_GIVER,
       });
     }
@@ -39,8 +33,6 @@ export const mapCounterparties = ({ isBssEwcsDeal, isGefDeal, partyUrns, startDa
     if (partyUrns.bondBeneficiary) {
       counterparties.push({
         counterpartyUrn: partyUrns.bondBeneficiary,
-        startDate,
-        exitDate,
         roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.BSS.BOND_BENEFICIARY,
       });
     }
@@ -51,8 +43,6 @@ export const mapCounterparties = ({ isBssEwcsDeal, isGefDeal, partyUrns, startDa
   if (isGefDeal && partyUrns.issuingBank) {
     counterparties.push({
       counterpartyUrn: partyUrns.issuingBank,
-      startDate,
-      exitDate,
       roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.GEF.ISSUING_BANK,
     });
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
@@ -8,9 +8,7 @@ const { DEFAULTS, OBLIGATION_SUBTYPE_MAP } = APIM_GIFT_INTEGRATION;
 describe('mapObligations', () => {
   const bssSubtypeName = 'Performance bond';
   const currency = 'GBP';
-  const effectiveDate = '2024-01-28';
   const facilityType = FACILITY_TYPE.CASH;
-  const maturityDate = '2026-02-14';
   const ukefExposure = 1500;
 
   describe('when isBssEwcsDeal is true', () => {
@@ -22,10 +20,8 @@ describe('mapObligations', () => {
       // Act
       const result = mapObligations({
         currency,
-        effectiveDate,
         isBssEwcsDeal,
         isGefDeal,
-        maturityDate,
         bssSubtypeName,
         ukefExposure,
       });
@@ -35,8 +31,6 @@ describe('mapObligations', () => {
         {
           amount: mapObligationAmount({ isGefDeal, facilityType, ukefExposure }),
           currency,
-          effectiveDate,
-          maturityDate,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
           subtypeCode: OBLIGATION_SUBTYPE_MAP.BSS['Performance bond'],
         },
@@ -55,10 +49,8 @@ describe('mapObligations', () => {
         // Act
         const result = mapObligations({
           currency,
-          effectiveDate,
           isBssEwcsDeal,
           isGefDeal,
-          maturityDate,
           bssSubtypeName: unmappedBssSubtypeName,
           ukefExposure,
         });
@@ -68,8 +60,6 @@ describe('mapObligations', () => {
           {
             amount: mapObligationAmount({ isGefDeal, facilityType, ukefExposure }),
             currency,
-            effectiveDate,
-            maturityDate,
             repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
             subtypeCode: null,
           },
@@ -89,11 +79,9 @@ describe('mapObligations', () => {
       // Act
       const result = mapObligations({
         currency,
-        effectiveDate,
         isBssEwcsDeal,
         isGefDeal,
         facilityType,
-        maturityDate,
         ukefExposure,
       });
 
@@ -102,8 +90,6 @@ describe('mapObligations', () => {
         {
           amount: mapObligationAmount({ isGefDeal, facilityType, ukefExposure }),
           currency,
-          effectiveDate,
-          maturityDate,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
           subtypeCode: null,
         },
@@ -122,10 +108,8 @@ describe('mapObligations', () => {
       // Act
       const result = mapObligations({
         currency,
-        effectiveDate,
         isBssEwcsDeal,
         isGefDeal,
-        maturityDate,
         ukefExposure,
       });
 
@@ -134,8 +118,6 @@ describe('mapObligations', () => {
         {
           amount: mapObligationAmount({ isGefDeal, facilityType, ukefExposure }),
           currency,
-          effectiveDate,
-          maturityDate,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
           subtypeCode: null,
         },

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
@@ -8,11 +8,9 @@ const { DEFAULTS, OBLIGATION_SUBTYPE_MAP } = APIM_GIFT_INTEGRATION;
 type MapObligationsParams = {
   bssSubtypeName?: string;
   currency: Currency;
-  effectiveDate: string;
   isBssEwcsDeal: boolean;
   facilityType?: string;
   isGefDeal: boolean;
-  maturityDate: string;
   ukefExposure: number;
 };
 
@@ -23,22 +21,18 @@ type MapObligationsParams = {
  * @param {MapObligationsParams} params - Data required to build the APIM GIFT "obligations" data.
  * @param {string} [params.bssSubtypeName] - The BSS facility's subtype name. Only used when `isBssEwcsDeal` is true.
  * @param {Currency} params.currency - The facility currency code to use for the obligation amount.
- * @param {string} params.effectiveDate - The start date of the facility (from TFM "facilityGuaranteeDates").
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
  * @param {string} [params.facilityType] - The facility type (e.g. "Bond", "Cash", "Contingent", "Loan"). Only required for GEF facilities.
- * @param {string} params.maturityDate - The exit date of the facility (from TFM "facilityGuaranteeDates").
  * @param {number} params.ukefExposure - The facility's UKEF exposure.
  * @returns {ApimGiftObligation[]} Mapped obligations array for the APIM GIFT payload.
  */
 export const mapObligations = ({
   bssSubtypeName,
   currency,
-  effectiveDate,
   isBssEwcsDeal,
   isGefDeal,
   facilityType,
-  maturityDate,
   ukefExposure,
 }: MapObligationsParams): ApimGiftObligation[] => {
   let subtypeCode = null;
@@ -62,8 +56,6 @@ export const mapObligations = ({
     {
       amount: mapObligationAmount({ isGefDeal, facilityType, ukefExposure }),
       currency,
-      effectiveDate,
-      maturityDate,
       repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
       subtypeCode,
     },

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/apim-gift.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/apim-gift.ts
@@ -35,10 +35,7 @@ export type ApimGiftFacilityOverview = {
 
 export type ApimAccrualSchedule = {
   accrualScheduleTypeCode: ApimGiftAccrualScheduleTypeCode;
-  accrualEffectiveDate: string;
-  accrualMaturityDate: string;
   accrualFrequencyCode: ApimGiftAccrualFrequencyCodeType | null;
-  firstCycleAccrualEndDate: string;
   accrualDayBasisCode: ApimGiftDayBasisType | null;
   baseRate: number;
   spreadRate: number | null;
@@ -47,16 +44,12 @@ export type ApimAccrualSchedule = {
 
 export type ApimGiftCounterparty = {
   counterpartyUrn: string;
-  startDate: string;
-  exitDate: string;
   roleCode: (typeof COUNTERPARTY_ROLE_CODE)[keyof typeof COUNTERPARTY_ROLE_CODE];
 };
 
 export type ApimGiftObligation = {
   amount: number | null;
   currency: string;
-  effectiveDate: string;
-  maturityDate: string;
   repaymentType: ApimGiftRepaymentType;
   subtypeCode: string | null;
 };


### PR DESCRIPTION
# Introduction :pencil2:

This PR refactors the GEF-UI API tests to remove
disableHappyPath: true // TODO DTFS2-6697: remove and test happy path
by mocking the required API calls and enabling coverage of the happy path tests.

#### Please note: This is a large refactor, so I will be creating smaller PRs to deliver this incrementally.

## Resolution :heavy_check_mark:

gef-ui/api-tests/application-submission.api-test.js
gef-ui/api-tests/automatic-cover.api-test.js
gef-ui/api-tests/common-tests/role-validation-api-tests.js
gef-ui/api-tests/eligible-automatic-cover.api-test.js
gef-ui/api-tests/facility-confirm-deletion.api-test.js
gef-ui/api-tests/supporting-information.api-test.js