### PR TITLE
chore(DTFS2-8454): part-5 gef-ui happy path api tests

### DIFF
--- a/gef-ui/api-tests/application-details.api-test.js
+++ b/gef-ui/api-tests/application-details.api-test.js
@@ -1,19 +1,38 @@
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  verify: jest.fn((req, res, next) => next()),
+}));
+
 const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER, CHECKER, READ_ONLY, ADMIN } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const dealId = '123';
 
 const { get, post } = createApi(app);
 
 describe('application details routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+    api.getPortalAmendmentsOnDeal.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}`, {}, headers),
       whitelistedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -21,8 +40,8 @@ describe('application details routes', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}`),
       whitelistedRoles: [MAKER],
-      successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
+      successCode: 302,
+      successHeaders: { location: `/gef/application-details/${dealId}/submit` },
     });
   });
 });

--- a/gef-ui/api-tests/common-tests/role-validation-api-tests.js
+++ b/gef-ui/api-tests/common-tests/role-validation-api-tests.js
@@ -2,6 +2,13 @@ jest.mock('../../server/services/api', () => ({
   ...jest.requireActual('../../server/services/api'),
   validateToken: () => true,
   validateBank: () => ({ isValid: true }),
+  getApplication: jest.fn(),
+  getFacilities: jest.fn(),
+  getFacility: jest.fn(),
+  getUserDetails: jest.fn(),
+  getPortalAmendmentsOnDeal: jest.fn(),
+  getTfmDeal: jest.fn(),
+  downloadFile: jest.fn(),
 }));
 jest.mock('@ukef/dtfs2-common', () => ({
   ...jest.requireActual('@ukef/dtfs2-common'),

--- a/gef-ui/api-tests/confirm-cover-start-date.api-test.js
+++ b/gef-ui/api-tests/confirm-cover-start-date.api-test.js
@@ -1,7 +1,16 @@
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  verify: jest.fn((req, res, next) => next()),
+}));
+
 const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get, post } = createApi(app);
 
@@ -9,12 +18,25 @@ const dealId = '123';
 const facilityId = '111';
 
 describe('confirm cover start date routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+    api.getPortalAmendmentsOnDeal.mockResolvedValue([]);
+    api.getFacility.mockResolvedValue({
+      details: { _id: facilityId, dealId, name: 'Facility one', coverEndDate: '2030-01-01T00:00:00.000Z', coverStartDate: null },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/:facilityId/confirm-cover-start-date/', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/${facilityId}/confirm-cover-start-date/`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -23,7 +45,6 @@ describe('confirm cover start date routes', () => {
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/${facilityId}/confirm-cover-start-date/`),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/cover-start-date.api-test.js
+++ b/gef-ui/api-tests/cover-start-date.api-test.js
@@ -1,18 +1,38 @@
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  verify: jest.fn((req, res, next) => next()),
+}));
+
 const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get } = createApi(app);
+
 const dealId = '123';
 
 describe('cover start date routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+    api.getPortalAmendmentsOnDeal.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/cover-start-date', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/cover-start-date`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/downloadFile.api-test.js
+++ b/gef-ui/api-tests/downloadFile.api-test.js
@@ -1,19 +1,40 @@
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  verify: jest.fn((req, res, next) => next()),
+}));
+
+const stream = require('stream');
 const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER, CHECKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
 
 const { get } = createApi(app);
 
 const fileId = '321';
 
+const createFileStream = () => {
+  const fileStream = new stream.PassThrough();
+  fileStream.headers = { 'content-type': 'application/pdf' };
+  fileStream.end(Buffer.from('file-contents'));
+  return fileStream;
+};
+
 describe('downloadFile routes', () => {
+  beforeEach(() => {
+    api.downloadFile.mockImplementation(() => createFileStream());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /file/:fileId', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/file/${fileId}`, {}, headers),
       whitelistedRoles: [MAKER, CHECKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });

--- a/gef-ui/api-tests/review-decision.api-test.js
+++ b/gef-ui/api-tests/review-decision.api-test.js
@@ -1,19 +1,38 @@
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  verify: jest.fn((req, res, next) => next()),
+}));
+
 const { createApi } = require('@ukef/dtfs2-common/api-test');
 const { MAKER } = require('../server/constants/roles');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
+const api = require('../server/services/api');
+const { MOCK_BASIC_DEAL } = require('../server/utils/mocks/mock-applications');
+
+const cloneMock = (value) => JSON.parse(JSON.stringify(value));
 
 const { get, post } = createApi(app);
 
 const dealId = '123';
 
 describe('review decision routes', () => {
+  beforeEach(() => {
+    api.getApplication.mockResolvedValue(cloneMock(MOCK_BASIC_DEAL));
+    api.getFacilities.mockResolvedValue({ status: 'Completed', items: [] });
+    api.getUserDetails.mockResolvedValue({ _id: '619bae3467cc7c002069fc21', firstname: 'Checker', surname: 'One' });
+    api.getPortalAmendmentsOnDeal.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('GET /application-details/:dealId/review-decision', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get(`/application-details/${dealId}/review-decision`, {}, headers),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 
@@ -22,7 +41,6 @@ describe('review decision routes', () => {
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/application-details/${dealId}/review-decision`),
       whitelistedRoles: [MAKER],
       successCode: 200,
-      disableHappyPath: true, // TODO DTFS2-6697: remove and test happy path.
     });
   });
 });


### PR DESCRIPTION
# Introduction :pencil2:

This PR refactors the GEF-UI API tests to remove
disableHappyPath: true // TODO DTFS2-6697: remove and test happy path
by mocking the required API calls and enabling coverage of the happy path tests.

#### Please note: This is a large refactor, so I will be creating smaller PRs to deliver this incrementally.

## Resolution :heavy_check_mark:
gef-ui/api-tests/application-details.api-test.js
gef-ui/api-tests/common-tests/role-validation-api-tests.js
gef-ui/api-tests/confirm-cover-start-date.api-test.js
gef-ui/api-tests/cover-start-date.api-test.js
gef-ui/api-tests/downloadFile.api-test.js
gef-ui/api-tests/review-decision.api-test.js

List all changes made to the codebase.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
