### PR TITLE
fix(DTFS2-8474): fixed payment-report-officer not being redirected to the correct page on login

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/successful-2fa-login.journey.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/successful-2fa-login.journey.spec.js
@@ -22,7 +22,7 @@ context('2FA Journey - Successful login flow', () => {
     commonBeforeEach(BANK1_MAKER1, { login: false });
   });
 
-  describe('Complete successful 2FA journey', () => {
+  describe('complete successful 2FA journey', () => {
     it('should redirect to check-your-email page after entering valid credentials', () => {
       cy.enterUsernameAndPassword(BANK1_MAKER1);
 
@@ -46,7 +46,7 @@ context('2FA Journey - Successful login flow', () => {
     });
   });
 
-  describe('Accessing protected routes after successful 2FA', () => {
+  describe('accessing protected routes after successful 2FA', () => {
     beforeEach(() => {
       complete2faLogin();
     });
@@ -66,7 +66,7 @@ context('2FA Journey - Successful login flow', () => {
     });
   });
 
-  describe('Redirecting away from 2FA pages after successful login', () => {
+  describe('redirecting away from 2FA pages after successful login', () => {
     beforeEach(() => {
       complete2faLogin();
     });
@@ -93,7 +93,7 @@ context('2FA Journey - Successful login flow', () => {
     });
   });
 
-  describe('Logging in as a payment report officer with 2FA enabled', () => {
+  describe('logging in as a payment report officer with 2FA enabled', () => {
     beforeEach(() => {
       complete2faLogin(BANK1_PAYMENT_REPORT_OFFICER1);
     });
@@ -103,7 +103,7 @@ context('2FA Journey - Successful login flow', () => {
     });
   });
 
-  describe('Logging in as a checker with 2FA enabled', () => {
+  describe('logging in as a checker with 2FA enabled', () => {
     beforeEach(() => {
       complete2faLogin(BANK1_CHECKER1);
     });
@@ -113,7 +113,7 @@ context('2FA Journey - Successful login flow', () => {
     });
   });
 
-  describe('Logging in as an admin with 2FA enabled', () => {
+  describe('logging in as an admin with 2FA enabled', () => {
     beforeEach(() => {
       complete2faLogin(ADMINNOMAKER);
     });
@@ -123,7 +123,7 @@ context('2FA Journey - Successful login flow', () => {
     });
   });
 
-  describe('Logging in as a read-only user with 2FA enabled', () => {
+  describe('logging in as a read-only user with 2FA enabled', () => {
     beforeEach(() => {
       complete2faLogin(READ_ONLY);
     });

--- a/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/successful-2fa-login.journey.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/successful-2fa-login.journey.spec.js
@@ -3,15 +3,15 @@ const relative = require('../../../../../relativeURL');
 const MOCK_USERS = require('../../../../../../../../e2e-fixtures');
 const { PORTAL_2FA_ACCESS_CODE } = require('../../../../../../../../e2e-fixtures/portal-users.fixture');
 
-const { BANK1_MAKER1 } = MOCK_USERS;
+const { BANK1_MAKER1, BANK1_PAYMENT_REPORT_OFFICER1, BANK1_CHECKER1, ADMINNOMAKER, READ_ONLY } = MOCK_USERS;
 const { commonBeforeEach } = require('../access-code-form.shared-test');
 
-const complete2faLogin = () => {
-  cy.enterUsernameAndPassword(BANK1_MAKER1);
+const complete2faLogin = (user = BANK1_MAKER1) => {
+  cy.enterUsernameAndPassword(user);
 
   cy.url().should('eq', relative('/login/check-your-email-access-code'));
 
-  cy.overridePortalUserSignInOTPWithValidTokenByUsername({ username: BANK1_MAKER1.username }).then(() => {
+  cy.overridePortalUserSignInOTPWithValidTokenByUsername({ username: user.username }).then(() => {
     cy.keyboardInput(checkYourEmailAccessCode.accessCodeInput(), PORTAL_2FA_ACCESS_CODE);
     cy.clickSubmitButton();
   });
@@ -90,6 +90,46 @@ context('2FA Journey - Successful login flow', () => {
 
       cy.url().should('not.eq', relative('/login/resend-another-access-code'));
       cy.url().should('not.eq', relative('/login'));
+    });
+  });
+
+  describe('Logging in as a payment report officer with 2FA enabled', () => {
+    beforeEach(() => {
+      complete2faLogin(BANK1_PAYMENT_REPORT_OFFICER1);
+    });
+
+    it('should redirect to the utilisation report upload page after successful login', () => {
+      cy.url().should('eq', relative('/utilisation-report-upload'));
+    });
+  });
+
+  describe('Logging in as a checker with 2FA enabled', () => {
+    beforeEach(() => {
+      complete2faLogin(BANK1_CHECKER1);
+    });
+
+    it('should redirect to the utilisation report upload page after successful login', () => {
+      cy.url().should('eq', relative('/dashboard/deals/0'));
+    });
+  });
+
+  describe('Logging in as an admin with 2FA enabled', () => {
+    beforeEach(() => {
+      complete2faLogin(ADMINNOMAKER);
+    });
+
+    it('should redirect to the default dashboard page after successful login', () => {
+      cy.url().should('eq', relative('/dashboard/deals/0'));
+    });
+  });
+
+  describe('Logging in as a read-only user with 2FA enabled', () => {
+    beforeEach(() => {
+      complete2faLogin(READ_ONLY);
+    });
+
+    it('should redirect to the default dashboard page after successful login', () => {
+      cy.url().should('eq', relative('/dashboard/deals/0'));
     });
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/successful-2fa-login.journey.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/successful-2fa-login.journey.spec.js
@@ -108,7 +108,7 @@ context('2FA Journey - Successful login flow', () => {
       complete2faLogin(BANK1_CHECKER1);
     });
 
-    it('should redirect to the utilisation report upload page after successful login', () => {
+    it('should redirect to the default dashboard page after successful login', () => {
       cy.url().should('eq', relative('/dashboard/deals/0'));
     });
   });

--- a/e2e-tests/ukef/cypress.config.js
+++ b/e2e-tests/ukef/cypress.config.js
@@ -31,6 +31,7 @@ module.exports = defineConfig({
   numTestsKeptInMemory: 1,
   viewportWidth: 1920,
   viewportHeight: 1080,
+  redirectionLimit: 50,
   retries: {
     runMode: 2,
     openMode: 0,

--- a/portal-ui/server/controllers/login/post-check-your-email-access-code.test.ts
+++ b/portal-ui/server/controllers/login/post-check-your-email-access-code.test.ts
@@ -142,7 +142,7 @@ describe('postCheckYourEmailAccessCodePage', () => {
 
     it('should render the post-login redirect page after successful OTP', () => {
       // Assert
-      expect(renderMock).toHaveBeenCalledWith('login/post-login-redirect.njk', {
+      expect(renderMock).toHaveBeenNthCalledWith(1, 'login/post-login-redirect.njk', {
         redirectUrl: LANDING_PAGES.DEFAULT,
       });
     });

--- a/portal-ui/server/controllers/login/post-check-your-email-access-code.test.ts
+++ b/portal-ui/server/controllers/login/post-check-your-email-access-code.test.ts
@@ -140,7 +140,7 @@ describe('postCheckYourEmailAccessCodePage', () => {
       });
     });
 
-    it('should redirect to dashboard after successful OTP', () => {
+    it('should render the post-login redirect page after successful OTP', () => {
       // Assert
       expect(renderMock).toHaveBeenCalledWith('login/post-login-redirect.njk', {
         redirectUrl: LANDING_PAGES.DEFAULT,

--- a/portal-ui/server/controllers/login/post-check-your-email-access-code.test.ts
+++ b/portal-ui/server/controllers/login/post-check-your-email-access-code.test.ts
@@ -6,6 +6,7 @@ import { PostCheckYourEmailAccessCodePageRequest, postCheckYourEmailAccessCode }
 import * as api from '../../api';
 import generateValidationErrors from './validation';
 import incorrectAccessCodeRule from './validation/rules/incorrect-access-code';
+import { LANDING_PAGES } from '../../constants';
 
 jest.mock('../../api');
 jest.mock('./validation');
@@ -141,7 +142,9 @@ describe('postCheckYourEmailAccessCodePage', () => {
 
     it('should redirect to dashboard after successful OTP', () => {
       // Assert
-      expect(redirectMock).toHaveBeenCalledWith('/dashboard');
+      expect(renderMock).toHaveBeenCalledWith('login/post-login-redirect.njk', {
+        redirectUrl: LANDING_PAGES.DEFAULT,
+      });
     });
   });
 

--- a/portal-ui/server/controllers/login/post-check-your-email-access-code.ts
+++ b/portal-ui/server/controllers/login/post-check-your-email-access-code.ts
@@ -8,6 +8,7 @@ import generateValidationErrors from './validation';
 import { CheckYourEmailAccessCodeViewModel } from '../../types/view-models/2fa/check-your-email-access-code-view-model';
 import { generate2FAViewModel } from '../../helpers/generate-2fa-view-model';
 import { isOtpExpired } from '../../helpers/is-otp-expired';
+import { getUserRedirectUrl } from '../../helpers';
 
 const CHECK_YOUR_EMAIL_TEMPLATE = 'login/check-your-email-access-code.njk';
 
@@ -107,7 +108,16 @@ export const postCheckYourEmailAccessCode = async (req: PostCheckYourEmailAccess
       user,
     });
 
-    return res.redirect('/dashboard');
+    /**
+     * determines the correct url to redirect user to
+     * eg payment-report-officer does not have access to the dashboard
+     * so should be redirected to the utilisation report upload page instead
+     */
+    const redirectUrl = getUserRedirectUrl(user);
+
+    return res.render('login/post-login-redirect.njk', {
+      redirectUrl,
+    });
   } catch (error) {
     console.error('Error submitting access code %o', error);
 

--- a/portal-ui/server/helpers/get-user-login-redirect-url.test.ts
+++ b/portal-ui/server/helpers/get-user-login-redirect-url.test.ts
@@ -1,0 +1,76 @@
+import { ROLES } from '@ukef/dtfs2-common';
+import { aPortalSessionUser } from '@ukef/dtfs2-common/test-helpers';
+import { getUserRedirectUrl } from './get-user-login-redirect-url';
+import { LANDING_PAGES } from '../constants';
+
+describe('getUserRedirectUrl', () => {
+  describe('when the user is a maker', () => {
+    it('should return the default landing page', () => {
+      const user = { ...aPortalSessionUser(), roles: [ROLES.MAKER] };
+
+      const result = getUserRedirectUrl(user);
+
+      expect(result).toEqual(LANDING_PAGES.DEFAULT);
+    });
+  });
+
+  describe('when the user is a checker', () => {
+    it('should return the default landing page', () => {
+      const user = { ...aPortalSessionUser(), roles: [ROLES.CHECKER] };
+
+      const result = getUserRedirectUrl(user);
+
+      expect(result).toEqual(LANDING_PAGES.DEFAULT);
+    });
+  });
+
+  describe('when the user is an admin', () => {
+    it('should return the default landing page', () => {
+      const user = { ...aPortalSessionUser(), roles: [ROLES.ADMIN] };
+
+      const result = getUserRedirectUrl(user);
+
+      expect(result).toEqual(LANDING_PAGES.DEFAULT);
+    });
+  });
+
+  describe('when the user is a payment report officer', () => {
+    it('should return the utilisation report upload landing page', () => {
+      const user = { ...aPortalSessionUser(), roles: [ROLES.PAYMENT_REPORT_OFFICER] };
+
+      const result = getUserRedirectUrl(user);
+
+      expect(result).toEqual(LANDING_PAGES.UTILISATION_REPORT_UPLOAD);
+    });
+  });
+
+  describe('when the user is a maker and payment report officer', () => {
+    it('should return the default landing page', () => {
+      const user = { ...aPortalSessionUser(), roles: [ROLES.MAKER, ROLES.PAYMENT_REPORT_OFFICER] };
+
+      const result = getUserRedirectUrl(user);
+
+      expect(result).toEqual(LANDING_PAGES.DEFAULT);
+    });
+  });
+
+  describe('when the user is read-only', () => {
+    it('should return the default landing page', () => {
+      const user = { ...aPortalSessionUser(), roles: [ROLES.READ_ONLY] };
+
+      const result = getUserRedirectUrl(user);
+
+      expect(result).toEqual(LANDING_PAGES.DEFAULT);
+    });
+  });
+
+  describe('when the user has no roles', () => {
+    it('should return the default landing page', () => {
+      const user = { ...aPortalSessionUser(), roles: [] };
+
+      const result = getUserRedirectUrl(user);
+
+      expect(result).toEqual(LANDING_PAGES.DEFAULT);
+    });
+  });
+});

--- a/portal-ui/server/helpers/get-user-login-redirect-url.ts
+++ b/portal-ui/server/helpers/get-user-login-redirect-url.ts
@@ -1,4 +1,4 @@
-import { PortalSessionUser } from '@ukef/dtfs2-common';
+import type { PortalSessionUser } from '@ukef/dtfs2-common';
 import getUserRoles from './getUserRoles';
 import { LANDING_PAGES } from '../constants';
 
@@ -13,9 +13,9 @@ type UserRolesCheck = {
 /**
  * Gets the redirect url for the user after they have successfully logged in
  * @param {PortalSessionUser} user - The user object
- * @returns {string} The url to redirect the user to
+ * @returns {(typeof LANDING_PAGES)[keyof typeof LANDING_PAGES]} The url to redirect the user to
  */
-export const getUserRedirectUrl = (user: PortalSessionUser): string => {
+export const getUserRedirectUrl = (user: PortalSessionUser): (typeof LANDING_PAGES)[keyof typeof LANDING_PAGES] => {
   const { isMaker, isChecker, isAdmin, isPaymentReportOfficer } = getUserRoles(user.roles) as UserRolesCheck;
 
   if (isMaker || isChecker || isAdmin) {

--- a/portal-ui/server/helpers/get-user-login-redirect-url.ts
+++ b/portal-ui/server/helpers/get-user-login-redirect-url.ts
@@ -1,0 +1,30 @@
+import { PortalSessionUser } from '@ukef/dtfs2-common';
+import getUserRoles from './getUserRoles';
+import { LANDING_PAGES } from '../constants';
+
+type UserRolesCheck = {
+  isMaker: boolean;
+  isChecker: boolean;
+  isAdmin: boolean;
+  isPaymentReportOfficer: boolean;
+  isReadOnly: boolean;
+};
+
+/**
+ * Gets the redirect url for the user after they have successfully logged in
+ * @param {PortalSessionUser} user - The user object
+ * @returns {string} The url to redirect the user to
+ */
+export const getUserRedirectUrl = (user: PortalSessionUser): string => {
+  const { isMaker, isChecker, isAdmin, isPaymentReportOfficer } = getUserRoles(user.roles) as UserRolesCheck;
+
+  if (isMaker || isChecker || isAdmin) {
+    return LANDING_PAGES.DEFAULT;
+  }
+
+  if (isPaymentReportOfficer) {
+    return LANDING_PAGES.UTILISATION_REPORT_UPLOAD;
+  }
+
+  return LANDING_PAGES.DEFAULT;
+};

--- a/portal-ui/server/helpers/index.js
+++ b/portal-ui/server/helpers/index.js
@@ -24,6 +24,7 @@ const { getRecordCorrectionCancelLinkHref } = require('./get-record-correction-c
 const { mapFacilityProperties } = require('./map-facility-properties');
 const { getNextAccessCodePage } = require('./getNextAccessCodePage');
 const { fixNullCurrencyOnBondAndLoans } = require('./fixNullCurrencyOnBondAndLoans');
+const { getUserRedirectUrl } = require('./get-user-login-redirect-url');
 
 module.exports = {
   isEveryDealFormComplete,
@@ -53,4 +54,5 @@ module.exports = {
   mapFacilityProperties,
   getNextAccessCodePage,
   fixNullCurrencyOnBondAndLoans,
+  getUserRedirectUrl,
 };


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes a bug where a payment report officer would not be redirected to `utilisation-report-upload` page and instead is shown the login page again

<img width="1895" height="1080" alt="image" src="https://github.com/user-attachments/assets/279dae0c-2220-430e-82e2-088a86a21c0c" />


## Resolution :heavy_check_mark:

* Added role check helper to redirect to the correct page
* Added tests
* Added more e2e tests