### PR TITLE
Revert chore: release 3.0.1 (#4794)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
     "packages": {
-        ".": {
-            "release-as": "3.0.1"
-        }
+        ".": {}
     },
     "pull-request-title-pattern": "chore(${scope}): release${component} ${version}",
     "extra-label": "Type: chore, Type: Docs",


### PR DESCRIPTION
This reverts commit 9071697a25be923edbbe5de9cd2ab3ff5f56b5a9.

# Introduction :pencil2:

Was introduced to try and force release-please to change version number
