### PR TITLE
fix(DTFS2-8353-8354): send a gift facility - obligation amount

### DIFF
--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/constants.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/constants.ts
@@ -45,7 +45,7 @@ export const TFM_CREDIT_RATING_MAP = {
  * Obligation amount calculations for GEF facilities, based on the APIM GIFT documentation:
  * - For Cash GEF facilities, the obligation amount is calculated as 85% of the Max UKEF exposure.
  * - For Contingent GEF facilities, the obligation amount is calculated as 70% of the Max UKEF exposure.
- * For non-GEF facilities, the obligation amount is simply the Max UKEF exposure.
+ * For non-GEF facilities, the obligation amount is the facility value, multiplied by the Max UKEF exposure.
  * These calculations are required to map the facility's UKEF exposure to the expected obligation amount in APIM/GIFT when mapping the facility "obligations" data for the APIM GIFT payload.
  */
 export const OBLIGATION_AMOUNT = {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
@@ -128,6 +128,7 @@ describe('createFacility', () => {
       obligations: mapObligations({
         bssSubtypeName: isBssEwcsDeal ? String(facilitySnapshot.bondType) : undefined,
         currency: facilitySnapshot.currency.id,
+        facilityAmount,
         facilityType: facilitySnapshot.type,
         isBssEwcsDeal,
         isGefDeal,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
@@ -158,6 +158,7 @@ export const createFacility = async ({
     obligations: mapObligations({
       bssSubtypeName,
       currency,
+      facilityAmount,
       facilityType,
       isBssEwcsDeal,
       isGefDeal,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
@@ -8,6 +8,7 @@ const { DEFAULTS, OBLIGATION_SUBTYPE_MAP } = APIM_GIFT_INTEGRATION;
 describe('mapObligations', () => {
   const bssSubtypeName = 'Performance bond';
   const currency = 'GBP';
+  const facilityAmount = 1500;
   const facilityType = FACILITY_TYPE.CASH;
   const ukefExposure = 1500;
 
@@ -20,6 +21,7 @@ describe('mapObligations', () => {
       // Act
       const result = mapObligations({
         currency,
+        facilityAmount,
         isBssEwcsDeal,
         isGefDeal,
         bssSubtypeName,
@@ -32,6 +34,7 @@ describe('mapObligations', () => {
           amount: mapObligationAmount({
             isBssEwcsDeal,
             isGefDeal,
+            facilityAmount,
             facilityType,
             ukefExposure,
           }),
@@ -54,6 +57,7 @@ describe('mapObligations', () => {
         // Act
         const result = mapObligations({
           currency,
+          facilityAmount,
           isBssEwcsDeal,
           isGefDeal,
           bssSubtypeName: unmappedBssSubtypeName,
@@ -66,6 +70,7 @@ describe('mapObligations', () => {
             amount: mapObligationAmount({
               isBssEwcsDeal,
               isGefDeal,
+              facilityAmount,
               facilityType,
               ukefExposure,
             }),
@@ -89,6 +94,7 @@ describe('mapObligations', () => {
       // Act
       const result = mapObligations({
         currency,
+        facilityAmount,
         isBssEwcsDeal,
         isGefDeal,
         facilityType,
@@ -101,6 +107,7 @@ describe('mapObligations', () => {
           amount: mapObligationAmount({
             isBssEwcsDeal,
             isGefDeal,
+            facilityAmount,
             facilityType,
             ukefExposure,
           }),
@@ -123,6 +130,7 @@ describe('mapObligations', () => {
       // Act
       const result = mapObligations({
         currency,
+        facilityAmount,
         isBssEwcsDeal,
         isGefDeal,
         ukefExposure,
@@ -134,6 +142,7 @@ describe('mapObligations', () => {
           amount: mapObligationAmount({
             isBssEwcsDeal,
             isGefDeal,
+            facilityAmount,
             facilityType,
             ukefExposure,
           }),

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
@@ -9,6 +9,7 @@ type MapObligationsParams = {
   bssSubtypeName?: string;
   currency: Currency;
   isBssEwcsDeal: boolean;
+  facilityAmount: number;
   facilityType?: string;
   isGefDeal: boolean;
   ukefExposure: number;
@@ -23,6 +24,7 @@ type MapObligationsParams = {
  * @param {Currency} params.currency - The facility currency code to use for the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
+ * @param {number} [params.facilityAmount] - The facility amount. Only required for BSS/EWCS deals.
  * @param {string} [params.facilityType] - The facility type (e.g. "Bond", "Cash", "Contingent", "Loan"). Only required for GEF facilities.
  * @param {number} params.ukefExposure - The facility's UKEF exposure.
  * @returns {ApimGiftObligation[]} Mapped obligations array for the APIM GIFT payload.
@@ -32,6 +34,7 @@ export const mapObligations = ({
   currency,
   isBssEwcsDeal,
   isGefDeal,
+  facilityAmount,
   facilityType,
   ukefExposure,
 }: MapObligationsParams): ApimGiftObligation[] => {
@@ -54,7 +57,13 @@ export const mapObligations = ({
 
   const obligations = [
     {
-      amount: mapObligationAmount({ isBssEwcsDeal, isGefDeal, facilityType, ukefExposure }),
+      amount: mapObligationAmount({
+        isBssEwcsDeal,
+        isGefDeal,
+        facilityAmount,
+        facilityType,
+        ukefExposure,
+      }),
       currency,
       repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
       subtypeCode,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
@@ -24,7 +24,7 @@ type MapObligationsParams = {
  * @param {Currency} params.currency - The facility currency code to use for the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
- * @param {number} [params.facilityAmount] - The facility amount. Only required for BSS/EWCS deals.
+ * @param {number} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
  * @param {string} [params.facilityType] - The facility type (e.g. "Bond", "Cash", "Contingent", "Loan"). Only required for GEF facilities.
  * @param {number} params.ukefExposure - The facility's UKEF exposure.
  * @returns {ApimGiftObligation[]} Mapped obligations array for the APIM GIFT payload.

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
@@ -1,8 +1,24 @@
 import { FACILITY_TYPE } from '@ukef/dtfs2-common';
-import { mapGefObligationAmount, mapObligationAmount } from '.';
+import { mapBssEwcsObligationAmount, mapGefObligationAmount, mapObligationAmount } from '.';
 import { OBLIGATION_AMOUNT } from '../../../constants';
 
 const { UKEF_EXPOSURE_PERCENTAGE } = OBLIGATION_AMOUNT;
+
+describe('mapBssEwcsObligationAmount', () => {
+  it('should return facilityAmount multiplied by ukefExposure', () => {
+    // Arrange
+    const facilityAmount = 1000;
+    const ukefExposure = 0.8;
+
+    // Act
+    const result = mapBssEwcsObligationAmount({ facilityAmount, ukefExposure });
+
+    // Assert
+    const expected = facilityAmount * ukefExposure;
+
+    expect(result).toEqual(expected);
+  });
+});
 
 describe('mapGefObligationAmount', () => {
   describe(`when facilityType is ${FACILITY_TYPE.CASH}`, () => {
@@ -57,6 +73,7 @@ describe('mapGefObligationAmount', () => {
 });
 
 describe('mapObligationAmount', () => {
+  const facilityAmount = 1000;
   const ukefExposure = 1000;
 
   describe('when isGefDeal is true', () => {
@@ -69,6 +86,7 @@ describe('mapObligationAmount', () => {
       const result = mapObligationAmount({
         isBssEwcsDeal,
         isGefDeal: true,
+        facilityAmount,
         facilityType,
         ukefExposure,
       });
@@ -81,7 +99,7 @@ describe('mapObligationAmount', () => {
   });
 
   describe('when isBssEwcsDeal is true and isGefDeal is false', () => {
-    it('should return ukefExposure', () => {
+    it('should return the result of mapBssEwcsObligationAmount', () => {
       // Arrange
       const isBssEwcsDeal = true;
 
@@ -89,11 +107,12 @@ describe('mapObligationAmount', () => {
       const result = mapObligationAmount({
         isBssEwcsDeal,
         isGefDeal: false,
+        facilityAmount,
         ukefExposure,
       });
 
       // Assert
-      const expected = ukefExposure;
+      const expected = mapBssEwcsObligationAmount({ facilityAmount, ukefExposure });
 
       expect(result).toEqual(expected);
     });
@@ -108,6 +127,7 @@ describe('mapObligationAmount', () => {
       const result = mapObligationAmount({
         isBssEwcsDeal,
         isGefDeal: false,
+        facilityAmount,
         ukefExposure,
       });
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
@@ -3,6 +3,11 @@ import { OBLIGATION_AMOUNT } from '../../../constants';
 
 const { UKEF_EXPOSURE_PERCENTAGE } = OBLIGATION_AMOUNT;
 
+type MapBssEwcsObligationAmountParams = {
+  facilityAmount: number;
+  ukefExposure: number;
+};
+
 type MapGefObligationAmountParams = {
   facilityType?: string;
   ukefExposure: number;
@@ -11,7 +16,10 @@ type MapGefObligationAmountParams = {
 type MapObligationAmountParams = MapGefObligationAmountParams & {
   isBssEwcsDeal: boolean;
   isGefDeal: boolean;
+  facilityAmount: number;
 };
+
+export const mapBssEwcsObligationAmount = ({ facilityAmount, ukefExposure }: MapBssEwcsObligationAmountParams): number => facilityAmount * ukefExposure;
 
 /**
  * Maps the obligation amount for a GEF facility.
@@ -45,17 +53,18 @@ export const mapGefObligationAmount = ({ facilityType, ukefExposure }: MapGefObl
  * @param {MapObligationAmountParams} params - Data required to calculate the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
+ * @param {number} [params.facilityAmount] - The facility amount. Only required for BSS/EWCS deals.
  * @param {string} [params.facilityType] - The facility type (e.g. "Cash", "Contingent"). Only required for GEF deals.
  * @param {number} params.ukefExposure - The facility's UKEF exposure.
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */
-export const mapObligationAmount = ({ isBssEwcsDeal, isGefDeal, facilityType, ukefExposure }: MapObligationAmountParams): number | null => {
-  if (isGefDeal) {
-    return mapGefObligationAmount({ facilityType, ukefExposure });
+export const mapObligationAmount = ({ isBssEwcsDeal, isGefDeal, facilityAmount, facilityType, ukefExposure }: MapObligationAmountParams): number | null => {
+  if (isBssEwcsDeal) {
+    return mapBssEwcsObligationAmount({ facilityAmount, ukefExposure });
   }
 
-  if (isBssEwcsDeal) {
-    return ukefExposure;
+  if (isGefDeal) {
+    return mapGefObligationAmount({ facilityType, ukefExposure });
   }
 
   return null;

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
@@ -19,6 +19,13 @@ type MapObligationAmountParams = MapGefObligationAmountParams & {
   facilityAmount: number;
 };
 
+/**
+ * Maps the obligation amount for a BSS/EWCS facility.
+ * @param {MapBssEwcsObligationAmountParams} params - Data required to calculate the obligation amount.
+ * @param {number} params.facilityAmount - The facility amount.
+ * @param {number} params.ukefExposure - The facility's UKEF exposure.
+ * @returns {number} The calculated obligation amount.
+ */
 export const mapBssEwcsObligationAmount = ({ facilityAmount, ukefExposure }: MapBssEwcsObligationAmountParams): number => facilityAmount * ukefExposure;
 
 /**
@@ -53,7 +60,7 @@ export const mapGefObligationAmount = ({ facilityType, ukefExposure }: MapGefObl
  * @param {MapObligationAmountParams} params - Data required to calculate the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
- * @param {number} [params.facilityAmount] - The facility amount. Only required for BSS/EWCS deals.
+ * @param {number} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
  * @param {string} [params.facilityType] - The facility type (e.g. "Cash", "Contingent"). Only required for GEF deals.
  * @param {number} params.ukefExposure - The facility's UKEF exposure.
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.


### PR DESCRIPTION
# Introduction :pencil2:

The obligation amount sent to APIM/GIFT should be mapped differently.

## Resolution :heavy_check_mark:

- Update `mapObligations`, `mapObligation` to have a `facilityAmount` param.
- Create new mapping function, `mapBssEwcsObligationAmount`.
- Update `mapObligationAmount`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
