### PR TITLE
chore(release-please-docs): add chores to release please notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,13 @@
     },
     "pull-request-title-pattern": "chore(${scope}): release${component} ${version}",
     "extra-label": "Type: chore, Type: Docs",
+    "changelog-sections": [
+    { "type": "feat", "hidden": false, "section": "Features" },
+    { "type": "fix", "hidden": false, "section": "Bug Fixes" },
+    { "type": "chore", "hidden": false, "section": "Miscellaneous Chores" },
+    { "type": "docs", "hidden": false, "section": "Docs" },
+    { "type": "revert", "hidden": false, "section": "Reverts" }
+  ],
     "extra-files": [
         "CHANGELOG.md"
     ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,12 +6,12 @@
     "pull-request-title-pattern": "chore(${scope}): release${component} ${version}",
     "extra-label": "Type: chore, Type: Docs",
     "changelog-sections": [
-    { "type": "feat", "hidden": false, "section": "Features" },
-    { "type": "fix", "hidden": false, "section": "Bug Fixes" },
-    { "type": "chore", "hidden": false, "section": "Miscellaneous Chores" },
-    { "type": "docs", "hidden": false, "section": "Docs" },
-    { "type": "revert", "hidden": false, "section": "Reverts" }
-  ],
+        { "type": "feat", "hidden": false, "section": "Features" },
+        { "type": "fix", "hidden": false, "section": "Bug Fixes" },
+        { "type": "chore", "hidden": false, "section": "Miscellaneous Chores" },
+        { "type": "docs", "hidden": false, "section": "Docs" },
+        { "type": "revert", "hidden": false, "section": "Reverts" }
+    ],
     "extra-files": [
         "CHANGELOG.md"
     ]


### PR DESCRIPTION
# Introduction :pencil2:

This PR adds chores to release-please notes.  chores were not showing in the release notes

## Resolution :heavy_check_mark:

* Used change-log sections to add chore and others to change logs
