### PR TITLE
chore(DTFS2-8480): change dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
       - '/dtfs-central-api'
       - '/reverse-proxy'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
       time: '00:00'
     labels:
       - 'chore'
@@ -58,7 +58,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
       time: '00:00'
     labels:
       - 'chore'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       - '/azure-functions/acbs'
       - '/dtfs-central-api'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
       time: '00:00'
     labels:
       - 'chore'


### PR DESCRIPTION
# Introduction :pencil2:

Dependabot currently runs monthly to check for updates.  Given recent package vulnerabilities, dependabot should run weekly

## Resolution :heavy_check_mark:

* change dependabot.yml to run weekly
