### PR TITLE
chore(DTFS2-8406): logging, indentation, test improvements

### DIFF
--- a/external-api/server/v1/controllers/gift-facility.controller.test.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.test.ts
@@ -321,7 +321,7 @@ describe('create', () => {
     // Assert
     expect(console.error).toHaveBeenCalledTimes(0);
     expect(console.info).toHaveBeenNthCalledWith(1, '⚡️ Invoking APIM TFS GIFT - create facility endpoint %s', mockFacilityId);
-    expect(console.info).toHaveBeenNthCalledWith(2, '✅ Successfully created GIFT facility %s', mockFacilityId);
+    expect(console.info).toHaveBeenNthCalledWith(2, '✅ Successfully sent GIFT facility %s creation to APIM TFS', mockFacilityId);
 
     expect(axios).toHaveBeenNthCalledWith(1, {
       method: 'POST',
@@ -356,7 +356,7 @@ describe('create', () => {
     // Assert
     expect(console.error).toHaveBeenCalledTimes(0);
     expect(console.info).toHaveBeenNthCalledWith(1, '⚡️ Invoking APIM TFS GIFT - create facility endpoint %s', mockFacilityId);
-    expect(console.info).toHaveBeenNthCalledWith(2, '✅ Successfully created GIFT facility %s', mockFacilityId);
+    expect(console.info).toHaveBeenNthCalledWith(2, '✅ Successfully sent GIFT facility %s creation to APIM TFS', mockFacilityId);
 
     expect(axios).toHaveBeenNthCalledWith(1, {
       method: 'POST',
@@ -478,7 +478,7 @@ describe('amend', () => {
     // Assert
     expect(console.error).toHaveBeenCalledTimes(0);
     expect(console.info).toHaveBeenNthCalledWith(1, '⚡️ Invoking APIM TFS GIFT - amend facility endpoint %s', mockFacilityId);
-    expect(console.info).toHaveBeenNthCalledWith(2, '✅ Successfully amended GIFT facility');
+    expect(console.info).toHaveBeenNthCalledWith(2, '✅ Successfully sent GIFT facility %s amendment to APIM TFS', mockFacilityId);
 
     expect(axios).toHaveBeenNthCalledWith(1, {
       method: 'POST',

--- a/external-api/server/v1/controllers/gift-facility.controller.ts
+++ b/external-api/server/v1/controllers/gift-facility.controller.ts
@@ -202,7 +202,7 @@ export const create = async (req: Request, res: Response) => {
       return res.sendStatus(status);
     }
 
-    console.info('✅ Successfully created GIFT facility %s', facilityId);
+    console.info('✅ Successfully sent GIFT facility %s creation to APIM TFS', facilityId);
 
     const responseData = 'data' in response ? response.data : undefined;
 
@@ -264,7 +264,7 @@ export const amend = async (req: Request, res: Response) => {
       return res.sendStatus(status);
     }
 
-    console.info('✅ Successfully amended GIFT facility');
+    console.info('✅ Successfully sent GIFT facility %s amendment to APIM TFS', facilityId);
 
     return res.status(status).send({
       success: true,

--- a/portal-ui/templates/contract/about/about-supplier.njk
+++ b/portal-ui/templates/contract/about/about-supplier.njk
@@ -19,12 +19,10 @@
 {% block content %}
 
   {% if validationErrors.count %}
-    {{
-      govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: validationErrors.summary
-      })
-    }}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
   {% endif %}
 
   {{ taskListHeader.render({

--- a/portal-ui/templates/contract/about/about-supply-buyer.njk
+++ b/portal-ui/templates/contract/about/about-supply-buyer.njk
@@ -13,12 +13,10 @@
 {% block content %}
 
   {% if validationErrors.count %}
-    {{
-      govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: validationErrors.summary
-      })
-    }}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
   {% endif %}
 
   {{ taskListHeader.render({

--- a/portal-ui/templates/contract/about/about-supply-check-your-answers.njk
+++ b/portal-ui/templates/contract/about/about-supply-check-your-answers.njk
@@ -10,12 +10,10 @@
 {% block content %}
 
   {% if validationErrors.count %}
-    {{
-      govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: validationErrors.summary
-      })
-    }}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
   {% endif %}
 
   {{ taskListHeader.render({

--- a/portal-ui/templates/contract/about/about-supply-financial.njk
+++ b/portal-ui/templates/contract/about/about-supply-financial.njk
@@ -14,14 +14,11 @@
 {% block content %}
 
 {% if validationErrors.count %}
-    {{
-      govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: validationErrors.summary
-      })
-    }}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: validationErrors.summary
+    }) }}
   {% endif %}
-
 
   {{ taskListHeader.render({
     title: 'Add financial information',
@@ -124,7 +121,6 @@
           }
         ]
       }) }}
-
     </div>
 
     {{ govukButton({
@@ -140,7 +136,6 @@
         "formaction" : "/contract/"+ deal._id +"/about/financial/save-go-back"
       }
     }) }}
-
   </form>
 
 {% endblock %}

--- a/portal-ui/templates/contract/about/components/about-submission-details.njk
+++ b/portal-ui/templates/contract/about/components/about-submission-details.njk
@@ -34,6 +34,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Supplier address
         </dt>
+
         <dd class="govuk-summary-list__value govuk-body-s">
           <p data-cy="supplier-address-line-1">{{ submissionDetails["supplier-address-line-1"]}}</p>
           <p data-cy="supplier-address-line-2">{{ submissionDetails["supplier-address-line-2"]}}</p>
@@ -50,12 +51,13 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Is the Supplier's correspondence address different from the Company's Registered Address?
         </dt>
+
         <dd data-cy="supplier-correspondence-address-is-different" class="govuk-summary-list__value govuk-body-s">
-        {% if submissionDetails["supplier-correspondence-address-is-different"]==='true' %}
-          Yes
-        {% else %}
-          No
-        {% endif %}
+          {% if submissionDetails["supplier-correspondence-address-is-different"]==='true' %}
+            Yes
+          {% else %}
+            No
+          {% endif %}
         </dd>
       </div>
     {% endif %}
@@ -79,6 +81,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Supplier correspondence address
         </dt>
+
         <dd class="govuk-summary-list__value govuk-body-s">
           <p data-cy="supplier-correspondence-address-line-1">{{ submissionDetails["supplier-correspondence-address-line-1"]}}</p>
           <p data-cy="supplier-correspondence-address-line-2">{{ submissionDetails["supplier-correspondence-address-line-2"]}}</p>
@@ -95,6 +98,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Industry sector
         </dt>
+
         <dd data-cy="industry-sector" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails["industry-sector"].name }}
         </dd>
@@ -106,6 +110,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Industry class
         </dt>
+
         <dd data-cy="industry-class" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails["industry-class"].name }}
         </dd>
@@ -117,6 +122,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           SME type
         </dt>
+
         <dd data-cy="sme-type" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails["sme-type"] }}
         </dd>
@@ -128,6 +134,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Description of supply contract
         </dt>
+
         <dd data-cy="supply-contract-description" class="govuk-summary-list__value govuk-body-s preserve-white-space">{{ submissionDetails["supply-contract-description"] }}</dd>
       </div>
     {% endif %}
@@ -137,6 +144,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Is the counter-indemnifier (for bonds) or guarantor (for loans) legally distinct from the supplier?
         </dt>
+
         <dd data-cy="legallyDistinct" class="govuk-summary-list__value govuk-body-s">
           {% if submissionDetails.legallyDistinct ==='true' %}
             Yes
@@ -152,6 +160,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Indemnifier's Companies House registration number, if UK registered
         </dt>
+
         <dd data-cy="indemnifier-companies-house-registration-number" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails["indemnifier-companies-house-registration-number"] }}
         </dd>
@@ -165,6 +174,7 @@
           <dt class="govuk-summary-list__key govuk-body-s">
             Indemnifier name
           </dt>
+
           <dd data-cy="indemnifier-name" class="govuk-summary-list__value govuk-body-s">
             {{ submissionDetails["indemnifier-name"] }}
           </dd>
@@ -179,6 +189,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Indemnifier address
         </dt>
+
         <dd class="govuk-summary-list__value govuk-body-s">
           <p data-cy="indemnifier-address-line-1">{{ submissionDetails["indemnifier-address-line-1"]}}</p>
           <p data-cy="indemnifier-address-line-2">{{ submissionDetails["indemnifier-address-line-2"]}}</p>
@@ -195,6 +206,7 @@
           <dt class="govuk-summary-list__key govuk-body-s">
             Is the Indemnifier's correspondence address different from the Company's Registered Address?
           </dt>
+
           <dd data-cy="indemnifierCorrespondenceAddressDifferent" class="govuk-summary-list__value govuk-body-s">
             {% if submissionDetails.indemnifierCorrespondenceAddressDifferent ==='true' %}
               Yes
@@ -215,6 +227,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Indemnifier correspondence address
         </dt>
+
         <dd class="govuk-summary-list__value govuk-body-s">
           <p data-cy="indemnifier-correspondence-address-line-1">{{ submissionDetails["indemnifier-correspondence-address-line-1"]}}</p>
           <p data-cy="indemnifier-correspondence-address-line-2">{{ submissionDetails["indemnifier-correspondence-address-line-2"]}}</p>
@@ -240,6 +253,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Buyer name
         </dt>
+
         <dd data-cy="buyer-name" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails["buyer-name"] }}
         </dd>
@@ -254,6 +268,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Buyer address
         </dt>
+
         <dd class="govuk-summary-list__value govuk-body-s">
           <p data-cy="buyer-address-line-1">{{ submissionDetails["buyer-address-line-1"]}}</p>
           <p data-cy="buyer-address-line-2">{{ submissionDetails["buyer-address-line-2"]}}</p>
@@ -269,6 +284,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Country of buyer
         </dt>
+
         <dd data-cy="buyer-address-country" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails['buyer-address-country'].name }}
         </dd>
@@ -280,6 +296,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Destination of goods and services
         </dt>
+
         <dd data-cy="destinationOfGoodsAndServices" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails.destinationOfGoodsAndServices.name }}
         </dd>
@@ -300,6 +317,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Supply Contract value (in Supply Contract currency)
         </dt>
+
         <dd data-cy="supplyContractValue" class="govuk-summary-list__value govuk-body-s" data-mask="currency">
           {{ submissionDetails.supplyContractValue }}
         </dd>
@@ -311,6 +329,7 @@
         <dt class="govuk-summary-list__key govuk-body-s">
           Supply Contract currency
         </dt>
+
         <dd data-cy="supplyContractCurrency" class="govuk-summary-list__value govuk-body-s">
           {{ submissionDetails.supplyContractCurrency.text }}
         </dd>
@@ -324,6 +343,7 @@
           <dt class="govuk-summary-list__key govuk-body-s">
             Conversion rate from Supply Contract currency to GBP
           </dt>
+
           <dd data-cy="supplyContractConversionRateToGBP" class="govuk-summary-list__value govuk-body-s">
             {{ submissionDetails.supplyContractConversionRateToGBP }}
           </dd>
@@ -335,6 +355,7 @@
           <dt class="govuk-summary-list__key govuk-body-s">
             Supply Contract conversion date, as determined by the bank(Supply Contract currency to GBP)
           </dt>
+
           <dd data-cy="supplyContractConversionDate" class="govuk-summary-list__value govuk-body-s">
             {{ submissionDetails.supplyContractConversionDate }}
           </dd>

--- a/portal-ui/templates/contract/about/components/indemnifier-correspondence-address.njk
+++ b/portal-ui/templates/contract/about/components/indemnifier-correspondence-address.njk
@@ -8,35 +8,33 @@
   {% set countries = opts.countries %}
   {% set validationErrors = opts.validationErrors %}
 
-  {{
-    govukRadios({
-      fieldset: {
-        legend: { text: "Is the Indemnifier's correspondence address different from the Company's Registered Address?" }
-      },
-      idPrefix: "indemnifierCorrespondenceAddressDifferent",
-      name: "indemnifierCorrespondenceAddressDifferent",
-      classes: "govuk-radios--inline",
-      items: [
-        {
-          value: "true",
-          text: "Yes",
-          attributes: {
-            "data-cy": "indemnifierCorrespondenceAddressDifferent-true"
-          },
-          checked: deal.submissionDetails.indemnifierCorrespondenceAddressDifferent === 'true'
+  {{ govukRadios({
+    fieldset: {
+      legend: { text: "Is the Indemnifier's correspondence address different from the Company's Registered Address?" }
+    },
+    idPrefix: "indemnifierCorrespondenceAddressDifferent",
+    name: "indemnifierCorrespondenceAddressDifferent",
+    classes: "govuk-radios--inline",
+    items: [
+      {
+        value: "true",
+        text: "Yes",
+        attributes: {
+          "data-cy": "indemnifierCorrespondenceAddressDifferent-true"
         },
-        {
-          value: "false",
-          text: "No",
-          attributes: {
-            "data-cy": "indemnifierCorrespondenceAddressDifferent-false"
-          },
-          checked: deal.submissionDetails.indemnifierCorrespondenceAddressDifferent === 'false'
-        }
-      ],
-      errorMessage: validationErrors.errorList.indemnifierCorrespondenceAddress
-    })
-  }}
+        checked: deal.submissionDetails.indemnifierCorrespondenceAddressDifferent === 'true'
+      },
+      {
+        value: "false",
+        text: "No",
+        attributes: {
+          "data-cy": "indemnifierCorrespondenceAddressDifferent-false"
+        },
+        checked: deal.submissionDetails.indemnifierCorrespondenceAddressDifferent === 'false'
+      }
+    ],
+    errorMessage: validationErrors.errorList.indemnifierCorrespondenceAddress
+  }) }}
 
   <div id="additional-form-fields-indemnifier-correspondence-address" class="{% if deal.submissionDetails.indemnifierCorrespondenceAddressDifferent !== 'true' %}display-none{% endif %}">
     {{ address.fields(

--- a/portal-ui/templates/contract/about/components/input-companies-house-reg-number.njk
+++ b/portal-ui/templates/contract/about/components/input-companies-house-reg-number.njk
@@ -3,10 +3,10 @@
 
 {% macro input(opts) %}
 
-  {% set prefix=opts.prefix %}
-  {% set label=opts.label %}
-  {% set deal=opts.deal %}
-  {% set errorMessage=opts.validationErrors.errorList[prefix+'-companies-house-registration-number'] %}
+  {% set prefix = opts.prefix %}
+  {% set label = opts.label %}
+  {% set deal = opts.deal %}
+  {% set errorMessage = opts.validationErrors.errorList[prefix+'-companies-house-registration-number'] %}
 
   {{ govukInput({
     label: { text: label },
@@ -22,10 +22,10 @@
   }) }}
 
   {{ govukButton({
-    "text": "Search",
-    "attributes" : {
-      "data-cy" : "DoSearch-" + prefix+'-companies-house-registration-number',
-      "formaction" : "/contract/" + deal._id + "/about/supplier/companies-house-search/" + prefix
+    text: "Search",
+    attributes: {
+      "data-cy": "DoSearch-" + prefix+'-companies-house-registration-number',
+      "formaction": "/contract/" + deal._id + "/about/supplier/companies-house-search/" + prefix
     }
   }) }}
 

--- a/portal-ui/templates/contract/about/components/legally-distinct-counter-indemnifier_slash_guarantor.njk
+++ b/portal-ui/templates/contract/about/components/legally-distinct-counter-indemnifier_slash_guarantor.njk
@@ -9,35 +9,33 @@
   {% set countries = opts.mappedCountries %}
   {% set validationErrors = opts.validationErrors %}
 
-  {{
-    govukRadios({
-      fieldset: {
-        legend: { text: "Is the counter-indemnifier (for bonds) or guarantor (for loans) legally distinct from the supplier?" }
-      },
-      idPrefix: "legallyDistinct-",
-      name: "legallyDistinct",
-      classes: "govuk-radios--inline",
-      items: [
-        {
-          value: "true",
-          text: "Yes",
-          attributes: {
-            "data-cy": "legallyDistinct-true"
-          },
-          checked: deal.submissionDetails.legallyDistinct === 'true'
+  {{ govukRadios({
+    fieldset: {
+      legend: { text: "Is the counter-indemnifier (for bonds) or guarantor (for loans) legally distinct from the supplier?" }
+    },
+    idPrefix: "legallyDistinct-",
+    name: "legallyDistinct",
+    classes: "govuk-radios--inline",
+    items: [
+      {
+        value: "true",
+        text: "Yes",
+        attributes: {
+          "data-cy": "legallyDistinct-true"
         },
-        {
-          value: "false",
-          text: "No",
-          attributes: {
-            "data-cy": "legallyDistinct-false"
-          },
-          checked: deal.submissionDetails.legallyDistinct === 'false'
-        }
-      ],
-      errorMessage: validationErrors.errorList.legallyDistinct
-    })
-  }}
+        checked: deal.submissionDetails.legallyDistinct === 'true'
+      },
+      {
+        value: "false",
+        text: "No",
+        attributes: {
+          "data-cy": "legallyDistinct-false"
+        },
+        checked: deal.submissionDetails.legallyDistinct === 'false'
+      }
+    ],
+    errorMessage: validationErrors.errorList.legallyDistinct
+  }) }}
 
   {% set renderByDefault=deal.submissionDetails.legallyDistinct %}
 

--- a/portal-ui/templates/contract/about/components/sme-type-radios.njk
+++ b/portal-ui/templates/contract/about/components/sme-type-radios.njk
@@ -8,7 +8,7 @@
     fieldset: {
       legend: { text: "SME type" }
     },
-    hint: { html: 'Confirm the SME type based on the <a href="https://ec.europa.eu/growth/smes/business-friendly-environment/sme-definition" target="_blank">European Commission definitions</a>' },
+    hint: { html: 'Confirm the SME type based on the <a href="https://ec.europa.eu/growth/smes/business-friendly-environment/sme-definition" target="_blank" rel="noreferrer noopener">European Commission definitions</a>' },
     idPrefix: "sme-type-",
     name: "sme-type",
     classes: "govuk-radios--inline",

--- a/portal-ui/templates/contract/about/components/sme-type-radios.njk
+++ b/portal-ui/templates/contract/about/components/sme-type-radios.njk
@@ -4,43 +4,41 @@
   {% set deal = opts.deal %}
   {% set validationErrors = opts.validationErrors %}
 
-  {{
-    govukRadios({
-      fieldset: {
-        legend: { text: "SME type" }
+  {{ govukRadios({
+    fieldset: {
+      legend: { text: "SME type" }
+    },
+    hint: { html: 'Confirm the SME type based on the <a href="https://ec.europa.eu/growth/smes/business-friendly-environment/sme-definition" target="_blank">European Commission definitions</a>' },
+    idPrefix: "sme-type-",
+    name: "sme-type",
+    classes: "govuk-radios--inline",
+    items: [
+      {
+        value: "Micro",
+        text: "Micro",
+        attributes: { "data-cy": "sme-type-Micro" },
+        checked: deal.submissionDetails["sme-type"] === 'Micro'
       },
-      hint: { html: 'Confirm the SME type based on the <a href="https://ec.europa.eu/growth/smes/business-friendly-environment/sme-definition" target="_blank">European Commission definitions</a>' },
-      idPrefix: "sme-type-",
-      name: "sme-type",
-      classes: "govuk-radios--inline",
-      items: [
-        {
-          value: "Micro",
-          text: "Micro",
-          attributes: { "data-cy": "sme-type-Micro" },
-          checked: deal.submissionDetails["sme-type"] === 'Micro'
-        },
-        {
-          value: "Small",
-          text: "Small",
-          attributes: { "data-cy": "sme-type-Small" },
-          checked: deal.submissionDetails["sme-type"] === 'Small'
-        },
-        {
-          value: "Medium",
-          text: "Medium",
-          attributes: { "data-cy": "sme-type-Medium" },
-          checked: deal.submissionDetails["sme-type"] === 'Medium'
-        },
-        {
-          value: "Non-SME",
-          text: "Non-SME",
-          attributes: { "data-cy": "sme-type-Non-SME" },
-          checked: deal.submissionDetails["sme-type"] === 'Non-SME'
-        }
-      ],
-      errorMessage: validationErrors.errorList["sme-type"]
-    })
-  }}
+      {
+        value: "Small",
+        text: "Small",
+        attributes: { "data-cy": "sme-type-Small" },
+        checked: deal.submissionDetails["sme-type"] === 'Small'
+      },
+      {
+        value: "Medium",
+        text: "Medium",
+        attributes: { "data-cy": "sme-type-Medium" },
+        checked: deal.submissionDetails["sme-type"] === 'Medium'
+      },
+      {
+        value: "Non-SME",
+        text: "Non-SME",
+        attributes: { "data-cy": "sme-type-Non-SME" },
+        checked: deal.submissionDetails["sme-type"] === 'Non-SME'
+      }
+    ],
+    errorMessage: validationErrors.errorList["sme-type"]
+  }) }}
 
 {% endmacro %}

--- a/portal-ui/templates/contract/about/components/supplier-correspondence-address.njk
+++ b/portal-ui/templates/contract/about/components/supplier-correspondence-address.njk
@@ -6,33 +6,31 @@
   {% set countries = opts.mappedCountries %}
   {% set validationErrors = opts.validationErrors %}
 
-    {{
-      govukRadios({
-        fieldset: {
-          legend: { text: "Is the Supplier's correspondence address different from the Company's Registered Address?" }
-        },
-        idPrefix: "supplier-correspondence-address-is-different-",
-        name: "supplier-correspondence-address-is-different",
-        classes: "govuk-radios--inline",
-        items: [
-          {
-            text: "Yes", value: "true",
-            checked: deal.submissionDetails["supplier-correspondence-address-is-different"] === 'true',
-            attributes: {
-              "data-cy": "supplier-correspondence-address-is-different-true"
-            }
-          },
-          {
-            text: "No", value: "false",
-            checked: deal.submissionDetails["supplier-correspondence-address-is-different"] === 'false',
-            attributes: {
-              "data-cy": "supplier-correspondence-address-is-different-false"
-            }
+    {{ govukRadios({
+      fieldset: {
+        legend: { text: "Is the Supplier's correspondence address different from the Company's Registered Address?" }
+      },
+      idPrefix: "supplier-correspondence-address-is-different-",
+      name: "supplier-correspondence-address-is-different",
+      classes: "govuk-radios--inline",
+      items: [
+        {
+          text: "Yes", value: "true",
+          checked: deal.submissionDetails["supplier-correspondence-address-is-different"] === 'true',
+          attributes: {
+            "data-cy": "supplier-correspondence-address-is-different-true"
           }
-        ],
-        errorMessage: validationErrors.errorList["supplier-correspondence-address-is-different"]
-      })
-    }}
+        },
+        {
+          text: "No", value: "false",
+          checked: deal.submissionDetails["supplier-correspondence-address-is-different"] === 'false',
+          attributes: {
+            "data-cy": "supplier-correspondence-address-is-different-false"
+          }
+        }
+      ],
+      errorMessage: validationErrors.errorList["supplier-correspondence-address-is-different"]
+    }) }}
 
     {% set renderByDefault=deal.submissionDetails["supplier-correspondence-address-is-different"] %}
 

--- a/portal-ui/templates/contract/about/components/supplier-name-and-address-lookup.njk
+++ b/portal-ui/templates/contract/about/components/supplier-name-and-address-lookup.njk
@@ -14,7 +14,7 @@
     validationErrors: validationErrors
   }) }}
 
-   <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count" data-maxlength="150">
+  <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count" data-maxlength="150">
     {{ govukInput({
       label: {
         text: "Supplier name"
@@ -33,7 +33,6 @@
     <span id="supplier-name-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
       You can enter up to 150 characters
     </span>
-  </div>
   </div>
 
   {{ address.fields(

--- a/trade-finance-manager-api/api-tests/v1/deals/deal-controller.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deal-controller.api-test.js
@@ -36,7 +36,7 @@ describe('deal controller', () => {
 
   describe('findOnePortalDeal', () => {
     it('should return false if the deal does not exist', async () => {
-      // Act
+      // Arrange & Act
       const deal = await findOnePortalDeal('NO_DEAL_ID');
 
       // Assert
@@ -44,7 +44,7 @@ describe('deal controller', () => {
     });
 
     it('should fetch a portal deal', async () => {
-      // Act
+      // Arrange & Act
       const deal = await findOnePortalDeal(MOCK_BSS_EWCS_DEAL._id);
 
       // Assert

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -127,7 +127,7 @@ describe('/v1/deals', () => {
       expect(tfmDataWithPartiesObject).toEqual(expected);
     });
 
-    it('should return  the requested resource if no companies house number is given', async () => {
+    it('should return the requested resource if no companies house number is given', async () => {
       // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_NO_COMPANIES_HOUSE));
 

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -1,3 +1,4 @@
+const { HttpStatusCode } = require('axios');
 const { DEAL_SUBMISSION_TYPE, DEAL_TYPE, CURRENCY } = require('@ukef/dtfs2-common');
 const { generatePortalAuditDetails } = require('@ukef/dtfs2-common/change-stream');
 const api = require('../../../server/v1/api');
@@ -90,21 +91,27 @@ describe('/v1/deals', () => {
   const auditDetails = generatePortalAuditDetails(mockChecker._id);
 
   describe('PUT /v1/deals/:dealId/submit', () => {
-    it('400s submission for invalid checker id', async () => {
+    it(`${HttpStatusCode.BadRequest}s submission for invalid checker id`, async () => {
+      // Arrange & Act
       const { status } = await submitDeal({ checker: { _id: '12345678910' } });
 
-      expect(status).toEqual(400);
+      // Assert
+      expect(status).toEqual(HttpStatusCode.BadRequest);
     });
 
-    it('404s submission for unknown id', async () => {
+    it(`${HttpStatusCode.NotFound}s submission for unknown id`, async () => {
+      // Arrange & Act
       const { status } = await submitDeal({ dealId: '12345678910', checker: mockChecker });
 
-      expect(status).toEqual(404);
+      // Assert
+      expect(status).toEqual(HttpStatusCode.NotFound);
     });
 
     it('should add TFM deal data', async () => {
+      // Arrange & Act
       const { body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
 
+      // Assert
       const mappedDeal = await mapSubmittedDeal(body);
       const tfmDataObject = await addTfmDealData(mappedDeal, generatePortalAuditDetails(mockChecker._id));
 
@@ -121,7 +128,10 @@ describe('/v1/deals', () => {
     });
 
     it('returns the requested resource if no companies house number is given', async () => {
+      // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_NO_COMPANIES_HOUSE));
+
+      // Assert
       // Remove bonds & loans as they are returned mutated so will not match
       const { bondTransactions: _bondTransaction, loanTransactions: _loanTransaction, ...mockDealWithoutFacilities } = MOCK_BSS_EWCS_DEAL_NO_COMPANIES_HOUSE;
 
@@ -137,12 +147,15 @@ describe('/v1/deals', () => {
         },
       };
 
-      expect(status).toEqual(200);
+      expect(status).toEqual(HttpStatusCode.Ok);
       expect(body).toMatchObject(tfmDeal);
     });
 
     it('returns the requested resource without partyUrn if not matched', async () => {
+      // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_NO_PARTY_DB));
+
+      // Assert
       // Remove bonds & loans as they are returned mutated so will not match
       const { bondTransactions: _bondTransaction, loanTransactions: _loanTransaction, ...mockDealWithoutFacilities } = MOCK_BSS_EWCS_DEAL_NO_PARTY_DB;
 
@@ -158,13 +171,15 @@ describe('/v1/deals', () => {
         },
       };
 
-      expect(status).toEqual(200);
+      expect(status).toEqual(HttpStatusCode.Ok);
       expect(body).toMatchObject(tfmDeal);
     });
 
     it('returns the requested resource with partyUrn if matched', async () => {
+      // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL));
 
+      // Assert
       // Remove bonds & loans as they are returned mutated so will not match
       const { bondTransactions: _bondTransaction, loanTransactions: _loanTransaction, ...mockDealWithoutFacilities } = MOCK_BSS_EWCS_DEAL;
 
@@ -180,14 +195,17 @@ describe('/v1/deals', () => {
         },
       };
 
-      expect(status).toEqual(200);
+      expect(status).toEqual(HttpStatusCode.Ok);
       expect(body).toMatchObject(tfmDeal);
     });
 
     describe(`when currency is NOT ${CURRENCY.GBP}`, () => {
       it(`should convert supplyContractValue to ${CURRENCY.GBP}`, async () => {
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED_NON_GBP_CONTRACT_VALUE));
-        expect(status).toEqual(200);
+
+        // Assert
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const { supplyContractValue } = MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED_NON_GBP_CONTRACT_VALUE.submissionDetails;
 
@@ -203,9 +221,11 @@ describe('/v1/deals', () => {
       describe(`when deal is ${DEAL_SUBMISSION_TYPE.AIN}`, () => {
         describe('when deal status is `Submitted`', () => {
           it('should add `Application` tfm stage', async () => {
+            // Arrange & Act
             const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_AIN));
 
-            expect(status).toEqual(200);
+            // Assert
+            expect(status).toEqual(HttpStatusCode.Ok);
 
             expect(body.tfm.stage).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
           });
@@ -215,9 +235,11 @@ describe('/v1/deals', () => {
       describe(`when deal is ${DEAL_SUBMISSION_TYPE.MIA}`, () => {
         describe('when deal status is `Submitted`', () => {
           it('should add `Application` tfm stage', async () => {
+            // Arrange & Act
             const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_MIA));
 
-            expect(status).toEqual(200);
+            // Assert
+            expect(status).toEqual(HttpStatusCode.Ok);
             expect(body.tfm.stage).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
           });
         });
@@ -225,17 +247,22 @@ describe('/v1/deals', () => {
 
       describe(`when deal is ${DEAL_SUBMISSION_TYPE.MIN}`, () => {
         it('should add `Application` tfm stage', async () => {
+          // Arrange & Act
           const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_MIN));
-          expect(status).toEqual(200);
+
+          // Assert
+          expect(status).toEqual(HttpStatusCode.Ok);
           expect(body.tfm.stage).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
         });
       });
     });
 
     it('adds dateReceived to deal.tfm', async () => {
+      // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
 
-      expect(status).toEqual(200);
+      // Assert
+      expect(status).toEqual(HttpStatusCode.Ok);
 
       const expectedDateReceived = generateDateReceived().dateReceived;
       expect(body.tfm.dateReceived).toEqual(expectedDateReceived);
@@ -243,14 +270,19 @@ describe('/v1/deals', () => {
     });
 
     describe(`when dealType is '${DEAL_TYPE.GEF}'`, () => {
-      it('should return 200', async () => {
+      it(`should return ${HttpStatusCode.Ok}`, async () => {
+        // Arrange & Act
         const { status } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_AIN));
-        expect(status).toEqual(200);
+
+        // Assert
+        expect(status).toEqual(HttpStatusCode.Ok);
       });
 
       it('should call updateGefFacility', async () => {
+        // Arrange & Act
         const { body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_AIN));
 
+        // Assert
         const facilityId = body.facilities.find((f) => f.hasBeenIssued === true)._id;
 
         expect(updateGefFacilitySpy).toHaveBeenCalledWith({
@@ -266,8 +298,10 @@ describe('/v1/deals', () => {
     describe('portal status updates', () => {
       describe(`when ${DEAL_SUBMISSION_TYPE.AIN} ${DEAL_TYPE.BSS} deal is submitted`, () => {
         it('should call externalApis.updatePortalDealStatus with correct status', async () => {
+          // Arrange & Act
           await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL));
 
+          // Assert
           expect(updatePortalBssDealStatusSpy).toHaveBeenCalledWith({
             dealId: MOCK_BSS_EWCS_DEAL._id,
             status: CONSTANTS.DEALS.PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED,
@@ -278,8 +312,10 @@ describe('/v1/deals', () => {
 
       describe(`when ${DEAL_SUBMISSION_TYPE.MIN} ${DEAL_TYPE.BSS} deal is submitted`, () => {
         it('should call externalApis.updatePortalDealStatus with correct status', async () => {
+          // Arrange & Act
           await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_MIN));
 
+          // Assert
           expect(updatePortalBssDealStatusSpy).toHaveBeenCalledWith({
             dealId: MOCK_BSS_EWCS_DEAL_MIN._id,
             status: CONSTANTS.DEALS.PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED,
@@ -290,8 +326,10 @@ describe('/v1/deals', () => {
 
       describe(`when ${DEAL_SUBMISSION_TYPE.MIA} ${DEAL_TYPE.BSS} deal is submitted`, () => {
         it('should call externalApis.updatePortalDealStatus with correct status', async () => {
+          // Arrange & Act
           await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_MIA));
 
+          // Assert
           expect(updatePortalBssDealStatusSpy).toHaveBeenCalledWith({
             dealId: MOCK_BSS_EWCS_DEAL_MIA._id,
             status: CONSTANTS.DEALS.PORTAL_DEAL_STATUS.IN_PROGRESS_BY_UKEF,
@@ -302,8 +340,10 @@ describe('/v1/deals', () => {
 
       describe(`when ${DEAL_SUBMISSION_TYPE.AIN} ${DEAL_TYPE.GEF} deal is submitted`, () => {
         it('should call externalApis.updateGefDealStatus with correct status', async () => {
+          // Arrange & Act
           await submitDeal(createSubmitBody(MOCK_GEF_DEAL_AIN));
 
+          // Assert
           expect(updatePortalGefDealStatusSpy).toHaveBeenCalledWith({
             dealId: MOCK_GEF_DEAL_AIN._id,
             status: CONSTANTS.DEALS.PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED,
@@ -314,8 +354,10 @@ describe('/v1/deals', () => {
 
       describe(`when ${DEAL_SUBMISSION_TYPE.MIN} ${DEAL_TYPE.GEF} deal is submitted`, () => {
         it('should call externalApis.updateGefDealStatus with correct status', async () => {
+          // Arrange & Act
           await submitDeal(createSubmitBody(MOCK_GEF_DEAL_MIN));
 
+          // Assert
           expect(updatePortalGefDealStatusSpy).toHaveBeenCalledWith({
             dealId: MOCK_GEF_DEAL_MIN._id,
             status: CONSTANTS.DEALS.PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED,
@@ -326,8 +368,10 @@ describe('/v1/deals', () => {
 
       describe(`when ${DEAL_SUBMISSION_TYPE.MIA} ${DEAL_TYPE.GEF} deal is submitted`, () => {
         it('should call externalApis.updateGefDealStatus with correct status', async () => {
+          // Arrange & Act
           await submitDeal(createSubmitBody(MOCK_GEF_DEAL_MIA));
 
+          // Assert
           expect(updatePortalGefDealStatusSpy).toHaveBeenCalledWith({
             dealId: MOCK_GEF_DEAL_MIA._id,
             status: CONSTANTS.DEALS.PORTAL_DEAL_STATUS.IN_PROGRESS_BY_UKEF,
@@ -338,12 +382,15 @@ describe('/v1/deals', () => {
     });
 
     it('should call canSendToApimGift', async () => {
+      // Arrange & Act
       const { body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL));
 
+      // Assert
       expect(canSendToApimGift).toHaveBeenCalledWith(body);
     });
 
     it('should call sendFacilitiesToApimGift', async () => {
+      // Arrange
       const mockIssuedFacilities = [...MOCK_BSS_EWCS_DEAL.bondTransactions.items, ...MOCK_BSS_EWCS_DEAL.loanTransactions.items].filter(
         (facility) => facility.hasBeenIssued,
       );
@@ -353,8 +400,10 @@ describe('/v1/deals', () => {
         issuedFacilities: mockIssuedFacilities,
       });
 
+      // Act
       await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL));
 
+      // Assert
       const submittedDeal = canSendToApimGift.mock.calls[0][0];
 
       expect(sendFacilitiesToApimGift).toHaveBeenNthCalledWith(
@@ -394,6 +443,7 @@ describe('/v1/deals', () => {
 
       describe('when all issued facilities are not in GIFT', () => {
         it('should call sendFacilitiesToApimGift with all issued facilities', async () => {
+          // Arrange
           canSendToApimGift.mockResolvedValueOnce({
             canSendFacilitiesToApimGift: true,
             issuedFacilities: [mockFacility1, mockFacility2],
@@ -401,8 +451,12 @@ describe('/v1/deals', () => {
             isGefDeal: false,
           });
 
+          // Act
           await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
+
+          // Assert
           const submittedDeal = canSendToApimGift.mock.calls[0][0];
+
           expect(sendFacilitiesToApimGift).toHaveBeenNthCalledWith(
             1,
             expect.objectContaining({
@@ -417,6 +471,7 @@ describe('/v1/deals', () => {
 
       describe('when there are no issued facilities to send to GIFT', () => {
         it('should not call sendFacilitiesToApimGift', async () => {
+          // Arrange
           canSendToApimGift.mockResolvedValueOnce({
             canSendFacilitiesToApimGift: false,
             issuedFacilities: [], // no facilities to send
@@ -424,13 +479,17 @@ describe('/v1/deals', () => {
             isGefDeal: false,
           });
 
+          // Act
           await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
+
+          // Assert
           expect(sendFacilitiesToApimGift).not.toHaveBeenCalled();
         });
       });
 
       describe('when some issued facilities are in GIFT, some are not', () => {
         it('should call sendFacilitiesToApimGift with the issued facilities that are not in GIFT', async () => {
+          // Arrange
           canSendToApimGift.mockResolvedValueOnce({
             canSendFacilitiesToApimGift: true,
             issuedFacilities: [mockFacility2, mockFacility3], // only facility 2 and 3 are not in GIFT
@@ -438,8 +497,12 @@ describe('/v1/deals', () => {
             isGefDeal: false,
           });
 
+          // Act
           await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
+
+          // Assert
           const submittedDeal = canSendToApimGift.mock.calls[0][0];
+
           expect(sendFacilitiesToApimGift).toHaveBeenNthCalledWith(
             1,
             expect.objectContaining({

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -91,7 +91,7 @@ describe('/v1/deals', () => {
   const auditDetails = generatePortalAuditDetails(mockChecker._id);
 
   describe('PUT /v1/deals/:dealId/submit', () => {
-    it(`${HttpStatusCode.BadRequest}s submission for invalid checker id`, async () => {
+    it(`should return ${HttpStatusCode.BadRequest} for a submission with an invalid checker id`, async () => {
       // Arrange & Act
       const { status } = await submitDeal({ checker: { _id: '12345678910' } });
 
@@ -99,7 +99,7 @@ describe('/v1/deals', () => {
       expect(status).toEqual(HttpStatusCode.BadRequest);
     });
 
-    it(`${HttpStatusCode.NotFound}s submission for unknown id`, async () => {
+    it(`should return ${HttpStatusCode.NotFound} for a submission with an unknown id`, async () => {
       // Arrange & Act
       const { status } = await submitDeal({ dealId: '12345678910', checker: mockChecker });
 
@@ -127,7 +127,7 @@ describe('/v1/deals', () => {
       expect(tfmDataWithPartiesObject).toEqual(expected);
     });
 
-    it('returns the requested resource if no companies house number is given', async () => {
+    it('should return  the requested resource if no companies house number is given', async () => {
       // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_NO_COMPANIES_HOUSE));
 
@@ -151,7 +151,7 @@ describe('/v1/deals', () => {
       expect(body).toMatchObject(tfmDeal);
     });
 
-    it('returns the requested resource without partyUrn if not matched', async () => {
+    it('should return the requested resource without partyUrn if not matched', async () => {
       // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_NO_PARTY_DB));
 
@@ -175,7 +175,7 @@ describe('/v1/deals', () => {
       expect(body).toMatchObject(tfmDeal);
     });
 
-    it('returns the requested resource with partyUrn if matched', async () => {
+    it('should return the requested resource with partyUrn if matched', async () => {
       // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL));
 
@@ -257,7 +257,7 @@ describe('/v1/deals', () => {
       });
     });
 
-    it('adds dateReceived to deal.tfm', async () => {
+    it('should add dateReceived to deal.tfm', async () => {
       // Arrange & Act
       const { status, body } = await submitDeal(createSubmitBody(MOCK_BSS_EWCS_DEAL_AIN_SUBMITTED));
 

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -525,7 +525,6 @@ describe('/v1/deals', () => {
       });
 
       it('should update bond status to `Acknowledged` if the facilityStage changes from `Unissued` to `Issued`', async () => {
-        // Assert
         // Arrange
         // check status before calling submit endpoint
         const initialBond = MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED.bondTransactions.items[0];

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -1,3 +1,4 @@
+const { HttpStatusCode } = require('axios');
 const { AUDIT_USER_TYPES, DEAL_SUBMISSION_TYPE, DEAL_TYPE, FACILITY_TYPE } = require('@ukef/dtfs2-common');
 const { set } = require('date-fns');
 const { cloneDeep } = require('lodash');
@@ -140,14 +141,14 @@ describe('/v1/deals', () => {
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
           expect(updatedBond.status).toEqual('Acknowledged');
         });
 
         it('should call updatePortalFacilityStatus with `Acknowledged` status', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           const bondId = body.dealSnapshot.bondTransactions.items[0]._id;
@@ -157,11 +158,11 @@ describe('/v1/deals', () => {
         });
 
         it('should update bond.exposurePeriodInMonths', async () => {
-          // Act
+          // Arrange & Act
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
 
@@ -183,7 +184,7 @@ describe('/v1/deals', () => {
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
 
@@ -192,11 +193,11 @@ describe('/v1/deals', () => {
         });
 
         it('should add bond.premiumSchedule', async () => {
-          // Act
+          // Arrange & Act
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
 
@@ -205,7 +206,7 @@ describe('/v1/deals', () => {
         });
 
         it('should call updatePortalFacility', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
@@ -222,7 +223,7 @@ describe('/v1/deals', () => {
         });
 
         it('should add bond.hasBeenAcknowledged', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
@@ -232,7 +233,7 @@ describe('/v1/deals', () => {
         });
 
         it('should add bond.hasBeenIssuedAndAcknowledged', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
@@ -253,7 +254,7 @@ describe('/v1/deals', () => {
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -261,7 +262,7 @@ describe('/v1/deals', () => {
         });
 
         it('should call updatePortalFacilityStatus with `Acknowledged` status', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
@@ -271,11 +272,11 @@ describe('/v1/deals', () => {
         });
 
         it('should update loan.exposurePeriodInMonths', async () => {
-          // Act
+          // Arrange & Act
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -297,7 +298,7 @@ describe('/v1/deals', () => {
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -306,11 +307,11 @@ describe('/v1/deals', () => {
         });
 
         it('should add loan.premiumSchedule', async () => {
-          // Act
+          // Arrange & Act
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
-          expect(status).toEqual(200);
+          expect(status).toEqual(HttpStatusCode.Ok);
 
           const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -319,7 +320,7 @@ describe('/v1/deals', () => {
         });
 
         it('should call updatePortalFacility', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
@@ -336,7 +337,7 @@ describe('/v1/deals', () => {
         });
 
         it('should add loan.hasBeenAcknowledged', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
@@ -346,7 +347,7 @@ describe('/v1/deals', () => {
         });
 
         it('should add loan.hasBeenAcknowledged', async () => {
-          // Act
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
           // Assert
@@ -391,7 +392,7 @@ describe('/v1/deals', () => {
         const { status } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         expect(canSubmitToACBS).toHaveBeenCalledTimes(2);
         expect(canSubmitToACBS).toHaveBeenCalledWith({ deal: expect.any(Object) });
@@ -410,8 +411,7 @@ describe('/v1/deals', () => {
       });
 
       it('should not call sendFacilitiesToApimGift', async () => {
-        // Arrange
-        // Act
+        // Arrange & Act
         await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
@@ -465,7 +465,7 @@ describe('/v1/deals', () => {
         });
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         expect(body.submissionType).toEqual('Manual Inclusion Notice');
         expect(typeof body.manualInclusionNoticeSubmissionDate).toEqual('string');
@@ -476,7 +476,7 @@ describe('/v1/deals', () => {
       });
 
       it('should call canSendToApimGift', async () => {
-        // Act
+        // Arrange & Act
         await submitDeal(createSubmitBody(MOCK_MIA_SECOND_SUBMIT));
 
         // Assert
@@ -484,7 +484,7 @@ describe('/v1/deals', () => {
       });
 
       it('should NOT call sendFacilitiesToApimGift', async () => {
-        // Act
+        // Arrange & Act
         await submitDeal(createSubmitBody(MOCK_MIA_SECOND_SUBMIT));
 
         // Assert
@@ -525,6 +525,7 @@ describe('/v1/deals', () => {
       });
 
       it('should update bond status to `Acknowledged` if the facilityStage changes from `Unissued` to `Issued`', async () => {
+        // Assert
         // Arrange
         // check status before calling submit endpoint
         const initialBond = MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED.bondTransactions.items[0];
@@ -535,7 +536,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
         expect(updatedBond.status).toEqual('Acknowledged');
@@ -551,7 +552,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
         expect(updatedLoan.status).toEqual('Acknowledged');
@@ -565,7 +566,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         expect(canSubmitToACBS).toHaveBeenCalledTimes(2);
         expect(canSubmitToACBS).toHaveBeenCalledWith({ deal: body });
@@ -588,7 +589,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
 
@@ -597,11 +598,11 @@ describe('/v1/deals', () => {
       });
 
       it('should add bond.premiumSchedule', async () => {
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
 
@@ -623,7 +624,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -632,11 +633,11 @@ describe('/v1/deals', () => {
       });
 
       it('should add loan.premiumSchedule', async () => {
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -671,7 +672,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
 
@@ -690,7 +691,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedBond = body.facilities.find((f) => f.type === FACILITY_TYPE.BOND);
 
@@ -712,7 +713,7 @@ describe('/v1/deals', () => {
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -721,11 +722,11 @@ describe('/v1/deals', () => {
       });
 
       it('should add loan.premiumSchedule', async () => {
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const updatedLoan = body.facilities.find((f) => f.type === FACILITY_TYPE.LOAN);
 
@@ -741,7 +742,7 @@ describe('/v1/deals', () => {
         const { status } = await submitDeal(createSubmitBody(MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         expect(canSubmitToACBS).toHaveBeenCalledTimes(2);
         expect(canSubmitToACBS).toHaveBeenCalledWith({ deal: expect.any(Object) });
@@ -752,7 +753,7 @@ describe('/v1/deals', () => {
       });
 
       it('should call canSendToApimGift', async () => {
-        // Act
+        // Arrange & Act
         await submitDeal(createSubmitBody(MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
@@ -760,8 +761,7 @@ describe('/v1/deals', () => {
       });
 
       it('should NOT call sendFacilitiesToApimGift', async () => {
-        // Arrange
-        // Act
+        // Arrange & Act
         await submitDeal(createSubmitBody(MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED));
 
         // Assert
@@ -842,17 +842,17 @@ describe('/v1/deals', () => {
       };
 
       it('does NOT call premium schedule when dealType is GEF', async () => {
-        // Act
+        // Arrange & Act
         const { status } = await submitDeal(createSubmitBody(mockDeal));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         expect(api.getPremiumSchedule).not.toHaveBeenCalled();
       });
 
       it('should call updateGefFacility', async () => {
-        // Act
+        // Arrange & Act
         await submitDeal(createSubmitBody(MOCK_GEF_DEAL));
 
         // Assert
@@ -869,11 +869,11 @@ describe('/v1/deals', () => {
       });
 
       it('adds fee record to issued facilities', async () => {
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(mockDeal));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const issuedFacility = [...getFacilities(body), ...getUpdatedDealFacilities()].find((facility) => facility.hasBeenIssued);
         expect(issuedFacility).toBeDefined();
@@ -884,11 +884,11 @@ describe('/v1/deals', () => {
       });
 
       it('does NOT add fee record to unissued facilities', async () => {
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(mockDeal));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const unissuedFacility = [...getFacilities(body), ...getUpdatedDealFacilities()].find((facility) => !facility.hasBeenIssued);
         expect(unissuedFacility).toBeDefined();
@@ -897,11 +897,11 @@ describe('/v1/deals', () => {
       });
 
       it('does NOT add fee record when deal is MIA on 1st submission', async () => {
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_MIA));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const issuedFacility = [...getFacilities(body), ...getUpdatedDealFacilities()].find((facility) => facility.hasBeenIssued);
         expect(issuedFacility).toBeDefined();
@@ -910,11 +910,11 @@ describe('/v1/deals', () => {
       });
 
       it('does add fee record when deal is MIA on 2nd submission', async () => {
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_SECOND_SUBMIT_MIA));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
 
         const issuedFacility = [...getFacilities(body), ...getUpdatedDealFacilities()].find((facility) => facility.tfm);
         expect(issuedFacility).toBeDefined();
@@ -933,12 +933,11 @@ describe('/v1/deals', () => {
       });
 
       it('should update the application from MIA to MIN', async () => {
-        // Arrange
-        // Act
+        // Arrange & Act
         const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_SECOND_SUBMIT_MIA));
 
         // Assert
-        expect(status).toEqual(200);
+        expect(status).toEqual(HttpStatusCode.Ok);
         expect(body.submissionType).toEqual(CONSTANTS.DEALS.SUBMISSION_TYPE.MIN);
         expect(typeof body.manualInclusionNoticeSubmissionDate).toEqual('string');
       });

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
@@ -67,8 +67,10 @@ describe('/v1/deals', () => {
     describe('deal/case tasks', () => {
       describe('when deal is AIN', () => {
         it('adds AIN tasks to the deal with emailSent flag added to the first task', async () => {
+          // Arrange & Act
           const { status, body: submittedDeal } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_NO_COMPANIES_HOUSE));
 
+          // Assert
           expect(status).toEqual(200);
 
           const taskCreation = await createDealTasks(submittedDeal, generatePortalAuditDetails(MOCK_PORTAL_USERS[0]._id));
@@ -80,10 +82,13 @@ describe('/v1/deals', () => {
         });
 
         it('should call externalApis.sendEmail for first task email', async () => {
+          // Arrange
           const dealId = MOCK_DEAL_AIN_NO_COMPANIES_HOUSE._id;
 
+          // Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_NO_COMPANIES_HOUSE));
 
+          // Assert
           const firstTask = body.tfm.tasks[0].groupTasks[0];
 
           const { email: expectedTeamEmailAddress } = MOCK_TEAMS.find((t) => t.id === firstTask.team.id);
@@ -110,8 +115,10 @@ describe('/v1/deals', () => {
 
       describe('when deal is MIA', () => {
         it('adds MIA tasks to the deal with emailSent flag added to the first task', async () => {
+          // Arrange & Act
           const { status, body: submittedDeal } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SUBMITTED));
 
+          // Assert
           expect(status).toEqual(200);
 
           const taskCreation = await createDealTasks(submittedDeal, generatePortalAuditDetails(MOCK_PORTAL_USERS[0]._id));
@@ -123,8 +130,10 @@ describe('/v1/deals', () => {
         });
 
         it('should call externalApis.sendEmail for first task email', async () => {
+          // Arrange & Act
           const { body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIA_SUBMITTED));
 
+          // Assert
           const firstTask = body.tfm.tasks[0].groupTasks[0];
 
           const { email: expectedTeamEmailAddress } = MOCK_TEAMS.find((t) => t.id === firstTask.team.id);
@@ -150,14 +159,19 @@ describe('/v1/deals', () => {
 
       describe('when deal is MIN', () => {
         it('adds NOT add tasks to the deal', async () => {
+          // Act & Arrange
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIN));
 
+          // Assert
           expect(status).toEqual(200);
           expect(body.tfm.tasks).toBeUndefined();
         });
 
         it('should NOT call externalApis.sendEmail', async () => {
+          // Act & Arrange
           await submitDeal(createSubmitBody(MOCK_DEAL_MIN));
+
+          // Assert
           expect(sendEmailApiSpy).not.toHaveBeenCalled();
         });
       });

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
@@ -159,7 +159,7 @@ describe('/v1/deals', () => {
 
       describe('when deal is MIN', () => {
         it('adds NOT add tasks to the deal', async () => {
-          // Act & Arrange
+          // Arrange & Act
           const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_MIN));
 
           // Assert
@@ -168,7 +168,7 @@ describe('/v1/deals', () => {
         });
 
         it('should NOT call externalApis.sendEmail', async () => {
-          // Act & Arrange
+          // Arrange & Act
           await submitDeal(createSubmitBody(MOCK_DEAL_MIN));
 
           // Assert

--- a/trade-finance-manager-ui/templates/case/parties/summary/party.njk
+++ b/trade-finance-manager-ui/templates/case/parties/summary/party.njk
@@ -44,29 +44,29 @@
           },
           rows: [
             [
-            {
-              text: 'Name',
-              classes: 'govuk-!-width-one-quarter'
-            },
-            {
-              text: name,
-              classes: 'govuk-!-width-one-third'
-            },
-            {
-              text: '',
-              classes: 'govuk-!-width-one-quarter'
-            }
+              {
+                text: 'Name',
+                classes: 'govuk-!-width-one-quarter'
+              },
+              {
+                text: name,
+                classes: 'govuk-!-width-one-third'
+              },
+              {
+                text: '',
+                classes: 'govuk-!-width-one-quarter'
+              }
             ],
             [
-            {
-              text: 'Unique reference number'
-            },
-            {
-              text: urn
-            },
-            {
-              html: change
-            }
+              {
+                text: 'Unique reference number'
+              },
+              {
+                text: urn
+              },
+              {
+                html: change
+              }
             ]
           ]
         }) }}


### PR DESCRIPTION
# Introduction :pencil2:

## Resolution :heavy_check_mark:

- Update some APIM GIFT logging messages.
- Fix some nunjuck indentation issues.
- Add missing Act/Arrange/Assert to some TFM API tests.

## Miscellaneous :heavy_plus_sign:

- Add a missing `rel="noreferrer noopener"`

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
