### PR TITLE
chore(dependabot-fix): dependabot npm changes set to root directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,16 +10,8 @@ version: 2
 updates:
   # NPM
   - package-ecosystem: 'npm'
-    directories: 
-      - '/'
-      - '/external-api'
-      - '/portal-api'
-      - '/trade-finance-manager-api'
-      - '/gef-ui'
-      - '/portal'
-      - '/trade-finance-manager-ui'
-      - '/azure-functions/acbs'
-      - '/dtfs-central-api'
+    directory: '/'
+    target-branch: "chore/dependabot-fix"
     schedule:
       interval: 'weekly'
       time: '00:00'
@@ -28,7 +20,7 @@ updates:
     groups:
       npm-packages:
         patterns:
-          - '*'  
+          - '*'
 
   # Dockerfiles
   - package-ecosystem: 'docker'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
   # NPM
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: "chore/dependabot-fix"
     schedule:
       interval: 'weekly'
       time: '00:00'


### PR DESCRIPTION
# Introduction :pencil2:

This PR replaced directories with a single directory: '/'. The root lockfile and workspaces config already covers all sub-packages, so a single run discovers all dependencies across the monorepo.

