### PR TITLE
fix(DTFS2-8481): fix incorrect href for payment-report-officer on profile cancel button

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/login/profile.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/profile.spec.js
@@ -1,0 +1,91 @@
+const { header, userProfile } = require('../../pages');
+const relative = require('../../relativeURL');
+const { UKEF_BANK_1 } = require('../../../../../e2e-fixtures/banks.fixture');
+const MOCK_USERS = require('../../../../../e2e-fixtures');
+
+const { ADMIN, BANK1_MAKER1, BANK1_CHECKER1, BANK1_PAYMENT_REPORT_OFFICER1 } = MOCK_USERS;
+
+const dashboardUrl = relative('/dashboard/deals/0');
+const reportUploadUrl = relative('/utilisation-report-upload');
+
+describe('User profile page', () => {
+  describe('Maker', () => {
+    beforeEach(() => {
+      cy.login(BANK1_MAKER1);
+      header.profile().click();
+    });
+
+    it('should display the correct user profile information', () => {
+      cy.assertText(userProfile.firstname(), BANK1_MAKER1.firstname);
+      cy.assertText(userProfile.surname(), BANK1_MAKER1.surname);
+      cy.assertText(userProfile.email(), BANK1_MAKER1.email);
+      cy.assertText(userProfile.roles(), BANK1_MAKER1.roles.join(', '));
+      cy.assertText(userProfile.bank(), UKEF_BANK_1.name);
+    });
+
+    it('should go back to the dashboard when clicking the cancel button', () => {
+      cy.clickCancelButton();
+      cy.url().should('eq', dashboardUrl);
+    });
+  });
+
+  describe('Admin', () => {
+    beforeEach(() => {
+      cy.login(ADMIN);
+      header.profile().click();
+    });
+
+    it('should display the correct user profile information', () => {
+      cy.assertText(userProfile.firstname(), ADMIN.firstname);
+      cy.assertText(userProfile.surname(), ADMIN.surname);
+      cy.assertText(userProfile.email(), ADMIN.email);
+      userProfile.roles().should('contain', ADMIN.roles[0]);
+      userProfile.roles().should('contain', ADMIN.roles[1]);
+    });
+
+    it('should go back to the dashboard when clicking the cancel button', () => {
+      cy.clickCancelButton();
+      cy.url().should('eq', dashboardUrl);
+    });
+  });
+
+  describe('Checker', () => {
+    beforeEach(() => {
+      cy.login(BANK1_CHECKER1);
+      header.profile().click();
+    });
+
+    it('should display the correct user profile information', () => {
+      cy.assertText(userProfile.firstname(), BANK1_CHECKER1.firstname);
+      cy.assertText(userProfile.surname(), BANK1_CHECKER1.surname);
+      cy.assertText(userProfile.email(), BANK1_CHECKER1.email);
+      cy.assertText(userProfile.roles(), BANK1_CHECKER1.roles.join(', '));
+      cy.assertText(userProfile.bank(), UKEF_BANK_1.name);
+    });
+
+    it('should go back to the dashboard when clicking the cancel button', () => {
+      cy.clickCancelButton();
+      cy.url().should('eq', dashboardUrl);
+    });
+  });
+
+  describe('Payment report officer', () => {
+    beforeEach(() => {
+      cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
+      header.profile().click();
+    });
+
+    it('should display the correct user profile information', () => {
+      cy.assertText(userProfile.firstname(), BANK1_PAYMENT_REPORT_OFFICER1.firstname);
+      cy.assertText(userProfile.surname(), BANK1_PAYMENT_REPORT_OFFICER1.surname);
+      cy.assertText(userProfile.email(), BANK1_PAYMENT_REPORT_OFFICER1.email);
+      cy.assertText(userProfile.roles(), BANK1_PAYMENT_REPORT_OFFICER1.roles.join(', '));
+      cy.assertText(userProfile.bank(), UKEF_BANK_1.name);
+    });
+
+    it('should go back to the utilisation report upload page when clicking the cancel button', () => {
+      cy.clickCancelButton();
+      cy.url().should('eq', reportUploadUrl);
+    });
+  });
+});

--- a/e2e-tests/portal/cypress/e2e/pages/user/profile.js
+++ b/e2e-tests/portal/cypress/e2e/pages/user/profile.js
@@ -1,5 +1,10 @@
 const userProfile = {
+  firstname: () => cy.get('[data-cy="user-firstname"]'),
+  surname: () => cy.get('[data-cy="user-surname"]'),
+  roles: () => cy.get('[data-cy="user-roles"]'),
+  bank: () => cy.get('[data-cy="user-bank"]'),
   email: () => cy.get('[data-cy="user-email"]'),
+  lastLogin: () => cy.get('[data-cy="user-last-login"]'),
 };
 
 module.exports = userProfile;

--- a/portal-ui/server/routes/user/profile.js
+++ b/portal-ui/server/routes/user/profile.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const api = require('../../api');
-const { constructPayload, getApiData, requestParams, errorHref, generateErrorSummary } = require('../../helpers');
+const { constructPayload, getApiData, requestParams, errorHref, generateErrorSummary, getUserRedirectUrl } = require('../../helpers');
 const { PRIMARY_NAV_KEY } = require('../../constants');
 
 const router = express.Router();
@@ -31,10 +31,18 @@ router.get('/:_id', async (req, res) => {
 
   const user = await getApiData(api.user(_id, userToken), res);
 
+  /**
+   * determines the correct url to direct user to when pressing the cancel button on the profile page
+   * eg payment-report-officer does not have access to the dashboard
+   * so should be directed to the utilisation report upload page instead
+   */
+  const redirectUrl = getUserRedirectUrl(user);
+
   return res.render('user/profile.njk', {
     _id,
     user,
     primaryNav: PRIMARY_NAV_KEY.PROFILE,
+    redirectUrl,
   });
 });
 

--- a/portal-ui/templates/user/profile.njk
+++ b/portal-ui/templates/user/profile.njk
@@ -16,7 +16,7 @@
       <p class="govuk-body">First name:</p>
     </div>
     <div class="govuk-grid-column-one-quarter">
-       <p class="govuk-body">{{ user.firstname }} </p>
+       <p class="govuk-body" data-cy="user-firstname">{{ user.firstname }} </p>
     </div>
   </div>
 
@@ -25,7 +25,7 @@
       <p class="govuk-body">Surname:</p>
     </div>
     <div class="govuk-grid-column-one-quarter">
-       <p class="govuk-body">{{ user.surname }}</p>
+       <p class="govuk-body" data-cy="user-surname">{{ user.surname }}</p>
     </div>
   </div>
 
@@ -43,7 +43,7 @@
       <p class="govuk-body">User roles:</p>
     </div>
     <div class="govuk-grid-column-one-quarter">
-       <p class="govuk-body">
+       <p class="govuk-body" data-cy="user-roles">
         {% for role in user.roles %}
           {{ role }}{% if not loop.last%}, {% endif %}
         {% endfor %}
@@ -56,7 +56,7 @@
       <p class="govuk-body">Bank:</p>
     </div>
     <div class="govuk-grid-column-one-quarter">
-       <p class="govuk-body">{{ user.bank.name }}</p>
+       <p class="govuk-body" data-cy="user-bank">{{ user.bank.name }}</p>
     </div>
   </div>
 
@@ -65,7 +65,7 @@
       <p class="govuk-body">Last logged in:</p>
     </div>
     <div class="govuk-grid-column-one-quarter">
-       <p class="govuk-body">{{ user.lastLogin | localiseTimestamp("dd/MM/yyyy HH:mm", user.timezone) }}</p>
+       <p class="govuk-body" data-cy="user-last-login">{{ user.lastLogin | localiseTimestamp("dd/MM/yyyy HH:mm", user.timezone) }}</p>
     </div>
   </div>
 
@@ -84,7 +84,7 @@
           govukButton({
           text: "Cancel",
           classes: "govuk-button--secondary govuk-!-margin-right-1",
-          href: "/dashboard",
+          href: redirectUrl,
           attributes: {
             'data-cy': 'cancel-button'
           }


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes an issue where a payment-report-officer was redirected back to the login page when pressing cancel on the profile page.  This is because it redirected to dashboard and this role does not have access to the dashboard.

## Resolution :heavy_check_mark:

* added redirectUrl to profile routes using helper
* Changed cancel button href to redirectUrl
* Added e2e test

