### PR TITLE
fix(DTFS2-8486): amend a gift facility - date conversion

### DIFF
--- a/libs/common/src/helpers/date.test.ts
+++ b/libs/common/src/helpers/date.test.ts
@@ -14,6 +14,7 @@ import {
   differenceInDays,
   epochSecondsToMilliseconds,
   getFormattedUTCDateString,
+  getFormattedDateStringInTimeZone,
 } from './date';
 
 describe('date helpers', () => {
@@ -205,7 +206,37 @@ describe('date helpers', () => {
       const result = getFormattedUTCDateString(timestampMilliseconds);
 
       // Assert
-      expect(result).toEqual('2028-02-25');
+      const expected = '2028-02-25';
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getFormattedDateStringInTimeZone', () => {
+    it('should return the expected date for Unix timestamp in Europe/London time zone', () => {
+      // Arrange
+      const timestampMilliseconds = 1845154800000; // 2028-06-21T00:00:00+01:00
+
+      // Act
+      const result = getFormattedDateStringInTimeZone(timestampMilliseconds, 'Europe/London');
+
+      // Assert
+      const expected = '2028-06-21';
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should interpret Unix timestamp seconds values', () => {
+      // Arrange
+      const timestampSeconds = 1845154800; // 2028-06-21T00:00:00+01:00
+
+      // Act
+      const result = getFormattedDateStringInTimeZone(timestampSeconds, 'Europe/London');
+
+      // Assert
+      const expected = '2028-06-21';
+
+      expect(result).toEqual(expected);
     });
   });
 

--- a/libs/common/src/helpers/date.test.ts
+++ b/libs/common/src/helpers/date.test.ts
@@ -15,6 +15,7 @@ import {
   epochSecondsToMilliseconds,
   getFormattedUTCDateString,
   getFormattedDateStringInTimeZone,
+  normaliseEpochMilliseconds,
 } from './date';
 
 describe('date helpers', () => {
@@ -236,6 +237,24 @@ describe('date helpers', () => {
       // Assert
       const expected = '2028-06-21';
 
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('normaliseEpochMilliseconds', () => {
+    it.each([
+      { epoch: 0, expected: 0 },
+      { epoch: 1, expected: 1000 },
+      { epoch: 1704067200, expected: 1704067200000 },
+      { epoch: 9_999_999_999, expected: 9_999_999_999_000 },
+      { epoch: 10_000_000_000, expected: 10_000_000_000 },
+      { epoch: 1_704_067_200_000, expected: 1_704_067_200_000 },
+      { epoch: -1, expected: -1000 },
+    ])('should normalise epoch $epoch to milliseconds $expected', ({ epoch, expected }) => {
+      // Act
+      const result = normaliseEpochMilliseconds(epoch);
+
+      // Assert
       expect(result).toEqual(expected);
     });
   });

--- a/libs/common/src/helpers/date.ts
+++ b/libs/common/src/helpers/date.ts
@@ -99,7 +99,7 @@ export const getFormattedUTCDateString = (date: number): string => {
 };
 
 /**
- * Converts a Unix timestamp to a date string in the format 'YYYY-MM-DD' using a specific IANA time zone.
+ * Converts a Unix timestamp to a date string in the format 'yyyy-MM-dd' using a specific IANA time zone.
  *
  * Interprets values <= 9_999_999_999 as epoch seconds and values above as epoch milliseconds.
  * @param {number} date - The Unix timestamp (seconds or milliseconds, inferred by magnitude).

--- a/libs/common/src/helpers/date.ts
+++ b/libs/common/src/helpers/date.ts
@@ -62,7 +62,14 @@ export const getISO8601 = (date: Date = now()): string => date.toISOString();
 
 const MAX_EPOCH_SECONDS = 9_999_999_999; // Largest plausible epoch timestamp in seconds (2286-11-20T17:46:39Z). Values above are treated as milliseconds.
 
-const normaliseEpochMilliseconds = (date: number): number => {
+/**
+ * Normalizes an epoch timestamp to milliseconds.
+ * If the input is in seconds (<= MAX_EPOCH_SECONDS), it converts it to milliseconds.
+ * If the input is already in milliseconds (> MAX_EPOCH_SECONDS), it returns the input as is.
+ * @param {number} date - The epoch timestamp in seconds or milliseconds.
+ * @returns {number} The epoch timestamp in milliseconds.
+ */
+export const normaliseEpochMilliseconds = (date: number): number => {
   /**
    * If the epoch value is less than or equal to the maximum plausible epoch timestamp in seconds,
    * assume it's in seconds and convert to milliseconds.
@@ -95,9 +102,9 @@ export const getFormattedUTCDateString = (date: number): string => {
  * Converts a Unix timestamp to a date string in the format 'YYYY-MM-DD' using a specific IANA time zone.
  *
  * Interprets values <= 9_999_999_999 as epoch seconds and values above as epoch milliseconds.
- * @param date - The Unix timestamp (seconds or milliseconds, inferred by magnitude).
- * @param timeZone - IANA timezone identifier (for example: 'Europe/London').
- * @returns {string} The date string in the format 'YYYY-MM-DD' for the provided time zone.
+ * @param {number} date - The Unix timestamp (seconds or milliseconds, inferred by magnitude).
+ * @param {string} timeZone - IANA timezone identifier (for example: 'Europe/London').
+ * @returns {string} The date string in the format 'yyyy-MM-dd' for the provided time zone.
  */
 export const getFormattedDateStringInTimeZone = (date: number, timeZone: string): string => {
   const epochMilliseconds = normaliseEpochMilliseconds(date);

--- a/libs/common/src/helpers/date.ts
+++ b/libs/common/src/helpers/date.ts
@@ -60,6 +60,16 @@ export const getUnixTimestampSeconds: (date: Date) => UnixTimestampSeconds = get
  */
 export const getISO8601 = (date: Date = now()): string => date.toISOString();
 
+const MAX_EPOCH_SECONDS = 9_999_999_999; // Largest plausible epoch timestamp in seconds (2286-11-20T17:46:39Z). Values above are treated as milliseconds.
+
+const normaliseEpochMilliseconds = (date: number): number => {
+  /**
+   * If the epoch value is less than or equal to the maximum plausible epoch timestamp in seconds,
+   * assume it's in seconds and convert to milliseconds.
+   */
+  return date <= MAX_EPOCH_SECONDS ? date * 1000 : date;
+};
+
 /**
  * Converts a Unix timestamp to a UTC date string in the format 'YYYY-MM-DD'.
  *
@@ -68,13 +78,7 @@ export const getISO8601 = (date: Date = now()): string => date.toISOString();
  * @returns {string} The UTC date string in the format 'YYYY-MM-DD'.
  */
 export const getFormattedUTCDateString = (date: number): string => {
-  const MAX_EPOCH_SECONDS = 9_999_999_999; // Largest plausible epoch timestamp in seconds (2286-11-20T17:46:39Z). Values above are treated as milliseconds.
-
-  /**
-   * If the epoch value is less than or equal to the maximum plausible epoch timestamp in seconds,
-   * assume it's in seconds and convert to milliseconds
-   */
-  const epochMilliseconds = date <= MAX_EPOCH_SECONDS ? date * 1000 : date;
+  const epochMilliseconds = normaliseEpochMilliseconds(date);
 
   const isoString = new Date(epochMilliseconds).toISOString();
 
@@ -85,6 +89,20 @@ export const getFormattedUTCDateString = (date: number): string => {
   const formattedDate = isoString.slice(0, 10);
 
   return formattedDate;
+};
+
+/**
+ * Converts a Unix timestamp to a date string in the format 'YYYY-MM-DD' using a specific IANA time zone.
+ *
+ * Interprets values <= 9_999_999_999 as epoch seconds and values above as epoch milliseconds.
+ * @param date - The Unix timestamp (seconds or milliseconds, inferred by magnitude).
+ * @param timeZone - IANA timezone identifier (for example: 'Europe/London').
+ * @returns {string} The date string in the format 'YYYY-MM-DD' for the provided time zone.
+ */
+export const getFormattedDateStringInTimeZone = (date: number, timeZone: string): string => {
+  const epochMilliseconds = normaliseEpochMilliseconds(date);
+
+  return formatInTimeZone(epochMilliseconds, timeZone, 'yyyy-MM-dd');
 };
 
 /**

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
@@ -1,4 +1,4 @@
-import { getFormattedDateStringInTimeZone, getFormattedUTCDateString } from '@ukef/dtfs2-common';
+import { getFormattedDateStringInTimeZone, getFormattedUTCDateString, TIMEZONE } from '@ukef/dtfs2-common';
 import { TfmFacilityAmendmentData } from '../../types';
 import { getAmendmentFields } from '.';
 
@@ -10,8 +10,6 @@ const mockBaseAmendment: TfmFacilityAmendmentData = {
 };
 
 describe('getAmendmentFields', () => {
-  const londonTimeZone = 'Europe/London';
-
   it('should extract and format amendment fields from TFM amendment data', () => {
     // Arrange
     const amendment: TfmFacilityAmendmentData = {
@@ -28,7 +26,7 @@ describe('getAmendmentFields', () => {
     const expected = {
       newAmount: amendment.value,
       previousAmount: amendment.currentValue,
-      coverEndDate: getFormattedDateStringInTimeZone(Number(amendment?.tfm?.coverEndDate), londonTimeZone),
+      coverEndDate: getFormattedDateStringInTimeZone(Number(amendment?.tfm?.coverEndDate), TIMEZONE.DEFAULT),
       effectiveDate: getFormattedUTCDateString(Number(amendment.effectiveDate)),
     };
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
@@ -1,4 +1,4 @@
-import { getFormattedUTCDateString } from '@ukef/dtfs2-common';
+import { getFormattedDateStringInTimeZone, getFormattedUTCDateString } from '@ukef/dtfs2-common';
 import { TfmFacilityAmendmentData } from '../../types';
 import { getAmendmentFields } from '.';
 
@@ -10,6 +10,8 @@ const mockBaseAmendment: TfmFacilityAmendmentData = {
 };
 
 describe('getAmendmentFields', () => {
+  const londonTimeZone = 'Europe/London';
+
   it('should extract and format amendment fields from TFM amendment data', () => {
     // Arrange
     const amendment: TfmFacilityAmendmentData = {
@@ -26,11 +28,29 @@ describe('getAmendmentFields', () => {
     const expected = {
       newAmount: amendment.value,
       previousAmount: amendment.currentValue,
-      coverEndDate: getFormattedUTCDateString(Number(amendment?.tfm?.coverEndDate)),
+      coverEndDate: getFormattedDateStringInTimeZone(Number(amendment?.tfm?.coverEndDate), londonTimeZone),
       effectiveDate: getFormattedUTCDateString(Number(amendment.effectiveDate)),
     };
 
     expect(result).toEqual(expected);
+  });
+
+  it('should not shift coverEndDate by one day when timestamp is UK midnight during BST', () => {
+    // Arrange
+    const amendment: TfmFacilityAmendmentData = {
+      ...mockBaseAmendment,
+      tfm: {
+        coverEndDate: new Date('2028-06-21T00:00:00+01:00').getTime(),
+      },
+    };
+
+    // Act
+    const result = getAmendmentFields(amendment);
+
+    // Assert
+    const expected = '2028-06-21';
+
+    expect(result.coverEndDate).toEqual(expected);
   });
 
   describe('when tfm.coverEndDate is not provided', () => {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
@@ -1,7 +1,5 @@
-import { getFormattedDateStringInTimeZone, getFormattedUTCDateString } from '@ukef/dtfs2-common';
+import { getFormattedDateStringInTimeZone, getFormattedUTCDateString, TIMEZONE } from '@ukef/dtfs2-common';
 import { TfmFacilityAmendmentData } from '../../types';
-
-const LONDON_TIME_ZONE = 'Europe/London';
 
 type AmendmentFields = {
   newAmount: number;
@@ -21,7 +19,7 @@ export const getAmendmentFields = (amendment: TfmFacilityAmendmentData): Amendme
 
   const hasCoverEndDate = amendment?.tfm?.coverEndDate !== undefined && amendment.tfm.coverEndDate !== null;
 
-  const coverEndDate = hasCoverEndDate ? getFormattedDateStringInTimeZone(Number(amendment.tfm?.coverEndDate), LONDON_TIME_ZONE) : '';
+  const coverEndDate = hasCoverEndDate ? getFormattedDateStringInTimeZone(Number(amendment.tfm?.coverEndDate), TIMEZONE.DEFAULT) : '';
 
   const hasEffectiveDate = amendment.effectiveDate !== undefined && amendment.effectiveDate !== null;
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
@@ -1,5 +1,7 @@
-import { getFormattedUTCDateString } from '@ukef/dtfs2-common';
+import { getFormattedDateStringInTimeZone, getFormattedUTCDateString } from '@ukef/dtfs2-common';
 import { TfmFacilityAmendmentData } from '../../types';
+
+const LONDON_TIME_ZONE = 'Europe/London';
 
 type AmendmentFields = {
   newAmount: number;
@@ -17,11 +19,13 @@ export const getAmendmentFields = (amendment: TfmFacilityAmendmentData): Amendme
   const newAmount = typeof amendment.value === 'number' ? amendment.value : Number.NaN;
   const previousAmount = typeof amendment.currentValue === 'number' ? amendment.currentValue : Number.NaN;
 
-  const coverEndDate =
-    amendment?.tfm?.coverEndDate !== undefined && amendment.tfm.coverEndDate !== null ? getFormattedUTCDateString(Number(amendment.tfm.coverEndDate)) : '';
+  const hasCoverEndDate = amendment?.tfm?.coverEndDate !== undefined && amendment.tfm.coverEndDate !== null;
 
-  const effectiveDate =
-    amendment.effectiveDate !== undefined && amendment.effectiveDate !== null ? getFormattedUTCDateString(Number(amendment.effectiveDate)) : '';
+  const coverEndDate = hasCoverEndDate ? getFormattedDateStringInTimeZone(Number(amendment.tfm?.coverEndDate), LONDON_TIME_ZONE) : '';
+
+  const hasEffectiveDate = amendment.effectiveDate !== undefined && amendment.effectiveDate !== null;
+
+  const effectiveDate = hasEffectiveDate ? getFormattedUTCDateString(Number(amendment.effectiveDate)) : '';
 
   return {
     newAmount,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
@@ -19,11 +19,15 @@ export const getAmendmentFields = (amendment: TfmFacilityAmendmentData): Amendme
 
   const hasCoverEndDate = amendment?.tfm?.coverEndDate !== undefined && amendment.tfm.coverEndDate !== null;
 
-  const coverEndDate = hasCoverEndDate ? getFormattedDateStringInTimeZone(Number(amendment.tfm?.coverEndDate), TIMEZONE.DEFAULT) : '';
+  const coverEndDateValue = Number(amendment.tfm?.coverEndDate);
+
+  const coverEndDate = hasCoverEndDate ? getFormattedDateStringInTimeZone(coverEndDateValue, TIMEZONE.DEFAULT) : '';
 
   const hasEffectiveDate = amendment.effectiveDate !== undefined && amendment.effectiveDate !== null;
 
-  const effectiveDate = hasEffectiveDate ? getFormattedUTCDateString(Number(amendment.effectiveDate)) : '';
+  const effectiveDateValue = Number(amendment.effectiveDate);
+
+  const effectiveDate = hasEffectiveDate ? getFormattedUTCDateString(effectiveDateValue) : '';
 
   return {
     newAmount,


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes an issue where a DTFS timestamp would be incorrectly converted before being sent to GIFT. For example:

- Entered: `2028-06-21 00:00 +01:00`
- UTC equivalent: `2028-06-20T23:00:00.000Z`
- Sent date string: `2028-06-20`

## Resolution :heavy_check_mark:

- Update date helpers.
- Update `getAmendmentFields`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
