### PR TITLE
chore(DTFS2-8496): split dependabot npm into groups to avoid timeout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,12 @@
 # Automatic dependencies updates
 # for the following services:
 # 1. NPM
+#    - Uses a single root directory (/) which covers all workspace packages
+#    - Split into 6 groups (types, eslint, babel, testing, production, dev-other)
+#      to avoid Dependabot timeout caused by resolving all 2000+ packages at once
+#    - Groups 1-4 match by package name pattern (e.g. @types/*, eslint*, jest*)
+#    - "production" = packages in "dependencies" in package.json
+#    - "dev-other" = packages in "devDependencies" not matched by groups 1-4
 # 2. Docker
 # 3. GHA
 
@@ -17,9 +23,55 @@ updates:
     labels:
       - 'chore'
     groups:
-      npm-packages:
+      npm-types:
         patterns:
-          - '*'
+          - '@types/*'
+      npm-eslint:
+        patterns:
+          - 'eslint*'
+          - '@typescript-eslint/*'
+          - 'eslint-*'
+      npm-babel:
+        patterns:
+          - '@babel/*'
+          - 'babel-*'
+      npm-testing:
+        patterns:
+          - 'jest'
+          - 'jest-*'
+          - '@jest/*'
+          - 'ts-jest'
+          - 'cypress'
+          - 'supertest'
+      npm-production:
+        dependency-type: 'production'
+        exclude-patterns:
+          - '@types/*'
+          - 'eslint*'
+          - '@typescript-eslint/*'
+          - '@babel/*'
+          - 'babel-*'
+          - 'jest'
+          - 'jest-*'
+          - '@jest/*'
+          - 'ts-jest'
+          - 'cypress'
+          - 'supertest'
+      npm-dev-other:
+        dependency-type: 'development'
+        exclude-patterns:
+          - '@types/*'
+          - 'eslint*'
+          - '@typescript-eslint/*'
+          - 'eslint-*'
+          - '@babel/*'
+          - 'babel-*'
+          - 'jest'
+          - 'jest-*'
+          - '@jest/*'
+          - 'ts-jest'
+          - 'cypress'
+          - 'supertest'
 
   # Dockerfiles
   - package-ecosystem: 'docker'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,11 @@
 # for the following services:
 # 1. NPM
 #    - Uses a single root directory (/) which covers all workspace packages
-#    - Split into 6 groups (types, eslint, babel, testing, production, dev-other)
+#    - Split into 6 groups (types, eslint, babel, testing, dependencies, dev-dependencies)
 #      to avoid Dependabot timeout caused by resolving all 2000+ packages at once
 #    - Groups 1-4 match by package name pattern (e.g. @types/*, eslint*, jest*)
-#    - "production" = packages in "dependencies" in package.json
-#    - "dev-other" = packages in "devDependencies" not matched by groups 1-4
+#    - "dependencies" = packages in "dependencies" not already matched by groups 1-4
+#    - "dev-dependencies" = packages in "devDependencies" not already matched by groups 1-4
 # 2. Docker
 # 3. GHA
 
@@ -23,55 +23,59 @@ updates:
     labels:
       - 'chore'
     groups:
-      npm-types:
-        patterns:
-          - '@types/*'
-      npm-eslint:
-        patterns:
-          - 'eslint*'
-          - '@typescript-eslint/*'
-          - 'eslint-*'
       npm-babel:
         patterns:
           - '@babel/*'
           - 'babel-*'
-      npm-testing:
+      npm-dependencies:
         patterns:
-          - 'jest'
-          - 'jest-*'
-          - '@jest/*'
-          - 'ts-jest'
-          - 'cypress'
-          - 'supertest'
-      npm-production:
+          - '*'
         dependency-type: 'production'
         exclude-patterns:
-          - '@types/*'
-          - 'eslint*'
-          - '@typescript-eslint/*'
           - '@babel/*'
+          - '@jest/*'
+          - '@types/*'
+          - '@typescript-eslint/*'
           - 'babel-*'
+          - 'cypress'
+          - 'eslint*'
           - 'jest'
           - 'jest-*'
-          - '@jest/*'
-          - 'ts-jest'
-          - 'cypress'
           - 'supertest'
-      npm-dev-other:
+          - 'ts-jest'
+      npm-dev-dependencies:
+        patterns:
+          - '*'
         dependency-type: 'development'
         exclude-patterns:
-          - '@types/*'
-          - 'eslint*'
-          - '@typescript-eslint/*'
-          - 'eslint-*'
           - '@babel/*'
+          - '@jest/*'
+          - '@types/*'
+          - '@typescript-eslint/*'
           - 'babel-*'
+          - 'cypress'
+          - 'eslint*'
+          - 'eslint-*'
           - 'jest'
           - 'jest-*'
-          - '@jest/*'
-          - 'ts-jest'
-          - 'cypress'
           - 'supertest'
+          - 'ts-jest'
+      npm-eslint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'eslint*'
+          - 'eslint-*'
+      npm-testing:
+        patterns:
+          - '@jest/*'
+          - 'cypress'
+          - 'jest'
+          - 'jest-*'
+          - 'supertest'
+          - 'ts-jest'
+      npm-types:
+        patterns:
+          - '@types/*'
 
   # Dockerfiles
   - package-ecosystem: 'docker'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,8 @@ updates:
         dependency-type: 'production'
         exclude-patterns:
           - '@babel/*'
+          - '@cypress/*'
+          - '@cypress-*'
           - '@jest/*'
           - '@types/*'
           - '@typescript-eslint/*'
@@ -41,6 +43,7 @@ updates:
           - 'eslint*'
           - 'jest'
           - 'jest-*'
+          - 'nock'
           - 'supertest'
           - 'ts-jest'
       npm-dev-dependencies:
@@ -49,28 +52,32 @@ updates:
         dependency-type: 'development'
         exclude-patterns:
           - '@babel/*'
+          - '@cypress/*'
+          - '@cypress-*'
           - '@jest/*'
           - '@types/*'
           - '@typescript-eslint/*'
           - 'babel-*'
           - 'cypress'
           - 'eslint*'
-          - 'eslint-*'
           - 'jest'
           - 'jest-*'
+          - 'nock'
           - 'supertest'
           - 'ts-jest'
       npm-eslint:
         patterns:
           - '@typescript-eslint/*'
           - 'eslint*'
-          - 'eslint-*'
       npm-testing:
         patterns:
+          - '@cypress/*'
+          - '@cypress-*'
           - '@jest/*'
           - 'cypress'
           - 'jest'
           - 'jest-*'
+          - 'nock'
           - 'supertest'
           - 'ts-jest'
       npm-types:


### PR DESCRIPTION
# Introduction :pencil2:

Dependabot was timing out with error "Dependabot timed out during its update" (Version update 1413705797) when attempting to resolve npm dependencies.

## Resolution :heavy_check_mark:

* Replaced the single patterns: ['*'] npm group with 6 smaller groups (types, eslint, babel, testing, production, dev-other) to reduce the resolution workload per group
* This prevents Dependabot from trying to resolve compatibility for all 2000+ packages in a single pass, which was causing the timeout
* Added documentation comments explaining the grouping strategy

