### PR TITLE
fix(DTFS2-8503): create a gift facility - intentional delay

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/parties/parties-update.api-test.js
@@ -135,7 +135,7 @@ describe('PUT /v1/parties/:dealId', () => {
           facilities: issuedFacilities,
           isBssEwcsDeal: false,
           isGefDeal: true,
-          newPartyUrnCreated: true,
+          newPartyUrnCreated: false,
         }),
       );
     });

--- a/trade-finance-manager-api/server/v1/controllers/deal.add-party-urn.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/deal.add-party-urn.test.js
@@ -385,65 +385,130 @@ describe('addPartyUrns', () => {
     expect(response.newPartyUrnCreated).toBe(true);
   });
 
-  it('should set newPartyUrnCreated to false when the party already exists before getOrCreate', async () => {
-    // Arrange
-    const deal = {
-      ...MOCK_GEF_MAPPED_DEAL,
-      exporter: {
-        ...MOCK_GEF_MAPPED_DEAL.exporter,
-      },
-    };
+  describe('when the party already exists before getOrCreate', () => {
+    it('should set newPartyUrnCreated to false', async () => {
+      // Arrange
+      const deal = {
+        ...MOCK_GEF_MAPPED_DEAL,
+        exporter: {
+          ...MOCK_GEF_MAPPED_DEAL.exporter,
+        },
+      };
 
-    const isUkEntity = isCountryUk(deal.exporter.registeredAddress.country);
+      const isUkEntity = isCountryUk(deal.exporter.registeredAddress.country);
 
-    const { hasExporter, hasBuyer, hasIndemnifier, hasAgent } = identifyDealParties(deal);
+      const { hasExporter, hasBuyer, hasIndemnifier, hasAgent } = identifyDealParties(deal);
 
-    const mockReturn = {
-      ...MOCK_GEF_MAPPED_DEAL,
-      tfm: {
-        ...MOCK_GEF_MAPPED_DEAL.tfm,
-        parties: {
-          exporter: {
-            partyUrn,
-            partyUrnRequired: hasExporter,
-          },
-          buyer: {
-            partyUrn: '',
-            partyUrnRequired: hasBuyer,
-          },
-          indemnifier: {
-            partyUrn: '',
-            partyUrnRequired: hasIndemnifier,
-          },
-          agent: {
-            partyUrn: '',
-            partyUrnRequired: hasAgent,
+      const mockReturn = {
+        ...MOCK_GEF_MAPPED_DEAL,
+        tfm: {
+          ...MOCK_GEF_MAPPED_DEAL.tfm,
+          parties: {
+            exporter: {
+              partyUrn,
+              partyUrnRequired: hasExporter,
+            },
+            buyer: {
+              partyUrn: '',
+              partyUrnRequired: hasBuyer,
+            },
+            indemnifier: {
+              partyUrn: '',
+              partyUrnRequired: hasIndemnifier,
+            },
+            agent: {
+              partyUrn: '',
+              partyUrnRequired: hasAgent,
+            },
           },
         },
-      },
-    };
+      };
 
-    jest.mocked(getPartyDbInfo).mockResolvedValueOnce([{ partyUrn }]);
-    jest.mocked(getOrCreatePartyDbInfo).mockResolvedValueOnce([
-      {
-        partyUrn,
-        name: 'Test Ltd',
-        sfId: '001S900000zcI',
-        companyRegNo: 'SC467044',
-        type: null,
-        subtype: null,
-        isLegacyRecord: false,
-      },
-    ]);
-    jest.mocked(updateDeal).mockResolvedValue(mockReturn);
+      jest.mocked(getPartyDbInfo).mockResolvedValueOnce([{ partyUrn }]);
+      jest.mocked(getOrCreatePartyDbInfo).mockResolvedValueOnce([
+        {
+          partyUrn,
+          name: 'Test Ltd',
+          sfId: '001S900000zcI',
+          companyRegNo: 'SC467044',
+          type: null,
+          subtype: null,
+          isLegacyRecord: false,
+        },
+      ]);
+      jest.mocked(updateDeal).mockResolvedValue(mockReturn);
 
-    // Act
-    const response = await addPartyUrns(deal, auditDetails);
+      // Act
+      const response = await addPartyUrns(deal, auditDetails);
 
-    // Assert
-    expect(getPartyDbInfo).toHaveBeenCalledWith({ companyRegNo });
-    expect(getOrCreatePartyDbInfo).toHaveBeenCalledWith({ companyRegNo, companyName, probabilityOfDefault, isUkEntity, code });
-    expect(response.newPartyUrnCreated).toBe(false);
+      // Assert
+      expect(getPartyDbInfo).toHaveBeenNthCalledWith(1, { companyRegNo });
+      expect(getOrCreatePartyDbInfo).toHaveBeenNthCalledWith(1, { companyRegNo, companyName, probabilityOfDefault, isUkEntity, code });
+      expect(response.newPartyUrnCreated).toBe(false);
+    });
+  });
+
+  describe('when the existing party lookup returns a single object', () => {
+    it('should set newPartyUrnCreated to false', async () => {
+      // Arrange
+      const deal = {
+        ...MOCK_GEF_MAPPED_DEAL,
+        exporter: {
+          ...MOCK_GEF_MAPPED_DEAL.exporter,
+        },
+      };
+
+      const isUkEntity = isCountryUk(deal.exporter.registeredAddress.country);
+
+      const { hasExporter, hasBuyer, hasIndemnifier, hasAgent } = identifyDealParties(deal);
+
+      const mockReturn = {
+        ...MOCK_GEF_MAPPED_DEAL,
+        tfm: {
+          ...MOCK_GEF_MAPPED_DEAL.tfm,
+          parties: {
+            exporter: {
+              partyUrn,
+              partyUrnRequired: hasExporter,
+            },
+            buyer: {
+              partyUrn: '',
+              partyUrnRequired: hasBuyer,
+            },
+            indemnifier: {
+              partyUrn: '',
+              partyUrnRequired: hasIndemnifier,
+            },
+            agent: {
+              partyUrn: '',
+              partyUrnRequired: hasAgent,
+            },
+          },
+        },
+      };
+
+      jest.mocked(getPartyDbInfo).mockResolvedValueOnce({ partyUrn });
+      jest.mocked(getOrCreatePartyDbInfo).mockResolvedValueOnce([
+        {
+          partyUrn,
+          name: 'Test Ltd',
+          sfId: '001S900000zcI',
+          companyRegNo: 'SC467044',
+          type: null,
+          subtype: null,
+          isLegacyRecord: false,
+        },
+      ]);
+      jest.mocked(updateDeal).mockResolvedValue(mockReturn);
+
+      // Act
+      const response = await addPartyUrns(deal, auditDetails);
+
+      // Assert
+      expect(getPartyDbInfo).toHaveBeenNthCalledWith(1, { companyRegNo });
+      expect(getOrCreatePartyDbInfo).toHaveBeenNthCalledWith(1, { companyRegNo, companyName, probabilityOfDefault, isUkEntity, code });
+      expect(response.newPartyUrnCreated).toBe(false);
+    });
   });
 
   it('should return party urn when a complete exporter payload is supplied and default country to United Kingdom, when no country is returned from CH API.', async () => {

--- a/trade-finance-manager-api/server/v1/controllers/deal.party-db.js
+++ b/trade-finance-manager-api/server/v1/controllers/deal.party-db.js
@@ -31,6 +31,29 @@ const getCompany = async (req, res) => {
 };
 
 /**
+ * Extracts the PartyURN from the provided party database information.
+ * @param {*} partyDbInfo - The party database information.
+ * @returns {string} The PartyURN or an empty string if not found.
+ */
+const extractPartyUrn = (partyDbInfo) => {
+  if (Array.isArray(partyDbInfo) && partyDbInfo.length) {
+    return partyDbInfo[0]?.partyUrn || '';
+  }
+
+  if (partyDbInfo && typeof partyDbInfo === 'object') {
+    if (partyDbInfo.partyUrn) {
+      return partyDbInfo.partyUrn;
+    }
+
+    if (Array.isArray(partyDbInfo.data)) {
+      return partyDbInfo.data[0]?.partyUrn || '';
+    }
+  }
+
+  return '';
+};
+
+/**
  * Gets a PartyURN
  * @param {string} companyRegNo The company registration number
  * @param {string} companyName The company name
@@ -73,7 +96,7 @@ const getPartyUrn = async ({ companyRegNo, companyName, probabilityOfDefault, is
     return '';
   }
 
-  const partyUrn = partyDbInfo?.[0]?.partyUrn;
+  const partyUrn = extractPartyUrn(partyDbInfo);
 
   if (partyUrn) {
     return partyUrn;
@@ -130,7 +153,7 @@ const addPartyUrns = async (deal, auditDetails) => {
   if (shouldCheckExistingExporterParty) {
     const existingPartyDbInfo = await api.getPartyDbInfo({ companyRegNo });
 
-    exporterPartyExistedBeforeCreate = Boolean(existingPartyDbInfo?.[0]?.partyUrn);
+    exporterPartyExistedBeforeCreate = Boolean(extractPartyUrn(existingPartyDbInfo));
   }
 
   const exporterPartyUrn = await getPartyUrn({ companyRegNo, companyName, probabilityOfDefault, isUkEntity, code });
@@ -175,6 +198,7 @@ const addPartyUrns = async (deal, auditDetails) => {
 module.exports = {
   getCompany,
   addPartyUrns,
+  extractPartyUrn,
   getPartyUrn,
   identifyDealParties,
 };

--- a/trade-finance-manager-api/server/v1/controllers/deal.party-db.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/deal.party-db.test.js
@@ -151,6 +151,44 @@ describe('extractPartyUrn', () => {
     // Assert
     expect(result).toBe('');
   });
+
+  it('should return an empty string for undefined input', () => {
+    // Act
+    const result = api.extractPartyUrn(undefined);
+
+    // Assert
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string for an empty array', () => {
+    // Act
+    const result = api.extractPartyUrn([]);
+
+    // Assert
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string for an empty data array', () => {
+    // Arrange
+    const partyDbInfo = { data: [] };
+
+    // Act
+    const result = api.extractPartyUrn(partyDbInfo);
+
+    // Assert
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string for a plain object with no relevant properties', () => {
+    // Arrange
+    const partyDbInfo = { name: 'Test Ltd' };
+
+    // Act
+    const result = api.extractPartyUrn(partyDbInfo);
+
+    // Assert
+    expect(result).toBe('');
+  });
 });
 
 describe('getPartyUrn', () => {

--- a/trade-finance-manager-api/server/v1/controllers/deal.party-db.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/deal.party-db.test.js
@@ -97,6 +97,62 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+describe('extractPartyUrn', () => {
+  it('should return the party URN from the first array item', () => {
+    // Arrange
+    const partyDbInfo = [{ partyUrn: 'ARRAY_URN' }];
+
+    // Act
+    const result = api.extractPartyUrn(partyDbInfo);
+
+    // Assert
+    expect(result).toBe('ARRAY_URN');
+  });
+
+  it('should return the party URN from a single object', () => {
+    // Arrange
+    const partyDbInfo = { partyUrn: 'OBJECT_URN' };
+
+    // Act
+    const result = api.extractPartyUrn(partyDbInfo);
+
+    // Assert
+    expect(result).toBe('OBJECT_URN');
+  });
+
+  it('should return the party URN from a nested data array', () => {
+    // Arrange
+    const partyDbInfo = {
+      data: [{ partyUrn: 'NESTED_URN' }],
+    };
+
+    // Act
+    const result = api.extractPartyUrn(partyDbInfo);
+
+    // Assert
+    expect(result).toBe('NESTED_URN');
+  });
+
+  it('should return an empty string when no party URN is present', () => {
+    // Arrange
+    const partyDbInfo = { data: [{}] };
+
+    // Act
+    const result = api.extractPartyUrn(partyDbInfo);
+
+    // Assert
+    expect(result).toBe('');
+  });
+
+  it('should return an empty string for null input', () => {
+    // Act
+    const result = api.extractPartyUrn(null);
+
+    // Assert
+    expect(result).toBe('');
+  });
+});
+
 describe('getPartyUrn', () => {
   it('should return an empty string if no companyRegNo is provided', async () => {
     // Act

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.js
@@ -18,6 +18,8 @@ const updateParty = async (req, res) => {
   try {
     const { dealId } = req.params;
 
+    console.info('TFM deal %s updateParty - updating parties in TFM', dealId);
+
     const dealUpdate = {
       tfm: {
         parties: req.body,
@@ -39,7 +41,7 @@ const updateParty = async (req, res) => {
           facilities: issuedFacilities,
           isBssEwcsDeal,
           isGefDeal,
-          newPartyUrnCreated: true,
+          newPartyUrnCreated: false,
         });
       } catch (error) {
         console.error('TFM deal %s updateParty - sendFacilitiesToApimGift failed %o', dealId, error);

--- a/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/party.controller.test.js
@@ -173,7 +173,7 @@ describe('updateParty', () => {
         facilities: issuedFacilities,
         isBssEwcsDeal: false,
         isGefDeal: true,
-        newPartyUrnCreated: true,
+        newPartyUrnCreated: false,
       });
     });
 


### PR DESCRIPTION
# Introduction :pencil2:

When sending a new facility to APIM/GIFT, a `newPartyUrnCreated` flag is passed to the payload mapping functions to tell APIM to delay sending the facility to GIFT.

There is a bug where if a new party URN was **not** created (already exists in Salesforce), `newPartyUrnCreated` would remain true.

It appears to be due to the handling of response data from the party lookup.

This PR should hopefully fix the issue.

## Resolution :heavy_check_mark:

- Create `extractPartyUrn` helper
- Update `getPartyUrn`
- Update `addPartyUrns`
- Update `updateParty`
- Add/update tests

## Miscellaneous :heavy_plus_sign:

- Minor logging improvement

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
