### PR TITLE
fix(DTFS2-8485): create a gift facility - obligation amount

### DIFF
--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
@@ -138,7 +138,6 @@ describe('createFacility', () => {
         facilityType: facilitySnapshot.type,
         isBssEwcsDeal,
         isGefDeal,
-        ukefExposure: Number(tfm.ukefExposure),
       }),
       riskDetails: await mapRiskDetails({
         creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
@@ -62,8 +62,6 @@ export const createFacility = async ({
   const effectiveDate = String(facilityGuaranteeDates?.guaranteeCommencementDate);
   const expiryDate = String(facilityGuaranteeDates?.guaranteeExpiryDate);
 
-  const ukefExposure = Number(tfm.ukefExposure);
-
   const coverPercentage = mapCoverPercentage({
     facilitySnapshot,
     isBssEwcsDeal,
@@ -157,7 +155,6 @@ export const createFacility = async ({
       facilityType,
       isBssEwcsDeal,
       isGefDeal,
-      ukefExposure,
     }),
     riskDetails: await mapRiskDetails({
       creditRiskRatings,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
@@ -10,7 +10,6 @@ describe('mapObligations', () => {
   const currency = 'GBP';
   const facilityAmount = 1500;
   const facilityType = FACILITY_TYPE.CASH;
-  const ukefExposure = 1500;
 
   describe('when isBssEwcsDeal is true', () => {
     it('should return an array with one obligation and mapped subtypeCode', () => {
@@ -25,7 +24,6 @@ describe('mapObligations', () => {
         isBssEwcsDeal,
         isGefDeal,
         bssSubtypeName,
-        ukefExposure,
       });
 
       // Assert
@@ -36,7 +34,6 @@ describe('mapObligations', () => {
             isGefDeal,
             facilityAmount,
             facilityType,
-            ukefExposure,
           }),
           currency,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
@@ -61,7 +58,6 @@ describe('mapObligations', () => {
           isBssEwcsDeal,
           isGefDeal,
           bssSubtypeName: unmappedBssSubtypeName,
-          ukefExposure,
         });
 
         // Assert
@@ -72,7 +68,6 @@ describe('mapObligations', () => {
               isGefDeal,
               facilityAmount,
               facilityType,
-              ukefExposure,
             }),
             currency,
             repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
@@ -98,7 +93,6 @@ describe('mapObligations', () => {
         isBssEwcsDeal,
         isGefDeal,
         facilityType,
-        ukefExposure,
       });
 
       // Assert
@@ -109,7 +103,6 @@ describe('mapObligations', () => {
             isGefDeal,
             facilityAmount,
             facilityType,
-            ukefExposure,
           }),
           currency,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
@@ -133,7 +126,6 @@ describe('mapObligations', () => {
         facilityAmount,
         isBssEwcsDeal,
         isGefDeal,
-        ukefExposure,
       });
 
       // Assert
@@ -144,7 +136,6 @@ describe('mapObligations', () => {
             isGefDeal,
             facilityAmount,
             facilityType,
-            ukefExposure,
           }),
           currency,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
@@ -12,7 +12,6 @@ type MapObligationsParams = {
   facilityAmount: number | null;
   facilityType?: string;
   isGefDeal: boolean;
-  ukefExposure: number;
 };
 
 /**
@@ -26,7 +25,6 @@ type MapObligationsParams = {
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
  * @param {number | null} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
  * @param {string} [params.facilityType] - The facility type (e.g. "Bond", "Cash", "Contingent", "Loan"). Only required for GEF facilities.
- * @param {number} params.ukefExposure - The facility's UKEF exposure.
  * @returns {ApimGiftObligation[]} Mapped obligations array for the APIM GIFT payload.
  */
 export const mapObligations = ({
@@ -36,7 +34,6 @@ export const mapObligations = ({
   isGefDeal,
   facilityAmount,
   facilityType,
-  ukefExposure,
 }: MapObligationsParams): ApimGiftObligation[] => {
   let subtypeCode = null;
 
@@ -62,7 +59,6 @@ export const mapObligations = ({
         isGefDeal,
         facilityAmount,
         facilityType,
-        ukefExposure,
       }),
       currency,
       repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
@@ -23,7 +23,7 @@ type MapObligationsParams = {
  * @param {Currency} params.currency - The facility currency code to use for the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
- * @param {number | null} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
+ * @param {number | null} params.facilityAmount - The facility amount (required for BSS/EWCS; used for GEF obligation calculation).
  * @param {string} [params.facilityType] - The facility type (e.g. "Bond", "Cash", "Contingent", "Loan"). Only required for GEF facilities.
  * @returns {ApimGiftObligation[]} Mapped obligations array for the APIM GIFT payload.
  */

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
@@ -4,18 +4,19 @@ import { OBLIGATION_AMOUNT } from '../../../constants';
 
 const { UKEF_EXPOSURE_PERCENTAGE } = OBLIGATION_AMOUNT;
 
+const facilityAmount = 1000;
+
 describe('mapGefObligationAmount', () => {
   describe(`when facilityType is ${FACILITY_TYPE.CASH}`, () => {
     it(`should return the ukefExposure multiplied by the ${FACILITY_TYPE.CASH} percentage with decimals`, () => {
       // Arrange
       const facilityType = FACILITY_TYPE.CASH;
-      const ukefExposure = 1000;
 
       // Act
-      const result = mapGefObligationAmount({ facilityType, ukefExposure });
+      const result = mapGefObligationAmount({ facilityType, facilityAmount });
 
       // Assert
-      const expectedRounded = ukefExposure * UKEF_EXPOSURE_PERCENTAGE.CASH;
+      const expectedRounded = facilityAmount * UKEF_EXPOSURE_PERCENTAGE.CASH;
 
       const expected = Math.round(expectedRounded * 100) / 100;
 
@@ -27,13 +28,12 @@ describe('mapGefObligationAmount', () => {
     it(`should return the ukefExposure multiplied by the ${FACILITY_TYPE.CONTINGENT} percentage with decimals`, () => {
       // Arrange
       const facilityType = FACILITY_TYPE.CONTINGENT;
-      const ukefExposure = 1000;
 
       // Act
-      const result = mapGefObligationAmount({ facilityType, ukefExposure });
+      const result = mapGefObligationAmount({ facilityType, facilityAmount });
 
       // Assert
-      const expectedRounded = ukefExposure * UKEF_EXPOSURE_PERCENTAGE.CONTINGENT;
+      const expectedRounded = facilityAmount * UKEF_EXPOSURE_PERCENTAGE.CONTINGENT;
 
       const expected = Math.round(expectedRounded * 100) / 100;
 
@@ -45,10 +45,9 @@ describe('mapGefObligationAmount', () => {
     it('should return null', () => {
       // Arrange
       const facilityType = FACILITY_TYPE.BOND;
-      const ukefExposure = 1000;
 
       // Act
-      const result = mapGefObligationAmount({ facilityType, ukefExposure });
+      const result = mapGefObligationAmount({ facilityType, facilityAmount });
 
       // Assert
       expect(result).toBeNull();
@@ -57,9 +56,6 @@ describe('mapGefObligationAmount', () => {
 });
 
 describe('mapObligationAmount', () => {
-  const facilityAmount = 1000;
-  const ukefExposure = 1000;
-
   describe('when isGefDeal is true', () => {
     it('should return the the result of mapGefObligationAmount', () => {
       // Arrange
@@ -72,11 +68,10 @@ describe('mapObligationAmount', () => {
         isGefDeal: true,
         facilityAmount,
         facilityType,
-        ukefExposure,
       });
 
       // Assert
-      const expected = mapGefObligationAmount({ facilityType, ukefExposure });
+      const expected = mapGefObligationAmount({ facilityType, facilityAmount });
 
       expect(result).toEqual(expected);
     });
@@ -92,7 +87,6 @@ describe('mapObligationAmount', () => {
         isBssEwcsDeal,
         isGefDeal: false,
         facilityAmount,
-        ukefExposure,
       });
 
       // Assert
@@ -110,7 +104,6 @@ describe('mapObligationAmount', () => {
         isBssEwcsDeal,
         isGefDeal: false,
         facilityAmount: null,
-        ukefExposure,
       });
 
       // Assert
@@ -128,7 +121,6 @@ describe('mapObligationAmount', () => {
         isBssEwcsDeal,
         isGefDeal: false,
         facilityAmount,
-        ukefExposure,
       });
 
       // Assert

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
@@ -8,7 +8,7 @@ const facilityAmount = 1000;
 
 describe('mapGefObligationAmount', () => {
   describe(`when facilityType is ${FACILITY_TYPE.CASH}`, () => {
-    it(`should return the ukefExposure multiplied by the ${FACILITY_TYPE.CASH} percentage with decimals`, () => {
+    it(`should return the facilityAmount multiplied by the ${FACILITY_TYPE.CASH} percentage with decimals`, () => {
       // Arrange
       const facilityType = FACILITY_TYPE.CASH;
 
@@ -24,8 +24,21 @@ describe('mapGefObligationAmount', () => {
     });
   });
 
+  describe('when facilityAmount is null', () => {
+    it('should return null', () => {
+      // Arrange
+      const facilityType = FACILITY_TYPE.CASH;
+
+      // Act
+      const result = mapGefObligationAmount({ facilityType, facilityAmount: null });
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
   describe(`when facilityType is ${FACILITY_TYPE.CONTINGENT}`, () => {
-    it(`should return the ukefExposure multiplied by the ${FACILITY_TYPE.CONTINGENT} percentage with decimals`, () => {
+    it(`should return the facilityAmount multiplied by the ${FACILITY_TYPE.CONTINGENT} percentage with decimals`, () => {
       // Arrange
       const facilityType = FACILITY_TYPE.CONTINGENT;
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
@@ -26,7 +26,7 @@ type MapObligationAmountParams = MapGefObligationAmountParams & {
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */
 export const mapGefObligationAmount = ({ facilityType, facilityAmount }: MapGefObligationAmountParams): number | null => {
-  if (facilityAmount && facilityAmount !== null) {
+  if (facilityAmount) {
     if (facilityType === FACILITY_TYPE.CASH) {
       const multiplier = UKEF_EXPOSURE_PERCENTAGE.CASH;
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
@@ -48,7 +48,7 @@ export const mapGefObligationAmount = ({ facilityType, facilityAmount }: MapGefO
  * @param {MapObligationAmountParams} params - Data required to calculate the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
- * @param {number | null} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
+ * @param {number | null} params.facilityAmount - The facility amount (required for BSS/EWCS; used for GEF obligation calculation).
  * @param {string} [params.facilityType] - The facility type (e.g. "Cash", "Contingent"). Only required for GEF deals.
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
@@ -18,7 +18,7 @@ type MapObligationAmountParams = MapGefObligationAmountParams & {
  * Maps the obligation amount for a GEF facility.
  * @param {MapGefObligationAmountParams} params - Data required to calculate the obligation amount.
  * @param {string} params.facilityType - The facility type (e.g. "Cash", "Contingent").
- * @param {number} params.facilityAmount - The facility amount
+ * @param {number | null} params.facilityAmount - The facility amount
  * @example
  * const obligationAmount = mapGefObligationAmount({ facilityType: 'Contingent', facilityAmount: 128.518888 }); => 89.96
  * const obligationAmount = mapGefObligationAmount({ facilityType: 'Cash', facilityAmount: 128.518888 }); => 109.24
@@ -26,7 +26,7 @@ type MapObligationAmountParams = MapGefObligationAmountParams & {
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */
 export const mapGefObligationAmount = ({ facilityType, facilityAmount }: MapGefObligationAmountParams): number | null => {
-  if (facilityAmount) {
+  if (facilityAmount && facilityAmount !== null) {
     if (facilityType === FACILITY_TYPE.CASH) {
       const multiplier = UKEF_EXPOSURE_PERCENTAGE.CASH;
 
@@ -48,7 +48,7 @@ export const mapGefObligationAmount = ({ facilityType, facilityAmount }: MapGefO
  * @param {MapObligationAmountParams} params - Data required to calculate the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
- * @param {number} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
+ * @param {number | null} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
  * @param {string} [params.facilityType] - The facility type (e.g. "Cash", "Contingent"). Only required for GEF deals.
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
@@ -5,7 +5,7 @@ const { UKEF_EXPOSURE_PERCENTAGE } = OBLIGATION_AMOUNT;
 
 type MapGefObligationAmountParams = {
   facilityType?: string;
-  ukefExposure: number;
+  facilityAmount: number | null;
 };
 
 type MapObligationAmountParams = MapGefObligationAmountParams & {
@@ -18,24 +18,26 @@ type MapObligationAmountParams = MapGefObligationAmountParams & {
  * Maps the obligation amount for a GEF facility.
  * @param {MapGefObligationAmountParams} params - Data required to calculate the obligation amount.
  * @param {string} params.facilityType - The facility type (e.g. "Cash", "Contingent").
- * @param {number} params.ukefExposure - The facility's UKEF exposure.
+ * @param {number} params.facilityAmount - The facility amount
  * @example
- * const obligationAmount = mapGefObligationAmount({ facilityType: 'Contingent', ukefExposure: 128.518888 }); => 89.96
- * const obligationAmount = mapGefObligationAmount({ facilityType: 'Cash', ukefExposure: 128.518888 }); => 109.24
- * const obligationAmount = mapGefObligationAmount({ facilityType: 'Unknown', ukefExposure: 128.518888 }); => null
+ * const obligationAmount = mapGefObligationAmount({ facilityType: 'Contingent', facilityAmount: 128.518888 }); => 89.96
+ * const obligationAmount = mapGefObligationAmount({ facilityType: 'Cash', facilityAmount: 128.518888 }); => 109.24
+ * const obligationAmount = mapGefObligationAmount({ facilityType: 'Unknown', facilityAmount: 128.518888 }); => null
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */
-export const mapGefObligationAmount = ({ facilityType, ukefExposure }: MapGefObligationAmountParams): number | null => {
-  if (facilityType === FACILITY_TYPE.CASH) {
-    const multiplier = UKEF_EXPOSURE_PERCENTAGE.CASH;
+export const mapGefObligationAmount = ({ facilityType, facilityAmount }: MapGefObligationAmountParams): number | null => {
+  if (facilityAmount) {
+    if (facilityType === FACILITY_TYPE.CASH) {
+      const multiplier = UKEF_EXPOSURE_PERCENTAGE.CASH;
 
-    return Math.round(ukefExposure * multiplier * 100) / 100;
-  }
+      return Math.round(facilityAmount * multiplier * 100) / 100;
+    }
 
-  if (facilityType === FACILITY_TYPE.CONTINGENT) {
-    const multiplier = UKEF_EXPOSURE_PERCENTAGE.CONTINGENT;
+    if (facilityType === FACILITY_TYPE.CONTINGENT) {
+      const multiplier = UKEF_EXPOSURE_PERCENTAGE.CONTINGENT;
 
-    return Math.round(ukefExposure * multiplier * 100) / 100;
+      return Math.round(facilityAmount * multiplier * 100) / 100;
+    }
   }
 
   return null;
@@ -48,16 +50,15 @@ export const mapGefObligationAmount = ({ facilityType, ukefExposure }: MapGefObl
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
  * @param {number} params.facilityAmount - The facility amount. Only required for BSS/EWCS deals.
  * @param {string} [params.facilityType] - The facility type (e.g. "Cash", "Contingent"). Only required for GEF deals.
- * @param {number} params.ukefExposure - The facility's UKEF exposure.
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */
-export const mapObligationAmount = ({ isBssEwcsDeal, isGefDeal, facilityAmount, facilityType, ukefExposure }: MapObligationAmountParams): number | null => {
+export const mapObligationAmount = ({ isBssEwcsDeal, isGefDeal, facilityAmount, facilityType }: MapObligationAmountParams): number | null => {
   if (isBssEwcsDeal) {
     return facilityAmount;
   }
 
   if (isGefDeal) {
-    return mapGefObligationAmount({ facilityType, ukefExposure });
+    return mapGefObligationAmount({ facilityType, facilityAmount });
   }
 
   return null;

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-overview/map-facility-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-overview/map-facility-amount/index.ts
@@ -15,8 +15,8 @@ type MapFacilityAmountParams = {
  *
  * cover percentages are stored as percent values (e.g. 80),
  * so this should divide by 100 to avoid sending amounts inflated by 100x.
- * @param {string | null} params - The parameters for mapping the facility amount.
- * @param {NumberGeneratorResponse} params.facilityAmount - The total facility amount.
+ * @param {MapFacilityAmountParams} params - The parameters for mapping the facility amount.
+ * @param {number | string} params.facilityAmount - The total facility amount.
  * @param {number | null} params.coverPercentage - The cover percentage for the facility.
  * @returns {number | null} The mapped facility amount.
  */


### PR DESCRIPTION
# Introduction :pencil2:

GIFT obligation amounts mapping needs updating to calculate using `facilityAmount` instead of `ukefExposure`.

This should additionally fix a bug where non-GBP facilities are not correct in GIFT. `facilityAmount` is the value in the original currency, whereas monetary values in a facility's `tfm` object are converted to GBP.

## Resolution :heavy_check_mark:

- Remove `ukefExposure` from obligation mapping functions.
- Update `mapGefObligationAmount` to use `facilityAmount` instead of `ukefExposure`.
- Update tests.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
