### PR TITLE
fix(DTFS2-8399): improve accessibility of dac-links-and-landmarks

### DIFF
--- a/portal-ui/component-tests/test-helpers/pagination/itShouldRenderFirstAndPreviousLinks.js
+++ b/portal-ui/component-tests/test-helpers/pagination/itShouldRenderFirstAndPreviousLinks.js
@@ -5,7 +5,7 @@ module.exports = ({ getWrapper, currentPage }) => {
     wrapper.expectElement('[data-cy="First_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="First_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="First"]').toLinkTo('/testRoute/0?testQuery=test', 'First');
+    wrapper.expectLink('[data-cy="First"]').toLinkTo('/testRoute/0?testQuery=test', 'First page');
     wrapper.expectElement('[data-cy="First"]').hasClass('govuk-link');
   });
 
@@ -15,7 +15,7 @@ module.exports = ({ getWrapper, currentPage }) => {
     wrapper.expectElement('[data-cy="Previous_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="Previous_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="Previous"]').toLinkTo(`/testRoute/${currentPage - 1}?testQuery=test`, 'Previous');
+    wrapper.expectLink('[data-cy="Previous"]').toLinkTo(`/testRoute/${currentPage - 1}?testQuery=test`, 'Previous page');
     wrapper.expectElement('[data-cy="Previous"]').hasClass('govuk-link');
   });
 };

--- a/portal-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
+++ b/portal-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
@@ -9,7 +9,7 @@ module.exports = ({ getWrapper, firstPage, lastPage, currentPage }) => {
       wrapper.expectElement(`[data-cy="Page_${i}_listItem"]`).hasClass('govuk-body');
       wrapper.expectElement(`[data-cy="Page_${i}_listItem"]`).hasClass('govuk-!-margin-bottom-3');
 
-      wrapper.expectLink(`[data-cy="Page_${i}"]`).toLinkTo(`/testRoute/${i}?testQuery=test`, (i + 1).toString());
+      wrapper.expectLink(`[data-cy="Page_${i}"]`).toLinkTo(`/testRoute/${i}?testQuery=test`, `Page ${i + 1}`);
       wrapper.expectElement(`[data-cy="Page_${i}"]`).hasClass('govuk-link');
 
       if (i === currentPage) {

--- a/portal-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
+++ b/portal-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
@@ -14,8 +14,10 @@ module.exports = ({ getWrapper, firstPage, lastPage, currentPage }) => {
 
       if (i === currentPage) {
         wrapper.expectElement(`[data-cy="Page_${i}_listItem"]`).hasClass('active');
+        wrapper.expectElement(`[data-cy="Page_${i}"]`).toHaveAttribute('aria-current', 'page');
       } else {
         wrapper.expectElement(`[data-cy="Page_${i}_listItem"]`).doesNotHaveClass('active');
+        wrapper.expectElement(`[data-cy="Page_${i}"]`).notToHaveAttribute('aria-current');
       }
     }
 

--- a/portal-ui/component-tests/test-helpers/pagination/itShouldRenderNavigationList.js
+++ b/portal-ui/component-tests/test-helpers/pagination/itShouldRenderNavigationList.js
@@ -5,11 +5,17 @@ module.exports = (getWrapper) => {
     wrapper.expectElement('[data-cy="pagination"]').toExist();
   });
 
-  it("should render a visually hidden header with the text 'Pagination'", () => {
+  it('should give the nav landmark an accessible name via aria-labelledby pointing at the pagination heading', () => {
     const wrapper = getWrapper();
 
-    wrapper.expectElement('h4').hasClass('govuk-visually-hidden');
-    wrapper.expectText('h4').toRead('Pagination');
+    wrapper.expectElement('nav[aria-labelledby="pagination-heading"]').toExist();
+  });
+
+  it("should render a visually hidden header with id 'pagination-heading' and the text 'Pagination'", () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement('h4#pagination-heading').hasClass('govuk-visually-hidden');
+    wrapper.expectText('h4#pagination-heading').toRead('Pagination');
   });
 
   it('should render an unordered list', () => {

--- a/portal-ui/component-tests/test-helpers/pagination/itShouldRenderNextAndLastLinks.js
+++ b/portal-ui/component-tests/test-helpers/pagination/itShouldRenderNextAndLastLinks.js
@@ -5,7 +5,7 @@ module.exports = ({ getWrapper, currentPage, totalPages }) => {
     wrapper.expectElement('[data-cy="Next_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="Next_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="Next"]').toLinkTo(`/testRoute/${currentPage + 1}?testQuery=test`, 'Next');
+    wrapper.expectLink('[data-cy="Next"]').toLinkTo(`/testRoute/${currentPage + 1}?testQuery=test`, 'Next page');
     wrapper.expectElement('[data-cy="Next"]').hasClass('govuk-link');
   });
 
@@ -15,7 +15,7 @@ module.exports = ({ getWrapper, currentPage, totalPages }) => {
     wrapper.expectElement('[data-cy="Last_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="Last_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="Last"]').toLinkTo(`/testRoute/${totalPages - 1}?testQuery=test`, 'Last');
+    wrapper.expectLink('[data-cy="Last"]').toLinkTo(`/testRoute/${totalPages - 1}?testQuery=test`, 'Last page');
     wrapper.expectElement('[data-cy="Last"]').hasClass('govuk-link');
   });
 };

--- a/portal-ui/templates/_macros/pagination.njk
+++ b/portal-ui/templates/_macros/pagination.njk
@@ -33,7 +33,9 @@
           {% for i in range(currentPage - 4, totalPages) %}
             {% if loop.index < 10 and i + 1 > 0 %}
               <li data-cy="Page_{{i}}_listItem" class="govuk-body govuk-!-margin-bottom-3 {%if i === currentPage %}active{% endif %}">
-                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link"><span class="govuk-visually-hidden">Page </span>{{ i + 1 }}</a>
+                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link" {% if i === currentPage %}aria-current="page"{% endif %}>
+                  <span class="govuk-visually-hidden">Page </span>{{ i + 1 }}
+                </a>
               </li>
             {% endif %}
           {%- endfor %}

--- a/portal-ui/templates/_macros/pagination.njk
+++ b/portal-ui/templates/_macros/pagination.njk
@@ -9,18 +9,18 @@
 
     {% if totalPages > 1 %}
 
-      <nav>
-        <h4 class="govuk-visually-hidden">Pagination</h4>
+      <nav aria-labelledby="pagination-heading">
+        <h4 id="pagination-heading" class="govuk-visually-hidden">Pagination</h4>
 
         <ul class="govuk-!-margin-bottom-0">
 
           {% if currentPage !== 0 %}
             <li data-cy="First_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="First" href="{{paginationRoute}}/0{{queryString}}" class="govuk-link">First</a>
+              <a data-cy="First" href="{{paginationRoute}}/0{{queryString}}" class="govuk-link">First<span class="govuk-visually-hidden"> page</span></a>
             </li>
 
             <li data-cy="Previous_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="Previous" href="{{paginationRoute}}/{{currentPage-1}}{{queryString}}" class="govuk-link">Previous</a>
+              <a data-cy="Previous" href="{{paginationRoute}}/{{currentPage-1}}{{queryString}}" class="govuk-link">Previous<span class="govuk-visually-hidden"> page</span></a>
             </li>
           {% endif %}
 
@@ -33,7 +33,7 @@
           {% for i in range(currentPage - 4, totalPages) %}
             {% if loop.index < 10 and i + 1 > 0 %}
               <li data-cy="Page_{{i}}_listItem" class="govuk-body govuk-!-margin-bottom-3 {%if i === currentPage %}active{% endif %}">
-                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link">{{ i + 1 }}</a>
+                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link"><span class="govuk-visually-hidden">Page </span>{{ i + 1 }}</a>
               </li>
             {% endif %}
           {%- endfor %}
@@ -47,11 +47,11 @@
 
           {% if currentPage !== (totalPages-1) %}
             <li data-cy="Next_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="Next" href="{{paginationRoute}}/{{currentPage+1}}{{queryString}}" class="govuk-link">Next</a>
+              <a data-cy="Next" href="{{paginationRoute}}/{{currentPage+1}}{{queryString}}" class="govuk-link">Next<span class="govuk-visually-hidden"> page</span></a>
             </li>
 
             <li data-cy="Last_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="Last" href="{{paginationRoute}}/{{totalPages-1}}{{queryString}}" class="govuk-link">Last</a>
+              <a data-cy="Last" href="{{paginationRoute}}/{{totalPages-1}}{{queryString}}" class="govuk-link">Last<span class="govuk-visually-hidden"> page</span></a>
             </li>
           {% endif %}
 

--- a/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderFirstAndPreviousLinks.js
+++ b/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderFirstAndPreviousLinks.js
@@ -5,7 +5,7 @@ module.exports = ({ getWrapper, currentPage }) => {
     wrapper.expectElement('[data-cy="First_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="First_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="First"]').toLinkTo('/testRoute/0?testQuery=test', 'First');
+    wrapper.expectLink('[data-cy="First"]').toLinkTo('/testRoute/0?testQuery=test', 'First page');
     wrapper.expectElement('[data-cy="First"]').hasClass('govuk-link');
   });
 
@@ -15,7 +15,7 @@ module.exports = ({ getWrapper, currentPage }) => {
     wrapper.expectElement('[data-cy="Previous_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="Previous_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="Previous"]').toLinkTo(`/testRoute/${currentPage - 1}?testQuery=test`, 'Previous');
+    wrapper.expectLink('[data-cy="Previous"]').toLinkTo(`/testRoute/${currentPage - 1}?testQuery=test`, 'Previous page');
     wrapper.expectElement('[data-cy="Previous"]').hasClass('govuk-link');
   });
 };

--- a/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
+++ b/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
@@ -9,7 +9,7 @@ module.exports = ({ getWrapper, firstPage, lastPage, currentPage }) => {
       wrapper.expectElement(`[data-cy="Page_${i}_listItem"]`).hasClass('govuk-body');
       wrapper.expectElement(`[data-cy="Page_${i}_listItem"]`).hasClass('govuk-!-margin-bottom-3');
 
-      wrapper.expectLink(`[data-cy="Page_${i}"]`).toLinkTo(`/testRoute/${i}?testQuery=test`, (i + 1).toString());
+      wrapper.expectLink(`[data-cy="Page_${i}"]`).toLinkTo(`/testRoute/${i}?testQuery=test`, `Page ${i + 1}`);
       wrapper.expectElement(`[data-cy="Page_${i}"]`).hasClass('govuk-link');
 
       if (i === currentPage) {

--- a/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderNavigationList.js
+++ b/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderNavigationList.js
@@ -5,11 +5,17 @@ module.exports = (getWrapper) => {
     wrapper.expectElement('[data-cy="pagination"]').toExist();
   });
 
-  it("should render a visually hidden header with the text 'Pagination'", () => {
+  it('should give the nav landmark an accessible name via aria-labelledby pointing at the pagination heading', () => {
     const wrapper = getWrapper();
 
-    wrapper.expectElement('h4').hasClass('govuk-visually-hidden');
-    wrapper.expectText('h4').toRead('Pagination');
+    wrapper.expectElement('nav[aria-labelledby="pagination-heading"]').toExist();
+  });
+
+  it("should render a visually hidden header with id 'pagination-heading' and the text 'Pagination'", () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement('h4#pagination-heading').hasClass('govuk-visually-hidden');
+    wrapper.expectText('h4#pagination-heading').toRead('Pagination');
   });
 
   it('should render an unordered list', () => {

--- a/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderNextAndLastLinks.js
+++ b/trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderNextAndLastLinks.js
@@ -5,7 +5,7 @@ module.exports = ({ getWrapper, currentPage, totalPages }) => {
     wrapper.expectElement('[data-cy="Next_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="Next_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="Next"]').toLinkTo(`/testRoute/${currentPage + 1}?testQuery=test`, 'Next');
+    wrapper.expectLink('[data-cy="Next"]').toLinkTo(`/testRoute/${currentPage + 1}?testQuery=test`, 'Next page');
     wrapper.expectElement('[data-cy="Next"]').hasClass('govuk-link');
   });
 
@@ -15,7 +15,7 @@ module.exports = ({ getWrapper, currentPage, totalPages }) => {
     wrapper.expectElement('[data-cy="Last_listItem"]').hasClass('govuk-body');
     wrapper.expectElement('[data-cy="Last_listItem"]').hasClass('govuk-!-margin-bottom-3');
 
-    wrapper.expectLink('[data-cy="Last"]').toLinkTo(`/testRoute/${totalPages - 1}?testQuery=test`, 'Last');
+    wrapper.expectLink('[data-cy="Last"]').toLinkTo(`/testRoute/${totalPages - 1}?testQuery=test`, 'Last page');
     wrapper.expectElement('[data-cy="Last"]').hasClass('govuk-link');
   });
 };

--- a/trade-finance-manager-ui/templates/_macros/pagination.njk
+++ b/trade-finance-manager-ui/templates/_macros/pagination.njk
@@ -33,7 +33,9 @@
           {% for i in range(currentPage - 4, totalPages) %}
             {% if loop.index < 10 and i + 1 > 0 %}
               <li data-cy="Page_{{i}}_listItem" class="govuk-body govuk-!-margin-bottom-3 {%if i === currentPage %}active{% endif %}">
-                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link"><span class="govuk-visually-hidden">Page </span>{{ i + 1 }}</a>
+                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link" {% if i === currentPage %}aria-current="page"{% endif %}>
+                  <span class="govuk-visually-hidden">Page </span>{{ i + 1 }}
+                </a>
               </li>
             {% endif %}
           {%- endfor %}

--- a/trade-finance-manager-ui/templates/_macros/pagination.njk
+++ b/trade-finance-manager-ui/templates/_macros/pagination.njk
@@ -9,18 +9,18 @@
 
     {% if totalPages > 1 %}
 
-      <nav>
-        <h4 class="govuk-visually-hidden">Pagination</h4>
+      <nav aria-labelledby="pagination-heading">
+        <h4 id="pagination-heading" class="govuk-visually-hidden">Pagination</h4>
 
         <ul class="govuk-!-margin-bottom-0">
 
           {% if currentPage !== 0 %}
             <li data-cy="First_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="First" href="{{paginationRoute}}/0{{queryString}}" class="govuk-link">First</a>
+              <a data-cy="First" href="{{paginationRoute}}/0{{queryString}}" class="govuk-link">First<span class="govuk-visually-hidden"> page</span></a>
             </li>
 
             <li data-cy="Previous_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="Previous" href="{{paginationRoute}}/{{currentPage-1}}{{queryString}}" class="govuk-link">Previous</a>
+              <a data-cy="Previous" href="{{paginationRoute}}/{{currentPage-1}}{{queryString}}" class="govuk-link">Previous<span class="govuk-visually-hidden"> page</span></a>
             </li>
           {% endif %}
 
@@ -33,7 +33,7 @@
           {% for i in range(currentPage - 4, totalPages) %}
             {% if loop.index < 10 and i + 1 > 0 %}
               <li data-cy="Page_{{i}}_listItem" class="govuk-body govuk-!-margin-bottom-3 {%if i === currentPage %}active{% endif %}">
-                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link">{{ i + 1 }}</a>
+                <a data-cy="Page_{{i}}" href="{{paginationRoute}}/{{i}}{{queryString}}" class="govuk-link"><span class="govuk-visually-hidden">Page </span>{{ i + 1 }}</a>
               </li>
             {% endif %}
           {%- endfor %}
@@ -47,11 +47,11 @@
 
           {% if currentPage !== (totalPages-1) %}
             <li data-cy="Next_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="Next" href="{{paginationRoute}}/{{currentPage+1}}{{queryString}}" class="govuk-link">Next</a>
+              <a data-cy="Next" href="{{paginationRoute}}/{{currentPage+1}}{{queryString}}" class="govuk-link">Next<span class="govuk-visually-hidden"> page</span></a>
             </li>
 
             <li data-cy="Last_listItem" class="govuk-body govuk-!-margin-bottom-3">
-              <a data-cy="Last" href="{{paginationRoute}}/{{totalPages-1}}{{queryString}}" class="govuk-link">Last</a>
+              <a data-cy="Last" href="{{paginationRoute}}/{{totalPages-1}}{{queryString}}" class="govuk-link">Last<span class="govuk-visually-hidden"> page</span></a>
             </li>
           {% endif %}
 


### PR DESCRIPTION
# Introduction :pencil2:

This PR improves the accessibility of the shared pagination macro used by the Portal dashboard and TFM deals/facilities pages. The `<nav>` landmark now has an accessible name via `aria-labelledby` pointing at the existing `Pagination` heading (which has been given an `id`), so screen-reader users get a meaningful announcement when jumping between landmarks. 

Each link is also wrapped with a `govuk-visually-hidden` span so the accessible name reads as a full phrase `First page`, `Previous page`, `Page 2`, `Next page`, `Last page` matching the GOV.UK Design System pattern, with no change to the visible UI.

The change was applied identically to both `portal-ui/pagination.njk` and `TFM/pagination.njk`, and the matching `component-tests/_macros` test helpers in both services were updated to assert the new ARIA wiring and the new accessible-name strings, all pagination component tests pass in each service.

## Resolution :heavy_check_mark:
List all changes made to the codebase.
- PORTAL-UI
portal-ui/component-tests/test-helpers/pagination/itShouldRenderFirstAndPreviousLinks.js
portal-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
portal-ui/component-tests/test-helpers/pagination/itShouldRenderNavigationList.js
portal-ui/component-tests/test-helpers/pagination/itShouldRenderNextAndLastLinks.js
portal-ui/templates/_macros/pagination.njk

- TFM:
trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderFirstAndPreviousLinks.js
trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderLinksToPagesInRange.js
trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderNavigationList.js
trade-finance-manager-ui/component-tests/test-helpers/pagination/itShouldRenderNextAndLastLinks.js
trade-finance-manager-ui/templates/_macros/pagination.njk

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
