### PR TITLE
fix(DTFS2-8431-8488): amend a gift facility - expiryDate mapping

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/amendments/send-facility-amendment.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/amendments/send-facility-amendment.api-test.js
@@ -42,9 +42,8 @@ describe('POST /v1/amendment/facility/:facilityId/amendment/:amendmentId', () =>
     dealId: mockDealId,
     changeFacilityValue: false,
     changeCoverEndDate: true,
-    tfm: {
-      coverEndDate: Date.parse('2024-04-01T00:00:00.000Z'),
-    },
+    coverEndDate: Date.parse('2024-04-01T00:00:00.000Z'),
+    tfm: {},
   };
 
   const expectedApimGiftAmendmentPayloads = [

--- a/trade-finance-manager-api/api-tests/v1/amendments/update-facility-amendment-apim-gift.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/amendments/update-facility-amendment-apim-gift.api-test.js
@@ -49,9 +49,8 @@ describe('PUT /v1/facilities/:facilityId/amendments/:amendmentId - APIM GIFT int
     status: TFM_AMENDMENT_STATUS.COMPLETED,
     changeFacilityValue: false,
     changeCoverEndDate: true,
-    tfm: {
-      coverEndDate: 1711929600000,
-    },
+    coverEndDate: 1711929600000,
+    tfm: {},
   };
 
   const tfmDeal = {

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
@@ -487,16 +487,16 @@ const calculateAcbsUkefExposure = (payload) => {
  * @returns {object} Computed payload with EPOCH sm compatible `coverEndDate`.
  */
 const formatAmendmentDates = (payload) => {
-  const formatted = {
+  const formattedDates = {
     ...payload,
     effectiveDate: epochSecondsToMilliseconds(payload.effectiveDate),
   };
 
-  if (formatted?.coverEndDate) {
-    formatted.coverEndDate = epochSecondsToMilliseconds(formatted.coverEndDate);
+  if (payload?.coverEndDate) {
+    formattedDates.coverEndDate = epochSecondsToMilliseconds(payload.coverEndDate);
   }
 
-  return formatted;
+  return formattedDates;
 };
 
 module.exports = {

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
@@ -484,7 +484,7 @@ const calculateAcbsUkefExposure = (payload) => {
 /**
  * Converts non-ms epoch to ms epoch.
  * @param {object} payload Amendment payload
- * @returns {object} Computed payload with EPOCH sm compatible `coverEndDate`.
+ * @returns {object} Computed payload with EPOCH ms compatible `coverEndDate`.
  */
 const formatAmendmentDates = (payload) => {
   const formattedDates = {

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -998,7 +998,7 @@ describe('internalAmendmentEmail()', () => {
     const response = await internalAmendmentEmail('1234567890');
 
     // Assert
-    expect(response.status).toEqual(HttpStatusCode.BAD_REQUEST);
+    expect(response.response.status).toEqual(HttpStatusCode.BAD_REQUEST);
   });
 
   const sendEmailApiSpy = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_RESPONSE));

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -998,7 +998,7 @@ describe('internalAmendmentEmail()', () => {
     const response = await internalAmendmentEmail('1234567890');
 
     // Assert
-    expect(response.response.status).toEqual(HttpStatusCode.BAD_REQUEST);
+    expect(response.status).toEqual(HttpStatusCode.BAD_REQUEST);
   });
 
   const sendEmailApiSpy = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_RESPONSE));

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -1,3 +1,4 @@
+const { HttpStatusCode } = require('axios');
 const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/change-stream');
 const { CURRENCY, FACILITY_TYPE, AMENDMENT_BANK_DECISION, formattedNumber, getGBPValue } = require('@ukef/dtfs2-common');
 const api = require('../api');
@@ -988,7 +989,7 @@ describe('addLatestAmendmentValue()', () => {
  * test cases.
  */
 describe('internalAmendmentEmail()', () => {
-  it('should expect 400 on a bad request', async () => {
+  it(`should expect ${HttpStatusCode.BAD_REQUEST} on a bad request`, async () => {
     // Arrange
     const sendEmailApiSpyBadResponse = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_BAD_RESPONSE));
     api.sendEmail = sendEmailApiSpyBadResponse;
@@ -997,7 +998,7 @@ describe('internalAmendmentEmail()', () => {
     const response = await internalAmendmentEmail('1234567890');
 
     // Assert
-    expect(response.response.status).toEqual(400);
+    expect(response.response.status).toEqual(HttpStatusCode.BAD_REQUEST);
   });
 
   const sendEmailApiSpy = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_RESPONSE));
@@ -1015,7 +1016,7 @@ describe('internalAmendmentEmail()', () => {
     expect(response).toEqual(false);
   });
 
-  it('should return expect object on a correct UKEF Facility ID', async () => {
+  it('should return an object for a valid UKEF Facility ID', async () => {
     // Act
     const response = await internalAmendmentEmail('1234567890');
 

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -989,7 +989,7 @@ describe('addLatestAmendmentValue()', () => {
  * test cases.
  */
 describe('internalAmendmentEmail()', () => {
-  it(`should expect ${HttpStatusCode.BAD_REQUEST} on a bad request`, async () => {
+  it(`should expect ${HttpStatusCode.BadRequest} on a bad request`, async () => {
     // Arrange
     const sendEmailApiSpyBadResponse = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_BAD_RESPONSE));
     api.sendEmail = sendEmailApiSpyBadResponse;
@@ -998,7 +998,7 @@ describe('internalAmendmentEmail()', () => {
     const response = await internalAmendmentEmail('1234567890');
 
     // Assert
-    expect(response.response.status).toEqual(HttpStatusCode.BAD_REQUEST);
+    expect(response.response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   const sendEmailApiSpy = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_RESPONSE));

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -930,17 +930,22 @@ describe('addLatestAmendmentValue()', () => {
   };
 
   it('should return empty object when no latestValue', async () => {
+    // Act
     const response = await addLatestAmendmentValue({}, {}, '1234');
 
+    // Assert
     expect(response).toEqual({});
   });
 
   it('should return object with null for exposure when no API responses', async () => {
+    // Arrange
     api.getAmendmentById = () => Promise.resolve({});
     api.findOneFacility = () => Promise.resolve({});
 
+    // Act
     const response = await addLatestAmendmentValue({}, valueResponse, '1234');
 
+    // Assert
     const expected = {
       exposure: null,
       value: {
@@ -948,15 +953,19 @@ describe('addLatestAmendmentValue()', () => {
         value: 5000,
       },
     };
+
     expect(response).toEqual(expected);
   });
 
   it('should return fully populated object with null when API responses and all correct parameters', async () => {
+    // Arrange
     api.getAmendmentById = () => Promise.resolve(mockAmendment);
     api.findOneFacility = () => Promise.resolve(mockFacility);
 
+    // Act
     const response = await addLatestAmendmentValue({}, valueResponse, '1234');
 
+    // Assert
     const expected = {
       exposure: {
         exposure: '600.00',
@@ -968,6 +977,7 @@ describe('addLatestAmendmentValue()', () => {
         value: 5000,
       },
     };
+
     expect(response).toEqual(expected);
   });
 });
@@ -978,11 +988,15 @@ describe('addLatestAmendmentValue()', () => {
  * test cases.
  */
 describe('internalAmendmentEmail()', () => {
-  it('Should expect 400 on a bad request', async () => {
+  it('should expect 400 on a bad request', async () => {
+    // Arrange
     const sendEmailApiSpyBadResponse = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_BAD_RESPONSE));
     api.sendEmail = sendEmailApiSpyBadResponse;
 
+    // Act
     const response = await internalAmendmentEmail('1234567890');
+
+    // Assert
     expect(response.response.status).toEqual(400);
   });
 
@@ -993,19 +1007,27 @@ describe('internalAmendmentEmail()', () => {
     api.sendEmail = sendEmailApiSpy;
   });
 
-  it('Should return false void UKEF Facility ID', async () => {
+  it('should return false void UKEF Facility ID', async () => {
+    // Act
     const response = await internalAmendmentEmail('');
+
+    // Assert
     expect(response).toEqual(false);
   });
 
-  it('Should return expect object on a correct UKEF Facility ID', async () => {
+  it('should return expect object on a correct UKEF Facility ID', async () => {
+    // Act
     const response = await internalAmendmentEmail('1234567890');
+
+    // Assert
     expect(response).toEqual(expect.any(Object));
   });
 
-  it('Should call the expected function with expected arguments set', async () => {
+  it('should call the expected function with expected arguments set', async () => {
+    // Act
     await internalAmendmentEmail('1234567890');
 
+    // Assert
     expect(sendEmailApiSpy).toHaveBeenCalledWith(CONSTANTS.EMAIL_TEMPLATE_IDS.INTERNAL_AMENDMENT_NOTIFICATION, process.env.UKEF_INTERNAL_NOTIFICATION, {
       ukefFacilityId: '1234567890',
     });

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -1007,7 +1007,7 @@ describe('internalAmendmentEmail()', () => {
     api.sendEmail = sendEmailApiSpy;
   });
 
-  it('should return false void UKEF Facility ID', async () => {
+  it('should return false for empty UKEF Facility ID', async () => {
     // Act
     const response = await internalAmendmentEmail('');
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
@@ -47,7 +47,7 @@ describe('getAmendmentFields', () => {
     expect(result.coverEndDate).toEqual(expected);
   });
 
-  describe('when tfm.coverEndDate is not provided', () => {
+  describe('when coverEndDate is not provided', () => {
     it('should return coverEndDate as an empty string', () => {
       // Arrange
       const amendment: TfmFacilityAmendmentData = mockBaseAmendment;

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
@@ -14,9 +14,7 @@ describe('getAmendmentFields', () => {
     // Arrange
     const amendment: TfmFacilityAmendmentData = {
       ...mockBaseAmendment,
-      tfm: {
-        coverEndDate: 1706745600000,
-      },
+      coverEndDate: 1706745600000,
     };
 
     // Act
@@ -26,7 +24,7 @@ describe('getAmendmentFields', () => {
     const expected = {
       newAmount: amendment.value,
       previousAmount: amendment.currentValue,
-      coverEndDate: getFormattedDateStringInTimeZone(Number(amendment?.tfm?.coverEndDate), TIMEZONE.DEFAULT),
+      coverEndDate: getFormattedDateStringInTimeZone(Number(amendment.coverEndDate), TIMEZONE.DEFAULT),
       effectiveDate: getFormattedUTCDateString(Number(amendment.effectiveDate)),
     };
 
@@ -37,9 +35,7 @@ describe('getAmendmentFields', () => {
     // Arrange
     const amendment: TfmFacilityAmendmentData = {
       ...mockBaseAmendment,
-      tfm: {
-        coverEndDate: new Date('2028-06-21T00:00:00+01:00').getTime(),
-      },
+      coverEndDate: new Date('2028-06-21T00:00:00+01:00').getTime(),
     };
 
     // Act
@@ -54,10 +50,7 @@ describe('getAmendmentFields', () => {
   describe('when tfm.coverEndDate is not provided', () => {
     it('should return coverEndDate as an empty string', () => {
       // Arrange
-      const amendment: TfmFacilityAmendmentData = {
-        ...mockBaseAmendment,
-        tfm: {},
-      };
+      const amendment: TfmFacilityAmendmentData = mockBaseAmendment;
 
       // Act
       const result = getAmendmentFields(amendment);
@@ -164,9 +157,7 @@ describe('getAmendmentFields', () => {
       // Arrange
       const amendment: TfmFacilityAmendmentData = {
         ...mockBaseAmendment,
-        tfm: {
-          coverEndDate: null as unknown as number,
-        },
+        coverEndDate: null,
       };
 
       // Act

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
@@ -17,9 +17,9 @@ export const getAmendmentFields = (amendment: TfmFacilityAmendmentData): Amendme
   const newAmount = typeof amendment.value === 'number' ? amendment.value : Number.NaN;
   const previousAmount = typeof amendment.currentValue === 'number' ? amendment.currentValue : Number.NaN;
 
-  const hasCoverEndDate = amendment?.tfm?.coverEndDate !== undefined && amendment.tfm.coverEndDate !== null;
+  const hasCoverEndDate = amendment?.coverEndDate !== undefined && amendment.coverEndDate !== null;
 
-  const coverEndDateValue = Number(amendment.tfm?.coverEndDate);
+  const coverEndDateValue = Number(amendment.coverEndDate);
 
   const coverEndDate = hasCoverEndDate ? getFormattedDateStringInTimeZone(coverEndDateValue, TIMEZONE.DEFAULT) : '';
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
@@ -10,9 +10,8 @@ const mockAmendmentBase: TfmFacilityAmendmentData = {
   currentValue: 100,
   value: 130,
   effectiveDate: 1704067200,
-  tfm: {
-    coverEndDate: 1706745600000,
-  },
+  coverEndDate: 1706745600000,
+  tfm: {},
 };
 
 describe('amendFacility', () => {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
@@ -16,6 +16,7 @@ const {
  */
 export const amendFacility = (amendment: TfmFacilityAmendmentData): ApimGiftFacilityAmendmentPayload[] => {
   const { previousAmount, newAmount, coverEndDate, effectiveDate } = getAmendmentFields(amendment);
+
   const { changeFacilityValue, changeCoverEndDate } = amendment;
 
   const amountDifference = getAmountDifference(previousAmount, newAmount);


### PR DESCRIPTION
# Introduction :pencil2:

The DTFS payload with `expiryDate` was not being populated when sent to APIM.

According to existing ACBS amendment payload construction, we should use `amendment.coverEndDate` instead of `amendment.tfm.coverEndDate`

## Resolution :heavy_check_mark:

- Update mapping.

## Miscellaneous :heavy_plus_sign:

- Minor readability improvements.
- Add some missing Arrange/Act/Assert's

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
