### PR TITLE
fix(DTFS2-8527-8529): amend a gift facility - submittedByPim check

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/amendments/update-facility-amendment-apim-gift.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/amendments/update-facility-amendment-apim-gift.api-test.js
@@ -96,6 +96,7 @@ describe('PUT /v1/facilities/:facilityId/amendments/:amendmentId - APIM GIFT int
       const { status } = await as()
         .put({
           status: TFM_AMENDMENT_STATUS.COMPLETED,
+          submittedByPim: true,
         })
         .to(url);
 
@@ -145,6 +146,7 @@ describe('PUT /v1/facilities/:facilityId/amendments/:amendmentId - APIM GIFT int
       const { status, body } = await as()
         .put({
           status: TFM_AMENDMENT_STATUS.COMPLETED,
+          submittedByPim: true,
         })
         .to(url);
 

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -295,6 +295,7 @@ describe('updated facility amendment API call', () => {
       describe('when APIM/GIFT submission is allowed', () => {
         const updateAmendmentBody = {
           status: TFM_AMENDMENT_STATUS.COMPLETED,
+          submittedByPim: true,
         };
 
         beforeEach(() => {
@@ -349,11 +350,30 @@ describe('updated facility amendment API call', () => {
           // Arrange
           const updateAmendmentBody = {
             status: TFM_AMENDMENT_STATUS.COMPLETED,
+            submittedByPim: true,
           };
 
           const { req } = createMocks({ params: { amendmentId, facilityId }, user: underwriter, body: updateAmendmentBody });
 
           mockIsTfmApimGiftIntegrationEnabled.mockReturnValue(false);
+
+          // Act
+          await amendmentController.updateFacilityAmendment(req, res);
+
+          // Assert
+          expect(submitFacilityAmendmentsToApimGift).not.toHaveBeenCalled();
+          expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+        });
+
+        it(`should not call APIM GIFT when submittedByPim is not set`, async () => {
+          // Arrange - intermediate 'Continue' step, no submittedByPim
+          const updateAmendmentBody = {
+            status: TFM_AMENDMENT_STATUS.COMPLETED,
+          };
+
+          const { req } = createMocks({ params: { amendmentId, facilityId }, user: underwriter, body: updateAmendmentBody });
+
+          mockIsTfmApimGiftIntegrationEnabled.mockReturnValue(true);
 
           // Act
           await amendmentController.updateFacilityAmendment(req, res);

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -365,22 +365,24 @@ describe('updated facility amendment API call', () => {
           expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
         });
 
-        it(`should not call APIM GIFT when submittedByPim is not set`, async () => {
-          // Arrange - intermediate 'Continue' step, no submittedByPim
-          const updateAmendmentBody = {
-            status: TFM_AMENDMENT_STATUS.COMPLETED,
-          };
+        describe('when submittedByPim is not set', () => {
+          it(`should not call APIM GIFT`, async () => {
+            // Arrange
+            const updateAmendmentBody = {
+              status: TFM_AMENDMENT_STATUS.COMPLETED,
+            };
 
-          const { req } = createMocks({ params: { amendmentId, facilityId }, user: underwriter, body: updateAmendmentBody });
+            const { req } = createMocks({ params: { amendmentId, facilityId }, user: underwriter, body: updateAmendmentBody });
 
-          mockIsTfmApimGiftIntegrationEnabled.mockReturnValue(true);
+            mockIsTfmApimGiftIntegrationEnabled.mockReturnValue(true);
 
-          // Act
-          await amendmentController.updateFacilityAmendment(req, res);
+            // Act
+            await amendmentController.updateFacilityAmendment(req, res);
 
-          // Assert
-          expect(submitFacilityAmendmentsToApimGift).not.toHaveBeenCalled();
-          expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+            // Assert
+            expect(submitFacilityAmendmentsToApimGift).not.toHaveBeenCalled();
+            expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+          });
         });
       });
     });

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -365,7 +365,7 @@ describe('updated facility amendment API call', () => {
           expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
         });
 
-        describe('when submittedByPim is not set', () => {
+        describe('when submittedByPim is not set and APIM/GIFT submission is allowed', () => {
           it(`should not call APIM GIFT`, async () => {
             // Arrange
             const updateAmendmentBody = {

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -331,7 +331,7 @@ const updateFacilityAmendment = async (req, res) => {
     if (amendmentId && facilityId && payload) {
       let amendment = await api.getAmendmentById(facilityId, amendmentId);
 
-      if (payload.createTasks && payload.submittedByPim) {
+      if (payload.createTasks && isSubmittedByPim) {
         const { tfm } = await api.findOneFacility(facilityId);
 
         payload.tasks = createAmendmentTasks(payload.requireUkefApproval, tfm);

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -315,6 +315,14 @@ const updateFacilityAmendment = async (req, res) => {
   // set to true if payload contains updateTfmLastUpdated else null
   const tfmLastUpdated = payload.updateTfmLastUpdated;
 
+  /**
+   * Only send to APIM/GIFT when the user submits the final check-answers page.
+   * All intermediate 'Continue' steps also call updateFacilityAmendment, so using
+   * submittedByPim as the discriminator prevents repeated APIM calls during the flow.
+   * This flag is also used in the ACBS canSendToAcbs checks.
+   */
+  const isSubmittedByPim = payload.submittedByPim === true;
+
   // default isTaskUpdate to false, set to true if payload contains taskUpdate.updateTask
   let isTaskUpdate = false;
 
@@ -413,7 +421,7 @@ const updateFacilityAmendment = async (req, res) => {
         // Amend facility TFM properties
         await amendIssuedFacility(amendment, facility, tfmDeal, generateTfmAuditDetails(req.user._id));
 
-        if (isTfmApimGiftIntegrationEnabled() && !isTaskUpdate) {
+        if (isTfmApimGiftIntegrationEnabled() && !isTaskUpdate && isSubmittedByPim) {
           console.info('TFM facility %s updateFacilityAmendment - calling canSendAmendmentsToApimGift', facilityId);
 
           const { canSendAmendmentsToApimGift: canSendToApimGift, amendmentPayloads } = canSendAmendmentsToApimGift(amendment);

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -321,7 +321,7 @@ const updateFacilityAmendment = async (req, res) => {
    * submittedByPim as the discriminator prevents repeated APIM calls during the flow.
    * This flag is also used in the ACBS canSendToAcbs checks.
    */
-  const isSubmittedByPim = payload.submittedByPim === true;
+  const isSubmittedByPim = payload?.submittedByPim === true;
 
   // default isTaskUpdate to false, set to true if payload contains taskUpdate.updateTask
   let isTaskUpdate = false;


### PR DESCRIPTION
# Introduction :pencil2:

Facility amendments were being sent to APIM/GIFT multiple times.

Adding a `submittedByPim` check should fix the issue.

## Resolution :heavy_check_mark:

- Add `submittedByPim` to amendments condition.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
