### PR TITLE
chore(DTFS2-8365): remove risk rating api call from APIM mapping and save credit risk as rating only

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk-risk-managers.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk-risk-managers.spec.js
@@ -1,3 +1,4 @@
+import { CREDIT_RATING } from '@ukef/dtfs2-common';
 import relative from '../../relativeURL';
 import pages from '../../pages';
 import MOCK_DEAL_MIA from '../../../fixtures/deal-MIA';
@@ -49,12 +50,12 @@ context('Case Underwriting - Pricing and risk for Risk Managers', () => {
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Change');
 
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), 'Good (BB-)');
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RATING.BB_MINUS);
     });
 
     it('after submitting a rating, editing the rating has default value and new rating displays in `pricing and risk` page', () => {
       // check value previously submitted
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), 'Good (BB-)');
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RATING.BB_MINUS);
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
@@ -68,7 +69,7 @@ context('Case Underwriting - Pricing and risk for Risk Managers', () => {
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
 
       // check new value displays in `pricing and risk` page
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), 'Acceptable (B+)');
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RATING.B_PLUS);
     });
   });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk.spec.js
@@ -1,3 +1,4 @@
+import { CREDIT_RATING } from '@ukef/dtfs2-common';
 import relative from '../../relativeURL';
 import { errorSummaryItems, caseSubNavigation } from '../../partials';
 import pages from '../../pages';
@@ -6,10 +7,9 @@ import { UNDERWRITING_SUPPORT_1, UNDERWRITER_1, BANK1_MAKER1, ADMIN } from '../.
 import { assertAutocompleteInput } from '../../common-tests/assertAutocompleteInput';
 
 const CREDIT_RISK_RATINGS = {
+  ...CREDIT_RATING,
   A: 'A',
-  B_PLUS: 'B+',
   BBB_PLUS: 'BBB+',
-  BB_MINUS: 'B-',
   INVALID: 'Z',
 };
 
@@ -139,12 +139,12 @@ context('Case Underwriting - Pricing and risk', () => {
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Change');
 
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), 'Good (BB-)');
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.BB_MINUS);
     });
 
     it('after submitting a rating, editing the rating has default value and new rating displays in `pricing and risk` page', () => {
       // check value previously submitted
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), 'Good (BB-)');
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.BB_MINUS);
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
@@ -158,7 +158,7 @@ context('Case Underwriting - Pricing and risk', () => {
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
 
       // check new value displays in `pricing and risk` page
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), 'Acceptable (B+)');
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.B_PLUS);
     });
 
     it('submitting `Other` in edit form displays text input and auto populates values after submit', () => {
@@ -167,19 +167,19 @@ context('Case Underwriting - Pricing and risk', () => {
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
       autoCompleteField.input().should('have.value', '');
 
-      cy.keyboardInput(autoCompleteField.input(), CREDIT_RISK_RATINGS.B_PLUS);
-      autoCompleteField.selectOption(CREDIT_RISK_RATINGS.B_PLUS).click();
+      cy.keyboardInput(autoCompleteField.input(), CREDIT_RISK_RATINGS.BBB_PLUS);
+      autoCompleteField.selectOption(CREDIT_RISK_RATINGS.BBB_PLUS).click();
       cy.clickSubmitButton();
 
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.B_PLUS);
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.BBB_PLUS);
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().should('be.checked');
       autoCompleteField.input().should('exist');
 
-      cy.assertText(autoCompleteField.results(), CREDIT_RISK_RATINGS.B_PLUS);
-      cy.assertValue(autoCompleteField, CREDIT_RISK_RATINGS.B_PLUS);
+      cy.assertText(autoCompleteField.results(), CREDIT_RISK_RATINGS.BBB_PLUS);
+      cy.assertValue(autoCompleteField, CREDIT_RISK_RATINGS.BBB_PLUS);
     });
 
     it('should use last submitted other value if revisiting the edit form and clearing the other input', () => {
@@ -187,8 +187,8 @@ context('Case Underwriting - Pricing and risk', () => {
 
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
 
-      cy.keyboardInput(autoCompleteField.input(), CREDIT_RISK_RATINGS.B_PLUS);
-      autoCompleteField.selectOption(CREDIT_RISK_RATINGS.B_PLUS).click();
+      cy.keyboardInput(autoCompleteField.input(), CREDIT_RISK_RATINGS.BBB_PLUS);
+      autoCompleteField.selectOption(CREDIT_RISK_RATINGS.BBB_PLUS).click();
       cy.clickSubmitButton();
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
@@ -197,12 +197,32 @@ context('Case Underwriting - Pricing and risk', () => {
       autoCompleteField.input().clear();
       cy.clickSubmitButton();
 
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.B_PLUS);
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.BBB_PLUS);
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
-      cy.assertText(autoCompleteField.results(), CREDIT_RISK_RATINGS.B_PLUS);
-      cy.assertValue(autoCompleteField, CREDIT_RISK_RATINGS.B_PLUS);
+      cy.assertText(autoCompleteField.results(), CREDIT_RISK_RATINGS.BBB_PLUS);
+      cy.assertValue(autoCompleteField, CREDIT_RISK_RATINGS.BBB_PLUS);
+    });
+
+    it(`should select the radio when coming back to the page after submitting ${CREDIT_RATING.B_PLUS} or ${CREDIT_RATING.BB_MINUS} in the other autocomplete`, () => {
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
+
+      cy.keyboardInput(autoCompleteField.input(), CREDIT_RISK_RATINGS.B_PLUS);
+      autoCompleteField.selectOption(CREDIT_RISK_RATINGS.B_PLUS).click();
+      cy.clickSubmitButton();
+
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputAcceptable().should('be.checked');
+
+      pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
+
+      cy.keyboardInput(autoCompleteField.input(), CREDIT_RISK_RATINGS.BB_MINUS);
+      autoCompleteField.selectOption(CREDIT_RISK_RATINGS.BB_MINUS).click();
+      cy.clickSubmitButton();
+
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputGood().should('be.checked');
     });
 
     describe('credit rating `Other` autocomplete page tests', () => {
@@ -232,7 +252,7 @@ context('Case Underwriting - Pricing and risk', () => {
 
     it('cannot add or edit a credit rating', () => {
       // double check that a credit rating already exists from previous tests
-      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.B_PLUS);
+      cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), CREDIT_RISK_RATINGS.BB_MINUS);
 
       pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('not.exist');
       pages.underwritingPricingAndRiskPage.exporterTableChangeProbabilityOfDefaultLink().should('not.exist');

--- a/libs/common/src/constants/tfm/credit-ratings.ts
+++ b/libs/common/src/constants/tfm/credit-ratings.ts
@@ -1,0 +1,8 @@
+/**
+ * TFM credit ratings that do not directly match APIM MDM credit risk ratings, and their mapped APIM MDM credit risk rating value.
+ * This is required to map TFM's exporter credit rating to the expected APIM MDM credit risk rating value for the facility credit rating to be sent to GIFT.
+ */
+export const TFM_CREDIT_RATING_MAP = {
+  'Good (BB-)': 'BB-',
+  'Acceptable (B+)': 'B+',
+};

--- a/libs/common/src/constants/tfm/credit-ratings.ts
+++ b/libs/common/src/constants/tfm/credit-ratings.ts
@@ -1,8 +1,0 @@
-/**
- * TFM credit ratings that do not directly match APIM MDM credit risk ratings, and their mapped APIM MDM credit risk rating value.
- * This is required to map TFM's exporter credit rating to the expected APIM MDM credit risk rating value for the facility credit rating to be sent to GIFT.
- */
-export const TFM_CREDIT_RATING_MAP = {
-  'Good (BB-)': 'BB-',
-  'Acceptable (B+)': 'B+',
-};

--- a/libs/common/src/constants/tfm/credit-ratings.ts
+++ b/libs/common/src/constants/tfm/credit-ratings.ts
@@ -7,12 +7,12 @@ export const TFM_CREDIT_RATING_MAP = {
   'Acceptable (B+)': 'B+',
 };
 
-export const EXPORTER_CREDIT_RATING_FULL = {
+export const CREDIT_RATING_TFM = {
   B_PLUS: 'Acceptable (B+)',
   BB_MINUS: 'Good (BB-)',
 };
 
-export const EXPORTER_CREDIT_RATING_SHORT = {
+export const CREDIT_RATING = {
   B_PLUS: 'B+',
   BB_MINUS: 'BB-',
 };

--- a/libs/common/src/constants/tfm/credit-ratings.ts
+++ b/libs/common/src/constants/tfm/credit-ratings.ts
@@ -1,0 +1,18 @@
+/**
+ * TFM credit ratings that do not directly match APIM MDM credit risk ratings, and their mapped APIM MDM credit risk rating value.
+ * This is required to map TFM's exporter credit rating to the expected APIM MDM credit risk rating value for the facility credit rating to be sent to GIFT.
+ */
+export const TFM_CREDIT_RATING_MAP = {
+  'Good (BB-)': 'BB-',
+  'Acceptable (B+)': 'B+',
+};
+
+export const EXPORTER_CREDIT_RATING_FULL = {
+  B_PLUS: 'Acceptable (B+)',
+  BB_MINUS: 'Good (BB-)',
+};
+
+export const EXPORTER_CREDIT_RATING_SHORT = {
+  B_PLUS: 'B+',
+  BB_MINUS: 'BB-',
+};

--- a/libs/common/src/constants/tfm/index.ts
+++ b/libs/common/src/constants/tfm/index.ts
@@ -8,3 +8,4 @@ export * from './comment-type';
 export * from './underwriter-manager-decisions';
 export * from './user-status';
 export * from './sso';
+export * from './credit-ratings';

--- a/libs/common/src/constants/tfm/index.ts
+++ b/libs/common/src/constants/tfm/index.ts
@@ -8,4 +8,3 @@ export * from './comment-type';
 export * from './underwriter-manager-decisions';
 export * from './user-status';
 export * from './sso';
-export * from './credit-ratings';

--- a/trade-finance-manager-api/server/v1/__mocks__/mock-credit-risk-ratings.ts
+++ b/trade-finance-manager-api/server/v1/__mocks__/mock-credit-risk-ratings.ts
@@ -20,5 +20,3 @@ export const MOCK_CREDIT_RISK_RATINGS: CreditRiskRating[] = [
     effectiveTo: '9999-12-31T00:00:00.000Z',
   },
 ];
-
-export const MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS: string[] = MOCK_CREDIT_RISK_RATINGS.map((rating) => rating.description);

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/get-reference-data/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/get-reference-data/index.test.ts
@@ -1,8 +1,6 @@
 import { DEAL_TYPE } from '@ukef/dtfs2-common';
 import api from '../../../../api';
 import { getReferenceData } from '.';
-import { mapApimCreditRiskRatings } from '../../../../mappings/map-apim-credit-risk-ratings';
-import { MOCK_CREDIT_RISK_RATINGS } from '../../../../__mocks__/mock-credit-risk-ratings';
 import { MOCK_FACILITY_CATEGORIES } from '../../../../__mocks__/mock-facility-categories';
 
 jest.mock('../../../../api');
@@ -10,7 +8,6 @@ jest.mock('../../../../api');
 describe('getReferenceData', () => {
   const mockApi = jest.mocked(api) as jest.Mocked<typeof api>;
 
-  let getCreditRiskRatingsSpy = jest.fn();
   let getFacilityCategoriesSpy = jest.fn();
 
   // Arrange
@@ -19,20 +16,8 @@ describe('getReferenceData', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    // Arrange
-    getCreditRiskRatingsSpy = jest.fn().mockResolvedValueOnce(MOCK_CREDIT_RISK_RATINGS);
-    mockApi.getCreditRiskRatings = getCreditRiskRatingsSpy;
-
     getFacilityCategoriesSpy = jest.fn().mockResolvedValueOnce(MOCK_FACILITY_CATEGORIES);
     mockApi.getFacilityCategories = getFacilityCategoriesSpy;
-  });
-
-  it('should call api.getCreditRiskRatings', async () => {
-    // Act
-    await getReferenceData(isGefDeal);
-
-    // Assert
-    expect(getCreditRiskRatingsSpy).toHaveBeenCalledTimes(1);
   });
 
   describe(`when the deal is a ${DEAL_TYPE.GEF} deal`, () => {
@@ -58,69 +43,6 @@ describe('getReferenceData', () => {
     });
   });
 
-  it('should return creditRiskRatings and facilityCategories', async () => {
-    // Act
-    const result = await getReferenceData(isGefDeal);
-
-    // Assert
-    const expected = {
-      creditRiskRatings: mapApimCreditRiskRatings(MOCK_CREDIT_RISK_RATINGS),
-      facilityCategories: MOCK_FACILITY_CATEGORIES,
-    };
-
-    expect(result).toEqual(expected);
-  });
-
-  describe('when api.getCreditRiskRatings throws an error', () => {
-    beforeEach(() => {
-      // Arrange
-      mockApi.getCreditRiskRatings = jest.fn().mockRejectedValueOnce(new Error());
-    });
-
-    it('should NOT propagate the error', async () => {
-      // Act & Assert
-      await expect(getReferenceData(isGefDeal)).resolves.not.toThrow();
-    });
-
-    it('should return with creditRiskRatings as an empty array', async () => {
-      // Act
-      const result = await getReferenceData(isGefDeal);
-
-      // Assert
-      const expected = {
-        creditRiskRatings: [],
-        facilityCategories: MOCK_FACILITY_CATEGORIES,
-      };
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when api.getCreditRiskRatings returns false (API error without throw)', () => {
-    beforeEach(() => {
-      // Arrange
-      mockApi.getCreditRiskRatings = jest.fn().mockResolvedValueOnce(false);
-    });
-
-    it('should NOT propagate the error', async () => {
-      // Act & Assert
-      await expect(getReferenceData(isGefDeal)).resolves.not.toThrow();
-    });
-
-    it('should return with creditRiskRatings as an empty array', async () => {
-      // Act
-      const result = await getReferenceData(isGefDeal);
-
-      // Assert
-      const expected = {
-        creditRiskRatings: [],
-        facilityCategories: MOCK_FACILITY_CATEGORIES,
-      };
-
-      expect(result).toEqual(expected);
-    });
-  });
-
   describe('when api.getFacilityCategories throws an error', () => {
     beforeEach(() => {
       // Arrange
@@ -138,7 +60,6 @@ describe('getReferenceData', () => {
 
       // Assert
       const expected = {
-        creditRiskRatings: mapApimCreditRiskRatings(MOCK_CREDIT_RISK_RATINGS),
         facilityCategories: [],
       };
 
@@ -163,7 +84,6 @@ describe('getReferenceData', () => {
 
       // Assert
       const expected = {
-        creditRiskRatings: mapApimCreditRiskRatings(MOCK_CREDIT_RISK_RATINGS),
         facilityCategories: [],
       };
 

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/get-reference-data/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/get-reference-data/index.ts
@@ -9,18 +9,17 @@ type GetReferenceDataResult = {
 /**
  * Get reference data from APIM MDD.
  * This is required to map APIM GIFT payloads, including:
- * - "Credit risk ratings"
  * - "Facility categories" (only for GEF deals, not required for BSS/EWCS deals)
  * @param {boolean} isGefDeal - A boolean indicating whether the deal is a GEF deal
  * @returns {Promise<GetReferenceDataResult>} Reference data
  *
  * NOTE: if the API call to get reference data from APIM MDM fails, we do NOT want to throw an error.
- * Instead, continue with an empty array of credit risk ratings and facility categories, which could result in the facility credit rating and category not being mapped.
+ * Instead, continue with an empty array of facility categories, which could result in the category not being mapped.
  * But at least the facility can still be created in GIFT and the issue can be investigated separately.
- * If the credit risk rating or facility category mapping fails, the facility credit rating and category will simply not be sent to GIFT, which is preferable to the entire facility creation failing.
+ * If the facility category mapping fails, the category will simply not be sent to GIFT, which is preferable to the entire facility creation failing.
  * Ultimately, this will trigger an alert in APIM for the failed API call, which can be investigated by the team.
- * The alternative of this would be to have retry logic in DTFS, but given the low likelihood of the API call failing and the fact that the credit risk rating and facility category mapping can be "best effort", this is not necessary.
- * Note that this is an edge case scenario as 99% of credit risk ratings are in TFM_CREDIT_RATING_MAP and do not require the API call to map the facility credit rating, and most facility categories are in TFM_FACILITY_CATEGORY_MAP and do not require the API call to map the facility category.
+ * The alternative of this would be to have retry logic in DTFS, but given the low likelihood of the API call failing and the fact that the facility category mapping can be "best effort", this is not necessary.
+ * Note that this is an edge case scenario as most facility categories are in TFM_FACILITY_CATEGORY_MAP and do not require the API call to map the facility category.
  */
 export const getReferenceData = async (isGefDeal: boolean): Promise<GetReferenceDataResult> => {
   const api = apiModule as ApiTypes;

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/get-reference-data/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/get-reference-data/index.ts
@@ -1,11 +1,8 @@
-import { CreditRiskRating } from '@ukef/dtfs2-common';
 import apiModule from '../../../../api';
-import { mapApimCreditRiskRatings } from '../../../../mappings/map-apim-credit-risk-ratings';
 import type { FacilityCategory } from '../../../../api-response-types';
 import { ApiTypes } from '../../../../mappings/apim-gift-payloads/types';
 
 type GetReferenceDataResult = {
-  creditRiskRatings: string[];
   facilityCategories: FacilityCategory[];
 };
 
@@ -28,17 +25,6 @@ type GetReferenceDataResult = {
 export const getReferenceData = async (isGefDeal: boolean): Promise<GetReferenceDataResult> => {
   const api = apiModule as ApiTypes;
 
-  let creditRiskRatingsResponse: CreditRiskRating[] = [];
-
-  try {
-    const response = await api.getCreditRiskRatings();
-
-    creditRiskRatingsResponse = Array.isArray(response) ? response : [];
-  } catch {
-    // Swallow errors and default creditRiskRatingsResponse to an empty array
-    creditRiskRatingsResponse = [];
-  }
-
   let facilityCategoriesResponse: FacilityCategory[] = [];
 
   if (isGefDeal) {
@@ -52,10 +38,7 @@ export const getReferenceData = async (isGefDeal: boolean): Promise<GetReference
     }
   }
 
-  const creditRiskRatings = mapApimCreditRiskRatings(creditRiskRatingsResponse);
-
   return {
-    creditRiskRatings,
     facilityCategories: facilityCategoriesResponse,
   };
 };

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/index.test.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/index.test.ts
@@ -5,7 +5,6 @@ import MOCK_TFM_DEAL_AIN_SUBMITTED from '../../../__mocks__/mock-TFM-deal-AIN-su
 import { MOCK_FACILITIES } from '../../../__mocks__/mock-facilities';
 import { APIM_GIFT_PAYLOADS } from '../../../mappings/apim-gift-payloads';
 import { ApimGiftFacilityCreationPayload } from '../../../mappings/apim-gift-payloads/types/apim-gift';
-import { MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS } from '../../../__mocks__/mock-credit-risk-ratings';
 import { MOCK_FACILITY_CATEGORIES } from '../../../__mocks__/mock-facility-categories';
 import { getReferenceData } from './get-reference-data';
 import { sendFacilitiesToApimGift } from '.';
@@ -57,7 +56,6 @@ describe('sendFacilitiesToApimGift', () => {
     beforeEach(() => {
       // Arrange
       getReferenceDataSpy.mockResolvedValue({
-        creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
         facilityCategories: MOCK_FACILITY_CATEGORIES,
       });
 
@@ -81,7 +79,6 @@ describe('sendFacilitiesToApimGift', () => {
         facility: mockFacility,
         isBssEwcsDeal: mockIsBssEwcsDeal,
         isGefDeal: mockIsGefDeal,
-        creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
         facilityCategories: MOCK_FACILITY_CATEGORIES,
       });
     });
@@ -155,7 +152,6 @@ describe('sendFacilitiesToApimGift', () => {
     beforeEach(() => {
       // Arrange
       getReferenceDataSpy.mockResolvedValue({
-        creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
         facilityCategories: MOCK_FACILITY_CATEGORIES,
       });
 
@@ -179,7 +175,6 @@ describe('sendFacilitiesToApimGift', () => {
         facilities: [mockFacility, mockFacilityTwo, mockFacilityThree],
         isBssEwcsDeal: mockIsBssEwcsDeal,
         isGefDeal: mockIsGefDeal,
-        creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
         facilityCategories: MOCK_FACILITY_CATEGORIES,
       });
     });

--- a/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/index.ts
+++ b/trade-finance-manager-api/server/v1/integrations/apim-gift/send-facilities-to-apim-gift/index.ts
@@ -33,7 +33,7 @@ export const sendFacilitiesToApimGift = async ({
 
   const api = apiModule as ApiTypes;
 
-  const { facilityCategories, creditRiskRatings } = await getReferenceData(isGefDeal);
+  const { facilityCategories } = await getReferenceData(isGefDeal);
 
   if (facilities.length === 1) {
     const payload = await APIM_GIFT_PAYLOADS.createFacility({
@@ -42,7 +42,6 @@ export const sendFacilitiesToApimGift = async ({
       isBssEwcsDeal,
       isGefDeal,
       facilityCategories,
-      creditRiskRatings,
     });
 
     const response = await api.createGiftFacility(payload);
@@ -56,7 +55,6 @@ export const sendFacilitiesToApimGift = async ({
     isBssEwcsDeal,
     isGefDeal,
     facilityCategories,
-    creditRiskRatings,
   });
 
   const responses: Array<TfmFacility | false> = [];

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/constants.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/constants.ts
@@ -33,15 +33,6 @@ export const PRODUCT_TYPE_CODES_TO_DEAL_TYPE = {
 } as const satisfies Record<ProductTypeCode, string>;
 
 /**
- * TFM credit ratings that do not directly match APIM MDM credit risk ratings, and their mapped APIM MDM credit risk rating value.
- * This is required to map TFM's exporter credit rating to the expected APIM MDM credit risk rating value for the facility credit rating to be sent to GIFT.
- */
-export const TFM_CREDIT_RATING_MAP = {
-  'Good (BB-)': 'BB-',
-  'Acceptable (B+)': 'B+',
-};
-
-/**
  * Obligation amount calculations for GEF facilities, based on the APIM GIFT documentation:
  * - For Cash GEF facilities, the obligation amount is calculated as 85% of the Max UKEF exposure.
  * - For Contingent GEF facilities, the obligation amount is calculated as 70% of the Max UKEF exposure.

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facilities/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facilities/index.test.ts
@@ -1,5 +1,4 @@
 import { TfmDeal, TfmFacility } from '@ukef/dtfs2-common';
-import { MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS } from '../../../__mocks__/mock-credit-risk-ratings';
 import { MOCK_FACILITY_CATEGORIES } from '../../../__mocks__/mock-facility-categories';
 import * as createFacilityModule from '../create-facility';
 import { ApimGiftFacilityCreationPayload } from '../types';
@@ -25,7 +24,6 @@ const baseParams = {
   deal: mockDeal,
   isBssEwcsDeal: mockIsBssEwcsDeal,
   isGefDeal: mockIsGefDeal,
-  creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
   facilityCategories: MOCK_FACILITY_CATEGORIES,
 };
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facilities/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facilities/index.ts
@@ -8,7 +8,6 @@ type CreateFacilitiesParams = {
   facilities: TfmFacility[];
   isBssEwcsDeal: boolean;
   isGefDeal: boolean;
-  creditRiskRatings: string[];
   facilityCategories: FacilityCategory[];
 };
 
@@ -23,7 +22,6 @@ export const createFacilities = async ({
   facilities,
   isBssEwcsDeal,
   isGefDeal,
-  creditRiskRatings,
   facilityCategories,
 }: CreateFacilitiesParams): Promise<ApimGiftFacilityCreationPayload[]> => {
   const payloads = await Promise.all(
@@ -33,7 +31,6 @@ export const createFacilities = async ({
         facility,
         isBssEwcsDeal,
         isGefDeal,
-        creditRiskRatings,
         facilityCategories,
       }),
     ),

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
@@ -2,7 +2,6 @@ import { Facility, getTfmUkefDealId, TfmDeal, TfmFacility } from '@ukef/dtfs2-co
 import { ObjectId } from 'mongodb';
 import MOCK_TFM_DEAL_AIN_SUBMITTED from '../../../__mocks__/mock-TFM-deal-AIN-submitted';
 import { MOCK_FACILITIES } from '../../../__mocks__/mock-facilities';
-import { MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS } from '../../../__mocks__/mock-credit-risk-ratings';
 import { MOCK_FACILITY_CATEGORIES } from '../../../__mocks__/mock-facility-categories';
 import { APIM_GIFT_INTEGRATION } from '../constants';
 import { getDealTypeFlags } from './get-deal-type-flags';
@@ -62,7 +61,6 @@ describe('createFacility', () => {
     facility: mockFacility,
     isBssEwcsDeal,
     isGefDeal,
-    creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
     facilityCategories: MOCK_FACILITY_CATEGORIES,
   };
 
@@ -122,7 +120,6 @@ describe('createFacility', () => {
         ukefExposure: Number(tfm.ukefExposure),
       }),
       riskDetails: await mapRiskDetails({
-        creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
         dealId: getTfmUkefDealId(mockDeal),
         exporterCreditRating: mockDeal.tfm.exporterCreditRating,
         facilityType: facilitySnapshot.type,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
@@ -17,7 +17,6 @@ export type FacilityCreationParams = {
   facility: TfmFacility;
   isBssEwcsDeal: boolean;
   isGefDeal: boolean;
-  creditRiskRatings: string[];
   facilityCategories: FacilityCategory[];
 };
 
@@ -28,7 +27,6 @@ export type FacilityCreationParams = {
  * @param {TfmFacility} params.facility - The TFM facility data containing `facilitySnapshot` and `tfm` values.
  * @param {boolean} params.isBssEwcsDeal - A boolean indicating whether the deal is a BSS/EWCS deal, which determines how certain facility values are mapped.
  * @param {boolean} params.isGefDeal - A boolean indicating whether the deal is a GEF deal, which determines how certain facility values are mapped.
- * @param {string[]} params.creditRiskRatings - An array of credit risk rating descriptions from APIM, required for mapping the facility credit risk rating to the format expected by APIM.
  * @param {FacilityCategory[]} params.facilityCategories - An array of facility categories from APIM, required for mapping the facility category to the format expected by APIM.
  * @returns {Promise<ApimGiftFacilityCreationPayload>} The APIM "GIFT facility creation" payload.
  */
@@ -37,7 +35,6 @@ export const createFacility = async ({
   facility,
   isBssEwcsDeal,
   isGefDeal,
-  creditRiskRatings,
   facilityCategories,
 }: FacilityCreationParams): Promise<ApimGiftFacilityCreationPayload> => {
   const ukefFacilityId = String(facility?.facilitySnapshot?.ukefFacilityId);
@@ -130,7 +127,6 @@ export const createFacility = async ({
       ukefExposure: facilityAmount,
     }),
     riskDetails: await mapRiskDetails({
-      creditRiskRatings,
       dealId,
       exporterCreditRating,
       facilityCategories,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.test.ts
@@ -38,7 +38,6 @@ describe('mapRiskDetails', () => {
 
   const params = {
     dealId: '123',
-    creditRiskRatings: ['AAA', 'AA+', 'AA'],
     facilityCategories: mockFacilityCategories,
     facilityType: '',
     exporterCreditRating: 'AAA',
@@ -83,7 +82,7 @@ describe('mapRiskDetails', () => {
         facilityType: params.facilityType,
         isGefDeal: params.isGefDeal,
       }),
-      facilityCreditRating: mapFacilityCreditRating(params.creditRiskRatings, params.exporterCreditRating),
+      facilityCreditRating: mapFacilityCreditRating(params.exporterCreditRating),
       riskStatus: DEFAULTS.RISK_DETAILS.RISK_STATUS,
       ukefIndustryCode: mockUkefIndustryCode,
     };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/index.ts
@@ -8,7 +8,6 @@ import { FacilityCategory, UkefIndustryCode } from '../../../../api-response-typ
 const { DEFAULTS } = APIM_GIFT_INTEGRATION;
 
 type MapRiskDetailsParams = {
-  creditRiskRatings: string[];
   dealId: string | null;
   exporterCreditRating: string;
   facilityType?: string;
@@ -20,7 +19,6 @@ type MapRiskDetailsParams = {
 /**
  * Map the facility "risk details".
  * @param {MapRiskDetailsParams} params - Data required to build the APIM GIFT "facility risk details" data.
- * @param {string[]} params.creditRiskRatings - The list of credit risk ratings. Required to map the facility credit rating to the APIM expected value.
  * @param {string | null} params.dealId - The TFM deal ID.
  * @param {string} params.exporterCreditRating - TFM's exporter's credit rating.
  * @param {string} [params.facilityType] - Optional facility type (e.g. "Bond", "Cash", "Contingent", "Loan"). Only required for GEF facilities.
@@ -29,7 +27,6 @@ type MapRiskDetailsParams = {
  * @returns {ApimGiftFacilityRiskDetails} The mapped risk details for the APIM GIFT payload.
  */
 export const mapRiskDetails = async ({
-  creditRiskRatings,
   dealId,
   exporterCreditRating,
   facilityType,
@@ -67,7 +64,7 @@ export const mapRiskDetails = async ({
       facilityType,
       isGefDeal,
     }),
-    facilityCreditRating: mapFacilityCreditRating(creditRiskRatings, exporterCreditRating),
+    facilityCreditRating: mapFacilityCreditRating(exporterCreditRating),
     riskStatus: DEFAULTS.RISK_DETAILS.RISK_STATUS,
     ukefIndustryCode,
   };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-credit-rating/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-credit-rating/index.test.ts
@@ -2,48 +2,45 @@ import { mapFacilityCreditRating } from '.';
 
 describe('mapFacilityCreditRating', () => {
   describe('when the exporter credit rating is in the TFM_CREDIT_RATING_MAP', () => {
-    it('should return the mapped credit rating', () => {
+    it('should return the mapped credit rating for BB-', () => {
       // Arrange
-      const mockCreditRiskRatings = ['BB-', 'B+'];
       const mockExporterCreditRating = 'Good (BB-)';
 
       // Act
-      const result = mapFacilityCreditRating(mockCreditRiskRatings, mockExporterCreditRating);
+      const result = mapFacilityCreditRating(mockExporterCreditRating);
 
       // Assert
       const expected = 'BB-';
 
       expect(result).toEqual(expected);
     });
-  });
 
-  describe('when the exporter credit rating is in the list of credit risk ratings', () => {
-    it('should return the mapped credit rating', () => {
+    it('should return the mapped credit rating for B+', () => {
       // Arrange
-      const mockCreditRiskRatings = ['AAA', 'AA+', 'AA'];
-      const mockExporterCreditRating = 'AAA';
+      const mockExporterCreditRating = 'Acceptable (B+)';
 
       // Act
-      const result = mapFacilityCreditRating(mockCreditRiskRatings, mockExporterCreditRating);
+      const result = mapFacilityCreditRating(mockExporterCreditRating);
 
       // Assert
-      const expected = 'AAA';
+      const expected = 'B+';
 
       expect(result).toEqual(expected);
     });
   });
 
-  describe('when the exporter credit rating is NOT in TFM_CREDIT_RATING_MAP or the list of credit risk ratings', () => {
-    it('should return null', () => {
+  describe('when the exporter credit rating is another credit rating', () => {
+    it('should return the mapped credit rating', () => {
       // Arrange
-      const mockCreditRiskRatings = ['AAA'];
-      const mockExporterCreditRating = 'CCC';
+      const mockExporterCreditRating = 'AAA';
 
       // Act
-      const result = mapFacilityCreditRating(mockCreditRiskRatings, mockExporterCreditRating);
+      const result = mapFacilityCreditRating(mockExporterCreditRating);
 
       // Assert
-      expect(result).toBeNull();
+      const expected = 'AAA';
+
+      expect(result).toEqual(expected);
     });
   });
 
@@ -53,11 +50,8 @@ describe('mapFacilityCreditRating', () => {
     { exporterCreditRating: '', description: 'empty string' },
   ])('when the exporter credit rating is $description', ({ exporterCreditRating }) => {
     it('should return null', () => {
-      // Arrange
-      const mockCreditRiskRatings = ['BB-', 'B+'];
-
       // Act
-      const result = mapFacilityCreditRating(mockCreditRiskRatings, exporterCreditRating);
+      const result = mapFacilityCreditRating(exporterCreditRating);
 
       // Assert
       expect(result).toBeNull();

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-credit-rating/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-credit-rating/index.ts
@@ -1,25 +1,19 @@
 import { TFM_CREDIT_RATING_MAP } from '../../../constants';
 
 /**
- * Map the facility credit rating based on the provided credit risk ratings from APIM MDM and TFM's exporter credit rating.
- * @param {string[]} creditRiskRatings - The list of credit risk ratings from APIM MDM.
+ * Map the facility credit rating based on TFM's exporter credit rating.
+ * Some ratings may still be the old Good (BB-) or Acceptable (B+) format, so we need to map them to the new format.
  * @param {string | null} exporterCreditRating - TFM's exporter's credit rating.
  * @returns {string | null} The mapped facility credit rating or null if not found.
  */
-export const mapFacilityCreditRating = (creditRiskRatings: string[], exporterCreditRating?: string | null): string | null => {
+export const mapFacilityCreditRating = (exporterCreditRating?: string | null): string | null => {
   if (!exporterCreditRating) {
     return null;
   }
 
-  const creditRating = exporterCreditRating.trim();
-
-  if (creditRating in TFM_CREDIT_RATING_MAP) {
-    return TFM_CREDIT_RATING_MAP[creditRating as keyof typeof TFM_CREDIT_RATING_MAP];
+  if (exporterCreditRating in TFM_CREDIT_RATING_MAP) {
+    return TFM_CREDIT_RATING_MAP[exporterCreditRating as keyof typeof TFM_CREDIT_RATING_MAP];
   }
 
-  if (creditRiskRatings.includes(creditRating)) {
-    return creditRating;
-  }
-
-  return null;
+  return exporterCreditRating;
 };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-credit-rating/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-risk-details/map-facility-credit-rating/index.ts
@@ -1,4 +1,4 @@
-import { TFM_CREDIT_RATING_MAP } from '../../../constants';
+import { TFM_CREDIT_RATING_MAP } from '@ukef/dtfs2-common';
 
 /**
  * Map the facility credit rating based on TFM's exporter credit rating.

--- a/trade-finance-manager-ui/component-tests/case/underwriting/edit-pricing-and-risk.component-test.js
+++ b/trade-finance-manager-ui/component-tests/case/underwriting/edit-pricing-and-risk.component-test.js
@@ -21,11 +21,11 @@ describe(page, () => {
 
   describe('radio buttons', () => {
     it('should render `Good` radio button', () => {
-      wrapper.expectInput('[data-cy="credit-rating-good"]').toHaveValue('Good (BB-)');
+      wrapper.expectInput('[data-cy="credit-rating-good"]').toHaveValue('BB-');
     });
 
     it('should render `Acceptable (B+)` radio button', () => {
-      wrapper.expectInput('[data-cy="credit-rating-acceptable"]').toHaveValue('Acceptable (B+)');
+      wrapper.expectInput('[data-cy="credit-rating-acceptable"]').toHaveValue('B+');
     });
 
     it('should render `Other` radio button', () => {

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.js
@@ -42,7 +42,9 @@ const getUnderWritingPricingAndRiskEdit = async (req, res) => {
 
   // Map the selected credit rating to the appropriate variables for rendering the page
   const { goodSelected, acceptableSelected, otherSelected, otherCreditRatingValue } = mapSelectedCreditRating(deal?.tfm?.exporterCreditRating);
-  const otherCreditRatings = await mapOtherCreditRatings(deal?.tfm?.exporterCreditRating);
+
+  // Only pass the saved rating to pre-select it if "Other" is actually selected; otherwise pass undefined so no option is marked selected
+  const otherCreditRatings = await mapOtherCreditRatings(otherCreditRatingValue);
 
   if (!Array.isArray(otherCreditRatings) || !otherCreditRatings?.length) {
     console.error('getUnderWritingPricingAndRiskEdit - No credit ratings returned from the API.');
@@ -82,14 +84,6 @@ const postUnderWritingPricingAndRisk = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  let submittedValue;
-
-  if (hasValue(req.body.exporterCreditRatingOther)) {
-    submittedValue = req.body.exporterCreditRatingOther;
-  } else {
-    submittedValue = req.body.exporterCreditRating;
-  }
-
   let validationErrors;
 
   const otherCreditRatings = await mapOtherCreditRatings();
@@ -101,6 +95,9 @@ const postUnderWritingPricingAndRisk = async (req, res) => {
 
   const selectedOther = req.body.exporterCreditRating === 'Other';
   const otherValue = hasValue(req.body.exporterCreditRatingOther);
+
+  // Only set the submitted value to the other value if the user has selected "Other" and provided a value for it
+  const submittedValue = selectedOther && otherValue ? req.body.exporterCreditRatingOther : req.body.exporterCreditRating;
 
   const noOptionSelected = !hasValue(req.body.exporterCreditRating);
 

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.js
@@ -4,6 +4,7 @@ const lossGivenDefaultControllers = require('./loss-given-default');
 const probabilityOfDefaultControllers = require('./probability-of-default');
 const facilityRiskProfileControllers = require('./facility-risk-profile');
 const { userCanEditGeneral } = require('./helpers');
+const { mapSelectedCreditRating } = require('../../../../helpers/map-selected-credit-rating');
 const { mapOtherCreditRatings } = require('../../../../helpers/map-other-credit-ratings');
 
 const getUnderWritingPricingAndRisk = (deal, user) => ({
@@ -39,6 +40,8 @@ const getUnderWritingPricingAndRiskEdit = async (req, res) => {
     return res.redirect('/not-found');
   }
 
+  // Map the selected credit rating to the appropriate variables for rendering the page
+  const { goodSelected, acceptableSelected, otherSelected, otherCreditRatingValue } = mapSelectedCreditRating(deal?.tfm?.exporterCreditRating);
   const otherCreditRatings = await mapOtherCreditRatings(deal?.tfm?.exporterCreditRating);
 
   if (!Array.isArray(otherCreditRatings) || !otherCreditRatings?.length) {
@@ -53,7 +56,11 @@ const getUnderWritingPricingAndRiskEdit = async (req, res) => {
     tfm: deal.tfm,
     dealId: deal.dealSnapshot._id,
     user: req.session.user,
+    goodSelected,
+    acceptableSelected,
+    otherSelected,
     otherCreditRatings,
+    otherCreditRatingValue,
     label,
   });
 };
@@ -138,6 +145,9 @@ const postUnderWritingPricingAndRisk = async (req, res) => {
       }
     }
 
+    // Map the selected credit rating to the appropriate variables for rendering the page with validation errors
+    const { goodSelected, acceptableSelected, otherSelected, otherCreditRatingValue } = mapSelectedCreditRating(submittedValue);
+
     return res.render('case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk', {
       activePrimaryNavigation: 'manage work',
       activeSubNavigation: 'underwriting',
@@ -150,6 +160,10 @@ const postUnderWritingPricingAndRisk = async (req, res) => {
       user: req.session.user,
       validationErrors,
       otherCreditRatings,
+      goodSelected,
+      acceptableSelected,
+      otherSelected,
+      otherCreditRatingValue,
       label,
     });
   }

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.test.js
@@ -98,7 +98,8 @@ describe('GET underwriting - pricing and risk edit', () => {
         label,
       });
 
-      expect(mapOtherCreditRatings).toHaveBeenCalledWith(mockDeal?.tfm?.exporterCreditRating);
+      // Should pass otherCreditRatingValue (empty string if not Other, or the value if Other is selected)
+      expect(mapOtherCreditRatings).toHaveBeenCalledWith(otherCreditRatingValue);
     });
 
     it('should render problem-with-service when credit ratings are not available', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.test.js
@@ -4,6 +4,7 @@ import api from '../../../../api';
 import { mockRes } from '../../../../test-mocks';
 import { userCanEditGeneral } from './helpers';
 import { mapOtherCreditRatings } from '../../../../helpers/map-other-credit-ratings';
+import { mapSelectedCreditRating } from '../../../../helpers/map-selected-credit-rating';
 
 jest.mock('../../../../helpers/map-other-credit-ratings', () => ({
   mapOtherCreditRatings: jest.fn(),
@@ -79,6 +80,9 @@ describe('GET underwriting - pricing and risk edit', () => {
       };
 
       await pricingAndRiskController.getUnderWritingPricingAndRiskEdit(req, res);
+
+      const { goodSelected, acceptableSelected, otherSelected, otherCreditRatingValue } = mapSelectedCreditRating(mockDeal?.tfm?.exporterCreditRating);
+
       expect(res.render).toHaveBeenCalledWith('case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk', {
         activePrimaryNavigation: 'manage work',
         activeSubNavigation: 'underwriting',
@@ -86,6 +90,10 @@ describe('GET underwriting - pricing and risk edit', () => {
         tfm: mockDeal.tfm,
         dealId: mockDeal.dealSnapshot._id,
         user: session.user,
+        goodSelected,
+        acceptableSelected,
+        otherSelected,
+        otherCreditRatingValue,
         otherCreditRatings,
         label,
       });
@@ -202,6 +210,8 @@ describe('POST underwriting - pricing and risk edit', () => {
           ],
         };
 
+        const { goodSelected, acceptableSelected, otherSelected, otherCreditRatingValue } = mapSelectedCreditRating(req.body.exporterCreditRating);
+
         expect(res.render).toHaveBeenCalledWith('case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk', {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'underwriting',
@@ -214,6 +224,10 @@ describe('POST underwriting - pricing and risk edit', () => {
           user: session.user,
           validationErrors: expectedValidationErrors,
           otherCreditRatings,
+          goodSelected,
+          acceptableSelected,
+          otherSelected,
+          otherCreditRatingValue,
           label,
         });
 
@@ -252,6 +266,8 @@ describe('POST underwriting - pricing and risk edit', () => {
           ],
         };
 
+        const { goodSelected, acceptableSelected, otherSelected, otherCreditRatingValue } = mapSelectedCreditRating(req.body.exporterCreditRating);
+
         expect(res.render).toHaveBeenCalledWith('case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk', {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'underwriting',
@@ -264,6 +280,10 @@ describe('POST underwriting - pricing and risk edit', () => {
           user: session.user,
           validationErrors: expectedValidationErrors,
           otherCreditRatings,
+          goodSelected,
+          acceptableSelected,
+          otherSelected,
+          otherCreditRatingValue,
           label,
         });
 

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
@@ -75,4 +75,19 @@ describe('mapSelectedCreditRating', () => {
       expect(result).toEqual(expected);
     });
   });
+
+  describe('when the selected value is null, undefined, or empty string', () => {
+    it.each([null, undefined, ''])('should return correct mapping for %s', (selectedValue) => {
+      const result = mapSelectedCreditRating(selectedValue as string);
+
+      const expected = {
+        goodSelected: false,
+        acceptableSelected: false,
+        otherSelected: false,
+        otherCreditRatingValue: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
 });

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
@@ -1,0 +1,78 @@
+import { mapSelectedCreditRating } from './map-selected-credit-rating';
+
+describe('mapSelectedCreditRating', () => {
+  describe('when the selected value is Good (BB-)', () => {
+    it('should return correct mapping', () => {
+      const result = mapSelectedCreditRating('Good (BB-)');
+
+      const expected = {
+        goodSelected: true,
+        acceptableSelected: false,
+        otherSelected: false,
+        otherCreditRatingValue: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the selected value is BB-', () => {
+    it('should return correct mapping', () => {
+      const result = mapSelectedCreditRating('BB-');
+
+      const expected = {
+        goodSelected: true,
+        acceptableSelected: false,
+        otherSelected: false,
+        otherCreditRatingValue: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the selected value is Acceptable (B+)', () => {
+    it('should return correct mapping', () => {
+      const result = mapSelectedCreditRating('Acceptable (B+)');
+
+      const expected = {
+        goodSelected: false,
+        acceptableSelected: true,
+        otherSelected: false,
+        otherCreditRatingValue: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the selected value is B+', () => {
+    it('should return correct mapping', () => {
+      const result = mapSelectedCreditRating('B+');
+
+      const expected = {
+        goodSelected: false,
+        acceptableSelected: true,
+        otherSelected: false,
+        otherCreditRatingValue: '',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when the selected value is other and has a value', () => {
+    it('should return correct mapping', () => {
+      const result = mapSelectedCreditRating('Some Other Value');
+
+      const expected = {
+        goodSelected: false,
+        acceptableSelected: false,
+        otherSelected: true,
+        otherCreditRatingValue: 'Some Other Value',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
@@ -1,10 +1,10 @@
-import { EXPORTER_CREDIT_RATING_FULL, EXPORTER_CREDIT_RATING_SHORT } from '@ukef/dtfs2-common';
+import { CREDIT_RATING_TFM, CREDIT_RATING } from '@ukef/dtfs2-common';
 import { mapSelectedCreditRating } from './map-selected-credit-rating';
 
 describe('mapSelectedCreditRating', () => {
-  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_FULL.BB_MINUS}`, () => {
+  describe(`when the selected value is ${CREDIT_RATING_TFM.BB_MINUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_FULL.BB_MINUS);
+      const result = mapSelectedCreditRating(CREDIT_RATING_TFM.BB_MINUS);
 
       const expected = {
         goodSelected: true,
@@ -17,9 +17,9 @@ describe('mapSelectedCreditRating', () => {
     });
   });
 
-  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_SHORT.BB_MINUS}`, () => {
+  describe(`when the selected value is ${CREDIT_RATING.BB_MINUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_SHORT.BB_MINUS);
+      const result = mapSelectedCreditRating(CREDIT_RATING.BB_MINUS);
 
       const expected = {
         goodSelected: true,
@@ -32,9 +32,9 @@ describe('mapSelectedCreditRating', () => {
     });
   });
 
-  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_FULL.B_PLUS}`, () => {
+  describe(`when the selected value is ${CREDIT_RATING_TFM.B_PLUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_FULL.B_PLUS);
+      const result = mapSelectedCreditRating(CREDIT_RATING_TFM.B_PLUS);
 
       const expected = {
         goodSelected: false,
@@ -47,9 +47,9 @@ describe('mapSelectedCreditRating', () => {
     });
   });
 
-  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_SHORT.B_PLUS}`, () => {
+  describe(`when the selected value is ${CREDIT_RATING.B_PLUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_SHORT.B_PLUS);
+      const result = mapSelectedCreditRating(CREDIT_RATING.B_PLUS);
 
       const expected = {
         goodSelected: false,

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.test.ts
@@ -1,9 +1,10 @@
+import { EXPORTER_CREDIT_RATING_FULL, EXPORTER_CREDIT_RATING_SHORT } from '@ukef/dtfs2-common';
 import { mapSelectedCreditRating } from './map-selected-credit-rating';
 
 describe('mapSelectedCreditRating', () => {
-  describe('when the selected value is Good (BB-)', () => {
+  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_FULL.BB_MINUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating('Good (BB-)');
+      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_FULL.BB_MINUS);
 
       const expected = {
         goodSelected: true,
@@ -16,9 +17,9 @@ describe('mapSelectedCreditRating', () => {
     });
   });
 
-  describe('when the selected value is BB-', () => {
+  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_SHORT.BB_MINUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating('BB-');
+      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_SHORT.BB_MINUS);
 
       const expected = {
         goodSelected: true,
@@ -31,9 +32,9 @@ describe('mapSelectedCreditRating', () => {
     });
   });
 
-  describe('when the selected value is Acceptable (B+)', () => {
+  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_FULL.B_PLUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating('Acceptable (B+)');
+      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_FULL.B_PLUS);
 
       const expected = {
         goodSelected: false,
@@ -46,9 +47,9 @@ describe('mapSelectedCreditRating', () => {
     });
   });
 
-  describe('when the selected value is B+', () => {
+  describe(`when the selected value is ${EXPORTER_CREDIT_RATING_SHORT.B_PLUS}`, () => {
     it('should return correct mapping', () => {
-      const result = mapSelectedCreditRating('B+');
+      const result = mapSelectedCreditRating(EXPORTER_CREDIT_RATING_SHORT.B_PLUS);
 
       const expected = {
         goodSelected: false,

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
@@ -1,3 +1,5 @@
+import { EXPORTER_CREDIT_RATING_FULL, EXPORTER_CREDIT_RATING_SHORT } from '@ukef/dtfs2-common';
+
 /**
  * maps the selected credit rating value to the corresponding radios or other credit rating value
  * some credit ratings are saved as "Good (BB-)" or "Acceptable (B+)" in TFM but newer ones are saved as "BB-" or "B+"
@@ -9,8 +11,8 @@
  * @returns an object with the corresponding radios or other credit rating value
  */
 export const mapSelectedCreditRating = (selectedValue: string) => {
-  const goodSelected = Boolean(selectedValue === 'Good (BB-)' || selectedValue === 'BB-');
-  const acceptableSelected = Boolean(selectedValue === 'Acceptable (B+)' || selectedValue === 'B+');
+  const goodSelected = Boolean(selectedValue === EXPORTER_CREDIT_RATING_FULL.BB_MINUS || selectedValue === EXPORTER_CREDIT_RATING_SHORT.BB_MINUS);
+  const acceptableSelected = Boolean(selectedValue === EXPORTER_CREDIT_RATING_FULL.B_PLUS || selectedValue === EXPORTER_CREDIT_RATING_SHORT.B_PLUS);
   const otherSelected = Boolean(selectedValue && !goodSelected && !acceptableSelected);
   let otherCreditRatingValue = '';
 

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
@@ -1,4 +1,4 @@
-import { EXPORTER_CREDIT_RATING_FULL, EXPORTER_CREDIT_RATING_SHORT } from '@ukef/dtfs2-common';
+import { CREDIT_RATING_TFM, CREDIT_RATING } from '@ukef/dtfs2-common';
 
 /**
  * maps the selected credit rating value to the corresponding radios or other credit rating value
@@ -11,9 +11,10 @@ import { EXPORTER_CREDIT_RATING_FULL, EXPORTER_CREDIT_RATING_SHORT } from '@ukef
  * @returns an object with the corresponding radios or other credit rating value
  */
 export const mapSelectedCreditRating = (selectedValue: string) => {
-  const goodSelected = Boolean(selectedValue === EXPORTER_CREDIT_RATING_FULL.BB_MINUS || selectedValue === EXPORTER_CREDIT_RATING_SHORT.BB_MINUS);
-  const acceptableSelected = Boolean(selectedValue === EXPORTER_CREDIT_RATING_FULL.B_PLUS || selectedValue === EXPORTER_CREDIT_RATING_SHORT.B_PLUS);
+  const goodSelected = Boolean(selectedValue === CREDIT_RATING_TFM.BB_MINUS || selectedValue === CREDIT_RATING.BB_MINUS);
+  const acceptableSelected = Boolean(selectedValue === CREDIT_RATING_TFM.B_PLUS || selectedValue === CREDIT_RATING.B_PLUS);
   const otherSelected = Boolean(selectedValue && !goodSelected && !acceptableSelected);
+
   let otherCreditRatingValue = '';
 
   if (otherSelected && selectedValue) {

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
@@ -9,12 +9,12 @@
  * @returns an object with the corresponding radios or other credit rating value
  */
 export const mapSelectedCreditRating = (selectedValue: string) => {
-  const goodSelected = selectedValue === 'Good (BB-)' || selectedValue === 'BB-';
-  const acceptableSelected = selectedValue === 'Acceptable (B+)' || selectedValue === 'B+';
-  const otherSelected = selectedValue && !goodSelected && !acceptableSelected;
+  const goodSelected = Boolean(selectedValue === 'Good (BB-)' || selectedValue === 'BB-');
+  const acceptableSelected = Boolean(selectedValue === 'Acceptable (B+)' || selectedValue === 'B+');
+  const otherSelected = Boolean(selectedValue && !goodSelected && !acceptableSelected);
   let otherCreditRatingValue = '';
 
-  if (otherSelected) {
+  if (otherSelected && selectedValue) {
     otherCreditRatingValue = selectedValue;
   }
 

--- a/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
+++ b/trade-finance-manager-ui/server/helpers/map-selected-credit-rating.ts
@@ -1,0 +1,27 @@
+/**
+ * maps the selected credit rating value to the corresponding radios or other credit rating value
+ * some credit ratings are saved as "Good (BB-)" or "Acceptable (B+)" in TFM but newer ones are saved as "BB-" or "B+"
+ * ensures that the correct radio is selected for the credit rating value saved in TFM
+ * if Good (BB-) or BB- is provided, the corresponding radio is selected
+ * if Acceptable (B+) or B+ is provided, the corresponding radio is selected
+ * if any other value is provided, the "Other" radio is selected and the value is displayed in the "Other" input field
+ * @param selectedValue - the selected credit rating value saved in TFM
+ * @returns an object with the corresponding radios or other credit rating value
+ */
+export const mapSelectedCreditRating = (selectedValue: string) => {
+  const goodSelected = selectedValue === 'Good (BB-)' || selectedValue === 'BB-';
+  const acceptableSelected = selectedValue === 'Acceptable (B+)' || selectedValue === 'B+';
+  const otherSelected = selectedValue && !goodSelected && !acceptableSelected;
+  let otherCreditRatingValue = '';
+
+  if (otherSelected) {
+    otherCreditRatingValue = selectedValue;
+  }
+
+  return {
+    goodSelected,
+    acceptableSelected,
+    otherSelected,
+    otherCreditRatingValue,
+  };
+};

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk
@@ -35,12 +35,9 @@
               <input type="hidden" name="_csrf" value="{{ csrfToken }}">
               {% set legendText = 'Add a credit rating for ' + deal.submissionDetails.supplierName %}
 
-              {% set exporterCreditRatingOtherChecked = tfm.exporterCreditRating.length > 0 and tfm.exporterCreditRating !== 'Good (BB-)' and tfm.exporterCreditRating !== 'Acceptable (B+)' %}
-              {% set exporterCreditRatingOtherTextInputValue = tfm.exporterCreditRating.length > 0 and tfm.exporterCreditRating !== 'Good (BB-)' and tfm.exporterCreditRating !== 'Acceptable (B+)' and tfm.exporterCreditRating %}
-
               {% set exporterCreditRatingOtherComponentData = {
                 errorMessage: validationErrors.errorList.exporterCreditRatingOther.text,
-                value: exporterCreditRatingOtherTextInputValue,
+                value: otherCreditRatingValue,
                 fieldId: 'exporterCreditRatingOther',
                 inputContainerClasses: 'govuk-input--width-20',
                 options: otherCreditRatings,
@@ -58,17 +55,17 @@
                   name: "exporterCreditRating",
                   items: [
                     {
-                      value: "Good (BB-)",
+                      value: "BB-",
                       text: "Good (BB-)",
-                      checked: tfm.exporterCreditRating === 'Good (BB-)',
+                      checked: goodSelected,
                       attributes: {
                         'data-cy': 'credit-rating-good'
                       }
                     },
                     {
-                      value: "Acceptable (B+)",
+                      value: "B+",
                       text: "Acceptable (B+)",
-                      checked: tfm.exporterCreditRating === 'Acceptable (B+)',
+                      checked: acceptableSelected,
                       attributes: {
                         'data-cy': 'credit-rating-acceptable'
                       }
@@ -76,7 +73,7 @@
                     {
                       value: "Other",
                       text: "Other",
-                      checked: exporterCreditRatingOtherChecked,
+                      checked: otherSelected,
                       attributes: {
                         'data-cy': 'credit-rating-other'
                       },


### PR DESCRIPTION
# Introduction :pencil2:

This PR removes the duplicated credit risk ratings api call from APIM mapping as it is called when rendering the edit credit risk page.  
It also saves the radios for credit risk rating as the rating only (eg BB-) instead of Good (BB-) and adds some mapping to handle this for new and old deals

## Resolution :heavy_check_mark:

* Add mapping function for mapping old (Good BB-) and new (BB-) exporterCreditRatings so the correct radio is selected
* Added tests
* Removed get credit risk ratings api call from APIM mapping files
