### PR TITLE
fix(DTFS2-8532): amend gift facility amount - calculation

### DIFF
--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
@@ -140,10 +140,10 @@ describe('getAmendmentFields', () => {
   describe('when effectiveDate is null', () => {
     it('should return effectiveDate as an empty string', () => {
       // Arrange
-      const amendment: TfmFacilityAmendmentData = {
+      const amendment = {
         ...mockBaseAmendment,
-        effectiveDate: null as unknown as number,
-      };
+        effectiveDate: null,
+      } as unknown as TfmFacilityAmendmentData;
 
       // Act
       const result = getAmendmentFields(amendment);

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
@@ -26,6 +26,7 @@ describe('getAmendmentFields', () => {
       previousAmount: amendment.currentValue,
       coverEndDate: getFormattedDateStringInTimeZone(Number(amendment.coverEndDate), TIMEZONE.DEFAULT),
       effectiveDate: getFormattedUTCDateString(Number(amendment.effectiveDate)),
+      coveredPercentage: null,
     };
 
     expect(result).toEqual(expected);
@@ -165,6 +166,66 @@ describe('getAmendmentFields', () => {
 
       // Assert
       expect(result.coverEndDate).toEqual('');
+    });
+  });
+
+  describe('when coveredPercentage is provided', () => {
+    it('should return coveredPercentage as a number', () => {
+      // Arrange
+      const amendment: TfmFacilityAmendmentData = {
+        ...mockBaseAmendment,
+        coveredPercentage: 80,
+      };
+
+      // Act
+      const result = getAmendmentFields(amendment);
+
+      // Assert
+      expect(result.coveredPercentage).toEqual(80);
+    });
+  });
+
+  describe('when coveredPercentage is not a number', () => {
+    it('should return coveredPercentage as null when undefined', () => {
+      // Arrange
+      const amendment: TfmFacilityAmendmentData = {
+        ...mockBaseAmendment,
+        coveredPercentage: undefined,
+      };
+
+      // Act
+      const result = getAmendmentFields(amendment);
+
+      // Assert
+      expect(result.coveredPercentage).toBeNull();
+    });
+
+    it('should return coveredPercentage as null when null', () => {
+      // Arrange
+      const amendment: TfmFacilityAmendmentData = {
+        ...mockBaseAmendment,
+        coveredPercentage: null,
+      };
+
+      // Act
+      const result = getAmendmentFields(amendment);
+
+      // Assert
+      expect(result.coveredPercentage).toBeNull();
+    });
+
+    it('should return coveredPercentage as null when a string', () => {
+      // Arrange
+      const amendment: TfmFacilityAmendmentData = {
+        ...mockBaseAmendment,
+        coveredPercentage: '80' as unknown as number,
+      };
+
+      // Act
+      const result = getAmendmentFields(amendment);
+
+      // Assert
+      expect(result.coveredPercentage).toBeNull();
     });
   });
 });

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
@@ -6,12 +6,13 @@ type AmendmentFields = {
   previousAmount: number;
   coverEndDate: string;
   effectiveDate: string;
+  coveredPercentage: number | null;
 };
 
 /**
  * Extracts amendment values from TFM amendment data.
  * @param {TfmFacilityAmendmentData} amendment - The facility amendment data from TFM.
- * @returns {AmendmentFields} An object containing amount, cover end date and effective date values for APIM/GIFT payload construction.
+ * @returns {AmendmentFields} An object containing amount, cover end date, effective date, and covered percentage values for APIM/GIFT payload construction.
  */
 export const getAmendmentFields = (amendment: TfmFacilityAmendmentData): AmendmentFields => {
   const newAmount = typeof amendment.value === 'number' ? amendment.value : Number.NaN;
@@ -29,10 +30,13 @@ export const getAmendmentFields = (amendment: TfmFacilityAmendmentData): Amendme
 
   const effectiveDate = hasEffectiveDate ? getFormattedUTCDateString(effectiveDateValue) : '';
 
+  const coveredPercentage = typeof amendment.coveredPercentage === 'number' ? amendment.coveredPercentage : null;
+
   return {
     newAmount,
     previousAmount,
     coverEndDate,
     effectiveDate,
+    coveredPercentage,
   };
 };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
@@ -28,8 +28,6 @@ describe('mapAmount', () => {
       const result = mapAmount(params);
 
       // Assert
-      // amountDifference = 150 - 100 = 50
-      // amount = 50 * (80 / 100) = 40
       expect(result).toEqual(40);
     });
 
@@ -45,8 +43,6 @@ describe('mapAmount', () => {
       const result = mapAmount(params);
 
       // Assert
-      // amountDifference = 200 - 100 = 100
-      // amount = 100 * (100 / 100) = 100
       expect(result).toEqual(100);
     });
 
@@ -62,8 +58,6 @@ describe('mapAmount', () => {
       const result = mapAmount(params);
 
       // Assert
-      // amountDifference = 250 - 100 = 150
-      // amount = 150 * (50 / 100) = 75
       expect(result).toEqual(75);
     });
 
@@ -79,9 +73,7 @@ describe('mapAmount', () => {
       const result = mapAmount(params);
 
       // Assert
-      // amountDifference = 60 - 100 = -40
-      // amount = -40 * (80 / 100) = -32
-      expect(result).toEqual(-32);
+      expect(result).toEqual(32);
     });
   });
 
@@ -227,7 +219,7 @@ describe('amendFacility', () => {
     expect(result).toEqual(expected);
   });
 
-  describe('when coveredPercentage is not provided', () => {
+  describe('when coveredPercentage is provided', () => {
     it(`should adjust the amount difference`, () => {
       // Arrange
       const mockAmendment = {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
@@ -31,7 +31,7 @@ describe('amendFacility', () => {
       {
         amendmentType: INCREASE_AMOUNT,
         amendmentData: {
-          amount: 30,
+          amount: null,
           date: '2024-01-01',
         },
       },
@@ -57,7 +57,7 @@ describe('amendFacility', () => {
       {
         amendmentType: DECREASE_AMOUNT,
         amendmentData: {
-          amount: 30,
+          amount: null,
           date: '2024-01-01',
         },
       },
@@ -106,7 +106,7 @@ describe('amendFacility', () => {
       {
         amendmentType: INCREASE_AMOUNT,
         amendmentData: {
-          amount: 30,
+          amount: null,
           date: '2024-01-01',
         },
       },
@@ -119,6 +119,64 @@ describe('amendFacility', () => {
     ];
 
     expect(result).toEqual(expected);
+  });
+
+  describe('when coveredPercentage is not provided', () => {
+    it(`should adjust the amount difference`, () => {
+      // Arrange
+      const mockAmendment = {
+        ...mockAmendmentBase,
+        value: 150,
+        coveredPercentage: 80,
+        changeFacilityValue: true,
+        changeCoverEndDate: false,
+      };
+
+      // Act
+      const result = amendFacility(mockAmendment);
+
+      // Assert
+      const expected = [
+        {
+          amendmentType: INCREASE_AMOUNT,
+          amendmentData: {
+            amount: 40,
+            date: '2024-01-01',
+          },
+        },
+      ];
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when coveredPercentage is null', () => {
+    it(`should return null amount`, () => {
+      // Arrange
+      const mockAmendment = {
+        ...mockAmendmentBase,
+        value: 150,
+        coveredPercentage: null,
+        changeFacilityValue: true,
+        changeCoverEndDate: false,
+      };
+
+      // Act
+      const result = amendFacility(mockAmendment);
+
+      // Assert
+      const expected = [
+        {
+          amendmentType: INCREASE_AMOUNT,
+          amendmentData: {
+            amount: null,
+            date: '2024-01-01',
+          },
+        },
+      ];
+
+      expect(result).toEqual(expected);
+    });
   });
 
   describe('when the amendment cannot be mapped to any valid APIM GIFT amendment type', () => {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
@@ -1,5 +1,5 @@
 import { APIM_GIFT_INTEGRATION } from '../constants';
-import { amendFacility } from '.';
+import { amendFacility, mapAmount } from '.';
 import { TfmFacilityAmendmentData } from '../types';
 
 const {
@@ -13,6 +13,112 @@ const mockAmendmentBase: TfmFacilityAmendmentData = {
   coverEndDate: 1706745600000,
   tfm: {},
 };
+
+describe('mapAmount', () => {
+  describe('when coveredPercentage is provided', () => {
+    it('should return the amount difference adjusted by 80% covered percentage', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: 80,
+        newAmount: 150,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      // amountDifference = 150 - 100 = 50
+      // amount = 50 * (80 / 100) = 40
+      expect(result).toEqual(40);
+    });
+
+    it('should return the amount difference adjusted by 100% covered percentage', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: 100,
+        newAmount: 200,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      // amountDifference = 200 - 100 = 100
+      // amount = 100 * (100 / 100) = 100
+      expect(result).toEqual(100);
+    });
+
+    it('should return the amount difference adjusted by 50% covered percentage', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: 50,
+        newAmount: 250,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      // amountDifference = 250 - 100 = 150
+      // amount = 150 * (50 / 100) = 75
+      expect(result).toEqual(75);
+    });
+
+    it('should handle decrease amount scenario with covered percentage', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: 80,
+        newAmount: 60,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      // amountDifference = 60 - 100 = -40
+      // amount = -40 * (80 / 100) = -32
+      expect(result).toEqual(-32);
+    });
+  });
+
+  describe('when coveredPercentage is null', () => {
+    it('should return null', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: null,
+        newAmount: 150,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('when coveredPercentage is 0', () => {
+    it('should return null (falsy check)', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: 0,
+        newAmount: 150,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+});
 
 describe('amendFacility', () => {
   it(`should return an array containing an "${INCREASE_AMOUNT}" payload`, () => {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
@@ -1,5 +1,5 @@
 import { APIM_GIFT_INTEGRATION } from '../constants';
-import { ApimGiftFacilityAmendmentPayload, TfmFacilityAmendmentData } from '../types';
+import { ApimGiftFacilityAmendmentPayload, MapAmountParams, TfmFacilityAmendmentData } from '../types';
 import { getAmountAmendmentType } from './get-amount-amendment-type';
 import { getAmendmentFields } from './get-amendment-fields';
 import { getAmountDifference } from './get-amount-difference';
@@ -7,6 +7,23 @@ import { getAmountDifference } from './get-amount-difference';
 const {
   AMENDMENT_TYPE: { REPLACE_EXPIRY_DATE },
 } = APIM_GIFT_INTEGRATION;
+
+/**
+ * Map an amendment amount to the amount adjusted by the covered percentage.
+ * @param {MapAmountParams} params - The parameters for mapping the amount.
+ * @param {number | null} params.coveredPercentage - The covered percentage to adjust the amount by.
+ * @param {number} params.newAmount - The new amount after the amendment.
+ * @param {number} params.previousAmount - The previous amount before the amendment.
+ * @returns The calculated amount adjusted by the covered percentage.
+ */
+export const mapAmount = ({ coveredPercentage, newAmount, previousAmount }: MapAmountParams) => {
+  const amountDifference = getAmountDifference(previousAmount, newAmount);
+
+  // calculate newAmount adjusted by the covered percentage
+  const amount = coveredPercentage ? amountDifference * (coveredPercentage / 100) : null;
+
+  return amount;
+};
 
 /**
  * Builds an array of APIM/GIFT amendment payloads from TFM amendment data.
@@ -19,10 +36,7 @@ export const amendFacility = (amendment: TfmFacilityAmendmentData): ApimGiftFaci
 
   const { changeFacilityValue, changeCoverEndDate } = amendment;
 
-  const amountDifference = getAmountDifference(previousAmount, newAmount);
-
-  // calculate newAmount adjusted by the covered percentage
-  const amount = coveredPercentage !== null ? amountDifference * (coveredPercentage / 100) : null;
+  const amount = mapAmount({ coveredPercentage, newAmount, previousAmount });
 
   const payloads: ApimGiftFacilityAmendmentPayload[] = [];
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
@@ -16,7 +16,7 @@ const {
  * @param {number} params.previousAmount - The previous amount before the amendment.
  * @returns The calculated amount adjusted by the covered percentage.
  */
-export const mapAmount = ({ coveredPercentage, newAmount, previousAmount }: MapAmountParams) => {
+export const mapAmount = ({ coveredPercentage, newAmount, previousAmount }: MapAmountParams): number | null => {
   const amountDifference = getAmountDifference(previousAmount, newAmount);
 
   // calculate newAmount adjusted by the covered percentage

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
@@ -10,16 +10,19 @@ const {
 
 /**
  * Builds an array of APIM/GIFT amendment payloads from TFM amendment data.
- * A single amendment can produce up to two payloads: one for an amount change and one for a cover end date change.
+ * A single amendment can produce up to two payloads: one for an "amount" change and one for a "expiry date" change.
  * @param {TfmFacilityAmendmentData} amendment - The facility amendment data from TFM.
  * @returns {ApimGiftFacilityAmendmentPayload[]} Array of APIM/GIFT payloads. Empty if no valid payload can be produced.
  */
 export const amendFacility = (amendment: TfmFacilityAmendmentData): ApimGiftFacilityAmendmentPayload[] => {
-  const { previousAmount, newAmount, coverEndDate, effectiveDate } = getAmendmentFields(amendment);
+  const { previousAmount, newAmount, coverEndDate, effectiveDate, coveredPercentage } = getAmendmentFields(amendment);
 
   const { changeFacilityValue, changeCoverEndDate } = amendment;
 
   const amountDifference = getAmountDifference(previousAmount, newAmount);
+
+  // calculate newAmount adjusted by the covered percentage
+  const amount = coveredPercentage !== null ? amountDifference * (coveredPercentage / 100) : null;
 
   const payloads: ApimGiftFacilityAmendmentPayload[] = [];
 
@@ -33,7 +36,7 @@ export const amendFacility = (amendment: TfmFacilityAmendmentData): ApimGiftFaci
       const payload = {
         amendmentType: amountAmendmentType,
         amendmentData: {
-          amount: amountDifference,
+          amount,
           date: effectiveDate,
         },
       };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/amendments.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/amendments.ts
@@ -23,6 +23,12 @@ export type TfmFacilityAmendmentData = {
   };
 };
 
+export type MapAmountParams = {
+  coveredPercentage?: number | null;
+  newAmount: number;
+  previousAmount: number;
+};
+
 export type AmendmentAmountDataParams = {
   amount: number | null;
   date: string;

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/amendments.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/amendments.ts
@@ -12,6 +12,8 @@ export type TfmFacilityAmendmentData = {
   currentValue?: number | null;
   effectiveDate?: number;
   coverEndDate?: number | null;
+  coveredPercentage?: number | null;
+  previousCoveredPercentage?: number | null;
   ukefDecision?: {
     value?: string;
     coverEndDate?: string;
@@ -22,7 +24,7 @@ export type TfmFacilityAmendmentData = {
 };
 
 export type AmendmentAmountDataParams = {
-  amount: number;
+  amount: number | null;
   date: string;
 };
 


### PR DESCRIPTION
# Introduction :pencil2:

The GIFT "amount" amendment was not using the covered percentage.

## Resolution :heavy_check_mark:

- Update `getAmendmentFields` to return `coveredPercentage`.
- Update `amendFacility` to calculate the amount via new function, `mapAmount`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
