### PR TITLE
chore(DTFS2-8535): change release deployments to be max-parallel 1 to stop failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
       ENVIRONMENT: ${{ needs.setup.outputs.environment }}
 
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       # Do not cancel in-progress jobs upon failure
       fail-fast: false
       # Single dimension matrix


### PR DESCRIPTION
# Introduction :pencil2:

This PR changes release.yml to have only 1 container deployment at a time to stop failures.  Otherwise deployments take a long time as they need to keep being rerrun.

## Resolution :heavy_check_mark:

* Change max-parallel to 1 in release.yml

