### PR TITLE
fix(DTFS2-8530): amend a gift facility - sent to apim/gift check

### DIFF
--- a/dtfs-central-api/server/v1/routes/middleware/payload-validation/validate-put-facility-amendment-payload.test.ts
+++ b/dtfs-central-api/server/v1/routes/middleware/payload-validation/validate-put-facility-amendment-payload.test.ts
@@ -1,0 +1,58 @@
+import httpMocks from 'node-mocks-http';
+import { HttpStatusCode } from 'axios';
+import { AuditDetails } from '@ukef/dtfs2-common';
+import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { aTfmSessionUser } from '../../../../../test-helpers';
+import { validatePutFacilityAmendmentPayload } from './validate-put-facility-amendment-payload';
+
+describe('validatePutFacilityAmendmentPayload', () => {
+  const getHttpMocks = () => httpMocks.createMocks();
+
+  const aValidAuditDetails = (): AuditDetails => generateTfmAuditDetails(aTfmSessionUser()._id);
+
+  it('should call the next function if payload contains apimGift.facilityAmendmentSent', () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    const next = jest.fn();
+
+    req.body = {
+      payload: {
+        apimGift: {
+          facilityAmendmentSent: true,
+        },
+        shouldNotUpdateTimestamp: true,
+      },
+      auditDetails: aValidAuditDetails(),
+    };
+
+    // Act
+    validatePutFacilityAmendmentPayload(req, res, next);
+
+    // Assert
+    expect(next).toHaveBeenCalled();
+    expect(res._isEndCalled()).toEqual(false);
+  });
+
+  it(`should respond with ${HttpStatusCode.BadRequest} if apimGift.facilityAmendmentSent is not a boolean`, () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    const next = jest.fn();
+
+    req.body = {
+      payload: {
+        apimGift: {
+          facilityAmendmentSent: 'true',
+        },
+      },
+      auditDetails: aValidAuditDetails(),
+    };
+
+    // Act
+    validatePutFacilityAmendmentPayload(req, res, next);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/dtfs-central-api/server/v1/routes/middleware/payload-validation/validate-put-facility-amendment-payload.ts
+++ b/dtfs-central-api/server/v1/routes/middleware/payload-validation/validate-put-facility-amendment-payload.ts
@@ -37,6 +37,9 @@ const PutFacilityAmendmentSchema = z.object({
       firstTaskEmailSent: z.boolean(),
       effectiveDate: z.number(),
       automaticApprovalEmail: z.boolean(),
+      apimGift: z.object({
+        facilityAmendmentSent: z.boolean(),
+      }),
       referenceNumber: z.string().optional(),
       shouldNotUpdateTimestamp: z.boolean().optional(),
       ukefDecision: z

--- a/trade-finance-manager-api/api-tests/v1/amendments/send-facility-amendment.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/amendments/send-facility-amendment.api-test.js
@@ -80,6 +80,7 @@ describe('POST /v1/amendment/facility/:facilityId/amendment/:amendmentId', () =>
     api.getAmendmentById = jest.fn().mockResolvedValue(amendment);
     api.findOneFacility = jest.fn().mockResolvedValue(facility);
     api.findOneDeal = jest.fn().mockResolvedValue(tfmDeal);
+    api.updateFacilityAmendment = jest.fn().mockResolvedValue({});
 
     submitFacilityAmendmentsToApimGift.mockResolvedValue([HttpStatusCode.Accepted]);
     canSendToAcbs.mockReturnValue(true);

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
@@ -54,19 +54,15 @@ describe('markFacilityAmendmentAsSentToApimGift', () => {
     });
 
     // Assert
-    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(
-      1,
-      facilityId,
-      amendmentId,
-      {
-        apimGift: {
-          existingField: 'existing-value',
-          facilityAmendmentSent: true,
-        },
-        shouldNotUpdateTimestamp: true,
+    const expectedObject = {
+      apimGift: {
+        existingField: 'existing-value',
+        facilityAmendmentSent: true,
       },
-      auditDetails,
-    );
+      shouldNotUpdateTimestamp: true,
+    };
+
+    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(1, facilityId, amendmentId, expectedObject, auditDetails);
   });
 
   it('should set facilityAmendmentSent to true when apimGift is missing', async () => {
@@ -79,17 +75,13 @@ describe('markFacilityAmendmentAsSentToApimGift', () => {
     });
 
     // Assert
-    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(
-      1,
-      facilityId,
-      amendmentId,
-      {
-        apimGift: {
-          facilityAmendmentSent: true,
-        },
-        shouldNotUpdateTimestamp: true,
+    const expectedObject = {
+      apimGift: {
+        facilityAmendmentSent: true,
       },
-      auditDetails,
-    );
+      shouldNotUpdateTimestamp: true,
+    };
+
+    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(1, facilityId, amendmentId, expectedObject, auditDetails);
   });
 });

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
@@ -1,0 +1,95 @@
+const api = require('../api');
+const { hasFacilityAmendmentBeenSentToApimGift, markFacilityAmendmentAsSentToApimGift } = require('./amendment.controller');
+
+jest.mock('../api', () => ({
+  updateFacilityAmendment: jest.fn(),
+}));
+
+describe('hasFacilityAmendmentBeenSentToApimGift', () => {
+  it('should return true when amendment apimGift facilityAmendmentSent is true', () => {
+    // Act
+    const result = hasFacilityAmendmentBeenSentToApimGift({ apimGift: { facilityAmendmentSent: true } });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it('should return false when amendment does not have apimGift', () => {
+    // Act
+    const result = hasFacilityAmendmentBeenSentToApimGift({});
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it('should return false when amendment is undefined', () => {
+    // Act
+    const result = hasFacilityAmendmentBeenSentToApimGift(undefined);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe('markFacilityAmendmentAsSentToApimGift', () => {
+  const facilityId = '66b1f2f6f4b5a8f3c7d9e011';
+  const amendmentId = '66b1f2f6f4b5a8f3c7d9e012';
+  const auditDetails = { id: '6051d94564494924d38ce67c', userType: 'tfm' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set facilityAmendmentSent to true and keep existing apimGift fields', async () => {
+    // Act
+    await markFacilityAmendmentAsSentToApimGift({
+      facilityId,
+      amendmentId,
+      amendment: {
+        apimGift: {
+          existingField: 'existing-value',
+        },
+      },
+      auditDetails,
+    });
+
+    // Assert
+    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(
+      1,
+      facilityId,
+      amendmentId,
+      {
+        apimGift: {
+          existingField: 'existing-value',
+          facilityAmendmentSent: true,
+        },
+        shouldNotUpdateTimestamp: true,
+      },
+      auditDetails,
+    );
+  });
+
+  it('should set facilityAmendmentSent to true when apimGift is missing', async () => {
+    // Act
+    await markFacilityAmendmentAsSentToApimGift({
+      facilityId,
+      amendmentId,
+      amendment: {},
+      auditDetails,
+    });
+
+    // Assert
+    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(
+      1,
+      facilityId,
+      amendmentId,
+      {
+        apimGift: {
+          facilityAmendmentSent: true,
+        },
+        shouldNotUpdateTimestamp: true,
+      },
+      auditDetails,
+    );
+  });
+});

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-sendFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-sendFacilityAmendment.test.js
@@ -10,6 +10,7 @@ const { APIM_GIFT_INTEGRATION } = require('../mappings/apim-gift-payloads/consta
 jest.mock('../api', () => ({
   getAmendmentById: jest.fn(),
   findOneFacility: jest.fn(),
+  updateFacilityAmendment: jest.fn(),
 }));
 
 jest.mock('../integrations/apim-gift/can-send-amendments-to-apim-gift');
@@ -36,6 +37,7 @@ describe('sendFacilityAmendment', () => {
 
     api.getAmendmentById.mockResolvedValue(amendment);
     api.findOneFacility.mockResolvedValue(facility);
+    api.updateFacilityAmendment.mockResolvedValue(amendment);
 
     isTfmApimGiftIntegrationEnabled.mockReturnValue(false);
   });
@@ -232,7 +234,41 @@ describe('sendFacilityAmendment', () => {
         ukefFacilityId: facility.facilitySnapshot.ukefFacilityId,
       });
 
+      expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(
+        1,
+        facilityId,
+        amendmentId,
+        {
+          apimGift: {
+            facilityAmendmentSent: true,
+          },
+          shouldNotUpdateTimestamp: true,
+        },
+        undefined,
+      );
+
       expect(console.info).toHaveBeenNthCalledWith(3, 'TFM facility %s sendFacilityAmendment - calling submitFacilityAmendmentsToApimGift', facilityId);
+    });
+
+    it('should skip APIM GIFT submission when amendment was already sent', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        params: { amendmentId, facilityId },
+      });
+
+      isTfmApimGiftIntegrationEnabled.mockReturnValue(true);
+      api.getAmendmentById.mockResolvedValueOnce({
+        ...amendment,
+        apimGift: {
+          facilityAmendmentSent: true,
+        },
+      });
+
+      await sendFacilityAmendment(req, res);
+
+      expect(canSendAmendmentsToApimGift).not.toHaveBeenCalled();
+      expect(submitFacilityAmendmentsToApimGift).not.toHaveBeenCalled();
+      expect(api.updateFacilityAmendment).not.toHaveBeenCalled();
     });
 
     it(`should return ${HttpStatusCode.BadGateway} when APIM GIFT submission fails`, async () => {

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-sendFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-sendFacilityAmendment.test.js
@@ -211,6 +211,7 @@ describe('sendFacilityAmendment', () => {
         method: 'POST',
         params: { amendmentId, facilityId },
       });
+      req.user = { _id: '66b1f2f6f4b5a8f3c7d9e099' };
 
       const payloads = [
         {
@@ -244,7 +245,10 @@ describe('sendFacilityAmendment', () => {
           },
           shouldNotUpdateTimestamp: true,
         },
-        undefined,
+        expect.objectContaining({
+          id: req.user._id,
+          userType: 'tfm',
+        }),
       );
 
       expect(console.info).toHaveBeenNthCalledWith(3, 'TFM facility %s sendFacilityAmendment - calling submitFacilityAmendmentsToApimGift', facilityId);

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -329,7 +329,7 @@ describe('updated facility amendment API call', () => {
           );
 
           expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(
-            1,
+            2,
             facilityId,
             amendmentId,
             expect.objectContaining({

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -327,6 +327,43 @@ describe('updated facility amendment API call', () => {
               ukefFacilityId: facility.facilitySnapshot.ukefFacilityId,
             }),
           );
+
+          expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(
+            1,
+            facilityId,
+            amendmentId,
+            expect.objectContaining({
+              apimGift: expect.objectContaining({
+                facilityAmendmentSent: true,
+              }),
+              shouldNotUpdateTimestamp: true,
+            }),
+            expect.any(Object),
+          );
+        });
+
+        it('should not call APIM GIFT when amendment was already sent', async () => {
+          // Arrange
+          const { req } = createMocks({ params: { amendmentId, facilityId }, user: underwriter, body: updateAmendmentBody });
+
+          api.getAmendmentById = jest.fn().mockResolvedValue({
+            ...MOCK_AMENDMENT,
+            changeFacilityValue: false,
+            changeCoverEndDate: true,
+            currentValue: 100,
+            value: 100,
+            effectiveDate: 1704067200,
+            tfm: { ...MOCK_AMENDMENT.tfm, coverEndDate: 1706745600000 },
+            apimGift: {
+              facilityAmendmentSent: true,
+            },
+          });
+
+          // Act
+          await amendmentController.updateFacilityAmendment(req, res);
+
+          // Assert
+          expect(submitFacilityAmendmentsToApimGift).not.toHaveBeenCalled();
         });
 
         it(`should return ${HttpStatusCode.BadRequest} when APIM GIFT submission fails`, async () => {

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -25,6 +25,35 @@ const {
 const CONSTANTS = require('../../constants');
 
 /**
+ * Checks if a facility amendment has been sent to APIM GIFT.
+ *
+ * @param {object} amendment - The amendment object.
+ * @returns {boolean} True if the facility amendment has been sent to APIM GIFT, false otherwise.
+ */
+const hasFacilityAmendmentBeenSentToApimGift = (amendment) => amendment?.apimGift?.facilityAmendmentSent === true;
+
+/**
+ * Marks a facility amendment as sent to APIM GIFT.
+ *
+ * @param {object} param0 - The parameters object.
+ * @param {string} param0.facilityId - The facility identifier.
+ * @param {string} param0.amendmentId - The amendment identifier.
+ * @param {object} param0.amendment - The amendment object.
+ * @param {import('@ukef/dtfs2-common').AuditDetails} param0.auditDetails - Audit details for update calls.
+ */
+const markFacilityAmendmentAsSentToApimGift = async ({ facilityId, amendmentId, amendment, auditDetails }) => {
+  const payload = {
+    apimGift: {
+      ...(amendment?.apimGift || {}),
+      facilityAmendmentSent: true,
+    },
+    shouldNotUpdateTimestamp: true,
+  };
+
+  await api.updateFacilityAmendment(facilityId, amendmentId, payload, auditDetails);
+};
+
+/**
  * Sends amendment-related notification emails when eligible.
  *
  * @param {string} amendmentId - The amendment identifier.
@@ -421,7 +450,10 @@ const updateFacilityAmendment = async (req, res) => {
         // Amend facility TFM properties
         await amendIssuedFacility(amendment, facility, tfmDeal, generateTfmAuditDetails(req.user._id));
 
-        if (isTfmApimGiftIntegrationEnabled() && !isTaskUpdate && isSubmittedByPim) {
+        const couldSendToApimGift =
+          isTfmApimGiftIntegrationEnabled() && !isTaskUpdate && isSubmittedByPim && !hasFacilityAmendmentBeenSentToApimGift(amendment);
+
+        if (couldSendToApimGift) {
           console.info('TFM facility %s updateFacilityAmendment - calling canSendAmendmentsToApimGift', facilityId);
 
           const { canSendAmendmentsToApimGift: canSendToApimGift, amendmentPayloads } = canSendAmendmentsToApimGift(amendment);
@@ -436,6 +468,13 @@ const updateFacilityAmendment = async (req, res) => {
 
               throw new Error(`Failed to submit facility ${ukefFacilityId} amendment ${amendmentId} to APIM GIFT`);
             }
+
+            await markFacilityAmendmentAsSentToApimGift({
+              facilityId,
+              amendmentId,
+              amendment,
+              auditDetails,
+            });
           }
         }
 
@@ -572,7 +611,9 @@ const sendFacilityAmendment = async (req, res) => {
         return res.status(HttpStatusCode.BadGateway).send({ data: 'Unable to send facility amendment to ACBS and/or APIM GIFT' });
       }
 
-      if (isTfmApimGiftIntegrationEnabled()) {
+      const couldSendToApimGift = isTfmApimGiftIntegrationEnabled() && !hasFacilityAmendmentBeenSentToApimGift(amendment);
+
+      if (couldSendToApimGift) {
         console.info('TFM facility %s sendFacilityAmendment - calling canSendAmendmentsToApimGift', facilityId);
 
         const { canSendAmendmentsToApimGift: canSendToApimGift, amendmentPayloads } = canSendAmendmentsToApimGift(amendment);
@@ -587,6 +628,15 @@ const sendFacilityAmendment = async (req, res) => {
 
             throw new Error(`Failed to submit facility ${ukefFacilityId} amendment ${amendmentId} to APIM GIFT`);
           }
+
+          const auditDetails = req?.user?._id ? generateTfmAuditDetails(req.user._id) : undefined;
+
+          await markFacilityAmendmentAsSentToApimGift({
+            facilityId,
+            amendmentId,
+            amendment,
+            auditDetails,
+          });
         }
       }
 
@@ -614,5 +664,7 @@ module.exports = {
   sendAmendmentEmail,
   updateTFMDealLastUpdated,
   createAmendmentTFMObject,
+  hasFacilityAmendmentBeenSentToApimGift,
+  markFacilityAmendmentAsSentToApimGift,
   sendFacilityAmendment,
 };

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -629,7 +629,7 @@ const sendFacilityAmendment = async (req, res) => {
             throw new Error(`Failed to submit facility ${ukefFacilityId} amendment ${amendmentId} to APIM GIFT`);
           }
 
-          const auditDetails = req?.user?._id ? generateTfmAuditDetails(req.user._id) : undefined;
+          const auditDetails = generateTfmAuditDetails(req?.user?._id);
 
           await markFacilityAmendmentAsSentToApimGift({
             facilityId,


### PR DESCRIPTION
# Introduction :pencil2:

Some amendments can be sent to APIM/GIFT multiple times.

This PR should fix that.

## Resolution :heavy_check_mark:

- Add new helpers, `hasFacilityAmendmentBeenSentToApimGift`, `markFacilityAmendmentAsSentToApimGift`
- Call `markFacilityAmendmentAsSentToApimGift` in amendment triggers.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
