### PR TITLE
chore(DTFS2-8519): stop tracking chores on release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,18 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
     "include-component-in-tag": false,
     "packages": {
-        ".": {
-            "release-type": "node",
-            "component": "",
-            "changelog-sections": [
-                { "type": "feat", "section": "Features", "hidden": false },
-                { "type": "fix",  "section": "Bug Fixes", "hidden": false },
-                { "type": "chore", "section": "Chores", "hidden": false },
-                { "type": "docs",  "section": "Documentation", "hidden": false },
-                { "type": "revert", "section": "Reverts", "hidden": false },
-                { "type": "style", "section": "Style", "hidden": false }
-            ]
-        }
+        ".": {}
     },
     "pull-request-title-pattern": "chore${scope}: release ${version}",
     "extra-label": "Type: chore,Type: Docs",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,10 @@
 {
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-    "include-component-in-tag": false,
     "packages": {
         ".": {}
     },
-    "pull-request-title-pattern": "chore${scope}: release ${version}",
-    "extra-label": "Type: chore,Type: Docs",
+    "pull-request-title-pattern": "chore(${scope}): release${component} ${version}",
+    "extra-label": "Type: chore, Type: Docs",
     "extra-files": [
         "CHANGELOG.md"
     ]


### PR DESCRIPTION
# Introduction :pencil2:

This PR stops tracking chores on release-please.  It was added to track some important chores in release-please notes

## Resolution :heavy_check_mark:

* Remove chores from release-please-config
