### PR TITLE
fix(DTFS2-8538): amend a gift facility amount - cover percentage

### DIFF
--- a/dtfs-central-api/server/v1/controllers/tfm/amendments/tfm-get-amendments.controller.ts
+++ b/dtfs-central-api/server/v1/controllers/tfm/amendments/tfm-get-amendments.controller.ts
@@ -44,12 +44,15 @@ const mapAmendmentToLatestValue = (
   currency: Currency;
 } => {
   const { amendmentId, value, currency } = amendment;
+
   if (!value) {
     throw new Error('Found amendment does not have a defined value');
   }
+
   if (!currency) {
     throw new Error('Found amendment does not have a defined currency');
   }
+
   return { amendmentId: amendmentId.toString(), value, currency };
 };
 
@@ -63,6 +66,7 @@ const mapAmendmentToLatestCompletedDate = (
   if (!coverEndDate) {
     throw new Error('Found amendment does not have a defined coverEndDate');
   }
+
   return {
     amendmentId: amendmentId.toString(),
     coverEndDate,
@@ -75,22 +79,26 @@ const mapAmendmentToFacilityEndDateValues = (amendment: FacilityAmendment): Comp
     if (!facilityEndDate) {
       throw new Error('Found amendment does not have a defined facility end date');
     }
+
     return {
       amendmentId: amendmentId.toString(),
       isUsingFacilityEndDate,
       facilityEndDate,
     };
   }
+
   if (isUsingFacilityEndDate === false) {
     if (!bankReviewDate) {
       throw new Error('Found amendment does not have a defined bank review date');
     }
+
     return {
       amendmentId: amendmentId.toString(),
       isUsingFacilityEndDate,
       bankReviewDate,
     };
   }
+
   return {
     amendmentId: amendmentId.toString(),
     isUsingFacilityEndDate: undefined,
@@ -138,6 +146,7 @@ export const getAmendmentsByFacilityId = async (req: Request, res: Response) => 
       const { status, message } = error;
       return res.status(status).send({ status, message });
     }
+
     return res.status(HttpStatusCode.InternalServerError).send({
       status: HttpStatusCode.InternalServerError,
       message: 'An unknown error occurred when getting amendments by facility id',
@@ -150,6 +159,7 @@ export const getAmendmentsByDealId = async (req: Request, res: Response) => {
 
   try {
     let amendment: Document | Document[] | null;
+
     switch (status) {
       case AMENDMENT_QUERY_STATUSES.IN_PROGRESS:
         amendment = await TfmFacilitiesRepo.findTfmAmendmentsByDealIdAndStatus(dealId, TFM_AMENDMENT_STATUS.IN_PROGRESS);
@@ -179,11 +189,13 @@ export const getAmendmentsByDealId = async (req: Request, res: Response) => {
     console.error('Error getting amendments by deal id:', error);
     if (error instanceof ApiError) {
       const { status: errorStatus, message } = error;
+
       return res.status(errorStatus).send({ status: errorStatus, message });
     }
+
     return res.status(HttpStatusCode.InternalServerError).send({
       status: HttpStatusCode.InternalServerError,
-      message: 'An unknown error occurred when getting amendments by facility id',
+      message: 'An unknown error occurred when getting amendments by deal id',
     });
   }
 };

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
@@ -1,33 +1,44 @@
 const api = require('../api');
-const { hasFacilityAmendmentBeenSentToApimGift, markFacilityAmendmentAsSentToApimGift } = require('./amendment.controller');
+const {
+  hasFacilityAmendmentBeenSentToApimGift,
+  markFacilityAmendmentAsSentToApimGift,
+  parseCoverPercentage,
+  enrichAmendmentForApimGift,
+} = require('./amendment.controller');
 
 jest.mock('../api', () => ({
   updateFacilityAmendment: jest.fn(),
 }));
 
 describe('hasFacilityAmendmentBeenSentToApimGift', () => {
-  it('should return true when amendment apimGift facilityAmendmentSent is true', () => {
-    // Act
-    const result = hasFacilityAmendmentBeenSentToApimGift({ apimGift: { facilityAmendmentSent: true } });
+  describe('when amendment apimGift facilityAmendmentSent is true', () => {
+    it('should return true', () => {
+      // Act
+      const result = hasFacilityAmendmentBeenSentToApimGift({ apimGift: { facilityAmendmentSent: true } });
 
-    // Assert
-    expect(result).toBe(true);
+      // Assert
+      expect(result).toBe(true);
+    });
   });
 
-  it('should return false when amendment does not have apimGift', () => {
-    // Act
-    const result = hasFacilityAmendmentBeenSentToApimGift({});
+  describe('when amendment does not have apimGift', () => {
+    it('should return false', () => {
+      // Act
+      const result = hasFacilityAmendmentBeenSentToApimGift({});
 
-    // Assert
-    expect(result).toBe(false);
+      // Assert
+      expect(result).toBe(false);
+    });
   });
 
-  it('should return false when amendment is undefined', () => {
-    // Act
-    const result = hasFacilityAmendmentBeenSentToApimGift(undefined);
+  describe('when amendment is undefined', () => {
+    it('should return false', () => {
+      // Act
+      const result = hasFacilityAmendmentBeenSentToApimGift(undefined);
 
-    // Assert
-    expect(result).toBe(false);
+      // Assert
+      expect(result).toBe(false);
+    });
   });
 });
 
@@ -40,48 +51,137 @@ describe('markFacilityAmendmentAsSentToApimGift', () => {
     jest.clearAllMocks();
   });
 
-  it('should set facilityAmendmentSent to true and keep existing apimGift fields', async () => {
-    // Act
-    await markFacilityAmendmentAsSentToApimGift({
-      facilityId,
-      amendmentId,
-      amendment: {
+  describe('when amendment has existing apimGift fields', () => {
+    it('should set facilityAmendmentSent to true and keep existing fields', async () => {
+      // Act
+      await markFacilityAmendmentAsSentToApimGift({
+        facilityId,
+        amendmentId,
+        amendment: {
+          apimGift: {
+            existingField: 'existing-value',
+          },
+        },
+        auditDetails,
+      });
+
+      // Assert
+      const expectedObject = {
         apimGift: {
           existingField: 'existing-value',
+          facilityAmendmentSent: true,
         },
-      },
-      auditDetails,
+        shouldNotUpdateTimestamp: true,
+      };
+
+      expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(1, facilityId, amendmentId, expectedObject, auditDetails);
     });
-
-    // Assert
-    const expectedObject = {
-      apimGift: {
-        existingField: 'existing-value',
-        facilityAmendmentSent: true,
-      },
-      shouldNotUpdateTimestamp: true,
-    };
-
-    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(1, facilityId, amendmentId, expectedObject, auditDetails);
   });
 
-  it('should set facilityAmendmentSent to true when apimGift is missing', async () => {
-    // Act
-    await markFacilityAmendmentAsSentToApimGift({
-      facilityId,
-      amendmentId,
-      amendment: {},
-      auditDetails,
+  describe('when amendment apimGift is missing', () => {
+    it('should set facilityAmendmentSent to true', async () => {
+      // Act
+      await markFacilityAmendmentAsSentToApimGift({
+        facilityId,
+        amendmentId,
+        amendment: {},
+        auditDetails,
+      });
+
+      // Assert
+      const expectedObject = {
+        apimGift: {
+          facilityAmendmentSent: true,
+        },
+        shouldNotUpdateTimestamp: true,
+      };
+
+      expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(1, facilityId, amendmentId, expectedObject, auditDetails);
     });
+  });
+});
 
-    // Assert
-    const expectedObject = {
-      apimGift: {
-        facilityAmendmentSent: true,
-      },
-      shouldNotUpdateTimestamp: true,
-    };
+describe('parseCoverPercentage', () => {
+  describe('when value is a number', () => {
+    it('should return the value unchanged', () => {
+      // Act
+      const result = parseCoverPercentage(80);
 
-    expect(api.updateFacilityAmendment).toHaveBeenNthCalledWith(1, facilityId, amendmentId, expectedObject, auditDetails);
+      // Assert
+      expect(result).toBe(80);
+    });
+  });
+
+  describe('when value is a percentage string', () => {
+    it('should parse and return the numeric value', () => {
+      // Act
+      const result = parseCoverPercentage(' 75% ');
+
+      // Assert
+      expect(result).toBe(75);
+    });
+  });
+
+  describe('when value type is unsupported', () => {
+    it('should return null', () => {
+      // Act
+      const result = parseCoverPercentage({ value: 80 });
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe('enrichAmendmentForApimGift', () => {
+  describe('when amendment coveredPercentage can be parsed', () => {
+    it('should keep amendment coveredPercentage', () => {
+      // Arrange
+      const amendment = { coveredPercentage: '95%', amendmentId: 'amendment-1' };
+      const facilitySnapshot = { coverPercentage: '80%' };
+
+      // Act
+      const result = enrichAmendmentForApimGift(amendment, facilitySnapshot);
+
+      // Assert
+      expect(result).toEqual({
+        ...amendment,
+        coveredPercentage: 95,
+      });
+    });
+  });
+
+  describe('when amendment coveredPercentage is missing and facility coverPercentage is present', () => {
+    it('should fallback to facility coverPercentage', () => {
+      // Arrange
+      const amendment = { amendmentId: 'amendment-2' };
+      const facilitySnapshot = { coverPercentage: '80%' };
+
+      // Act
+      const result = enrichAmendmentForApimGift(amendment, facilitySnapshot);
+
+      // Assert
+      expect(result).toEqual({
+        ...amendment,
+        coveredPercentage: 80,
+      });
+    });
+  });
+
+  describe('when facility coverPercentage is unavailable and coveredPercentage is present', () => {
+    it('should fallback to facility coveredPercentage', () => {
+      // Arrange
+      const amendment = { amendmentId: 'amendment-3' };
+      const facilitySnapshot = { coveredPercentage: '70%' };
+
+      // Act
+      const result = enrichAmendmentForApimGift(amendment, facilitySnapshot);
+
+      // Assert
+      expect(result).toEqual({
+        ...amendment,
+        coveredPercentage: 70,
+      });
+    });
   });
 });

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-apimGiftHelpers.test.js
@@ -112,6 +112,18 @@ describe('parseCoverPercentage', () => {
     });
   });
 
+  describe('when value is a non-finite number', () => {
+    it('should return null', () => {
+      // Act
+      const nanResult = parseCoverPercentage(Number.NaN);
+      const infinityResult = parseCoverPercentage(Number.POSITIVE_INFINITY);
+
+      // Assert
+      expect(nanResult).toBeNull();
+      expect(infinityResult).toBeNull();
+    });
+  });
+
   describe('when value is a percentage string', () => {
     it('should parse and return the numeric value', () => {
       // Act
@@ -119,6 +131,16 @@ describe('parseCoverPercentage', () => {
 
       // Assert
       expect(result).toBe(75);
+    });
+  });
+
+  describe('when value is an invalid percentage string', () => {
+    it('should return null', () => {
+      // Act
+      const result = parseCoverPercentage('not-a-number%');
+
+      // Assert
+      expect(result).toBeNull();
     });
   });
 
@@ -181,6 +203,40 @@ describe('enrichAmendmentForApimGift', () => {
       expect(result).toEqual({
         ...amendment,
         coveredPercentage: 70,
+      });
+    });
+  });
+
+  describe('when amendment coveredPercentage is invalid and facility coverPercentage is present', () => {
+    it('should fallback to facility coverPercentage', () => {
+      // Arrange
+      const amendment = { amendmentId: 'amendment-4', coveredPercentage: 'bad-value%' };
+      const facilitySnapshot = { coverPercentage: '65%' };
+
+      // Act
+      const result = enrichAmendmentForApimGift(amendment, facilitySnapshot);
+
+      // Assert
+      expect(result).toEqual({
+        ...amendment,
+        coveredPercentage: 65,
+      });
+    });
+  });
+
+  describe('when amendment coveredPercentage is 0 and facility has a value', () => {
+    it('should keep amendment coveredPercentage', () => {
+      // Arrange
+      const amendment = { amendmentId: 'amendment-5', coveredPercentage: 0 };
+      const facilitySnapshot = { coverPercentage: '65%' };
+
+      // Act
+      const result = enrichAmendmentForApimGift(amendment, facilitySnapshot);
+
+      // Assert
+      expect(result).toEqual({
+        ...amendment,
+        coveredPercentage: 0,
       });
     });
   });

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-sendFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-sendFacilityAmendment.test.js
@@ -185,7 +185,13 @@ describe('sendFacilityAmendment', () => {
 
       await sendFacilityAmendment(req, res);
 
-      expect(canSendAmendmentsToApimGift).toHaveBeenNthCalledWith(1, amendment);
+      expect(canSendAmendmentsToApimGift).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          ...amendment,
+          coveredPercentage: null,
+        }),
+      );
       expect(console.info).toHaveBeenNthCalledWith(2, 'TFM facility %s sendFacilityAmendment - calling canSendAmendmentsToApimGift', facilityId);
     });
 

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -56,7 +56,7 @@ const markFacilityAmendmentAsSentToApimGift = async ({ facilityId, amendmentId, 
 /**
  * Parses cover percentage values into a usable number.
  * - GEF facilities use `coverPercentage` (number).
- * - BSS/EWCS facilities use `coveredPercentage` (string number).
+ * - BSS/EWCS facilities use `coveredPercentage` (number string).
  *
  * @param {unknown} value - Candidate cover percentage value.
  * @returns {number | null} Parsed percentage value, or null when unavailable/invalid.

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -63,13 +63,13 @@ const markFacilityAmendmentAsSentToApimGift = async ({ facilityId, amendmentId, 
  */
 const parseCoverPercentage = (value) => {
   if (typeof value === 'number') {
-    return value;
+    return Number.isFinite(value) ? value : null;
   }
 
   if (typeof value === 'string') {
     const parsedValue = Number(value.replace(/%/g, '').trim());
 
-    return parsedValue;
+    return Number.isFinite(parsedValue) ? parsedValue : null;
   }
 
   return null;
@@ -83,11 +83,12 @@ const parseCoverPercentage = (value) => {
  * @returns {object} Amendment object with normalized coveredPercentage.
  */
 const enrichAmendmentForApimGift = (amendment, facilitySnapshot) => {
-  const coverPercentageFromFacility = parseCoverPercentage(facilitySnapshot?.coverPercentage || facilitySnapshot?.coveredPercentage);
+  const amendmentCoveredPercentage = parseCoverPercentage(amendment?.coveredPercentage);
+  const coverPercentageFromFacility = parseCoverPercentage(facilitySnapshot?.coverPercentage ?? facilitySnapshot?.coveredPercentage);
 
   return {
     ...amendment,
-    coveredPercentage: parseCoverPercentage(amendment?.coveredPercentage) || coverPercentageFromFacility,
+    coveredPercentage: amendmentCoveredPercentage ?? coverPercentageFromFacility,
   };
 };
 

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -54,6 +54,44 @@ const markFacilityAmendmentAsSentToApimGift = async ({ facilityId, amendmentId, 
 };
 
 /**
+ * Parses cover percentage values into a usable number.
+ * - GEF facilities use `coverPercentage` (number).
+ * - BSS/EWCS facilities use `coveredPercentage` (string number).
+ *
+ * @param {unknown} value - Candidate cover percentage value.
+ * @returns {number | null} Parsed percentage value, or null when unavailable/invalid.
+ */
+const parseCoverPercentage = (value) => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsedValue = Number(value.replace(/%/g, '').trim());
+
+    return parsedValue;
+  }
+
+  return null;
+};
+
+/**
+ * Enriches an amendment with a covered percentage suitable for APIM GIFT mapping.
+ *
+ * @param {object} amendment - The amendment object.
+ * @param {object} facilitySnapshot - The related facility snapshot object.
+ * @returns {object} Amendment object with normalized coveredPercentage.
+ */
+const enrichAmendmentForApimGift = (amendment, facilitySnapshot) => {
+  const coverPercentageFromFacility = parseCoverPercentage(facilitySnapshot?.coverPercentage || facilitySnapshot?.coveredPercentage);
+
+  return {
+    ...amendment,
+    coveredPercentage: parseCoverPercentage(amendment?.coveredPercentage) || coverPercentageFromFacility,
+  };
+};
+
+/**
  * Sends amendment-related notification emails when eligible.
  *
  * @param {string} amendmentId - The amendment identifier.
@@ -456,7 +494,9 @@ const updateFacilityAmendment = async (req, res) => {
         if (couldSendToApimGift) {
           console.info('TFM facility %s updateFacilityAmendment - calling canSendAmendmentsToApimGift', facilityId);
 
-          const { canSendAmendmentsToApimGift: canSendToApimGift, amendmentPayloads } = canSendAmendmentsToApimGift(amendment);
+          const amendmentForApimGift = enrichAmendmentForApimGift(amendment, facility.facilitySnapshot);
+
+          const { canSendAmendmentsToApimGift: canSendToApimGift, amendmentPayloads } = canSendAmendmentsToApimGift(amendmentForApimGift);
 
           if (canSendToApimGift) {
             console.info('TFM facility %s updateFacilityAmendment - calling submitFacilityAmendmentsToApimGift', facilityId);
@@ -616,7 +656,9 @@ const sendFacilityAmendment = async (req, res) => {
       if (couldSendToApimGift) {
         console.info('TFM facility %s sendFacilityAmendment - calling canSendAmendmentsToApimGift', facilityId);
 
-        const { canSendAmendmentsToApimGift: canSendToApimGift, amendmentPayloads } = canSendAmendmentsToApimGift(amendment);
+        const amendmentForApimGift = enrichAmendmentForApimGift(amendment, facility.facilitySnapshot);
+
+        const { canSendAmendmentsToApimGift: canSendToApimGift, amendmentPayloads } = canSendAmendmentsToApimGift(amendmentForApimGift);
 
         if (canSendToApimGift) {
           console.info('TFM facility %s sendFacilityAmendment - calling submitFacilityAmendmentsToApimGift', facilityId);
@@ -660,6 +702,8 @@ module.exports = {
   getAmendmentByFacilityId,
   getAmendmentsByDealId,
   getAllAmendments,
+  parseCoverPercentage,
+  enrichAmendmentForApimGift,
   submitToAcbs,
   sendAmendmentEmail,
   updateTFMDealLastUpdated,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-cover-percentage/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-cover-percentage/index.ts
@@ -32,8 +32,8 @@ export const toNumber = (value: string | number | null | undefined): number | nu
 
 /**
  * Get facility "cover percentage" as a number for APIM GIFT mapping.
- * - GEF deals use `coverPercentage` (number).
- * - BSS/EWCS deals use `coveredPercentage` (string number).
+ * - GEF facilities use `coverPercentage` (number).
+ * - BSS/EWCS facilities use `coveredPercentage` (string number).
  * @param {GetCoverPercentageParams} params - Inputs required to determine which source field to use.
  * @param {TfmFacilitySnapshot} params.facilitySnapshot - Facility snapshot containing cover percentage fields.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if deal is BSS/EWCS.

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-cover-percentage/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-cover-percentage/index.ts
@@ -33,7 +33,7 @@ export const toNumber = (value: string | number | null | undefined): number | nu
 /**
  * Get facility "cover percentage" as a number for APIM GIFT mapping.
  * - GEF facilities use `coverPercentage` (number).
- * - BSS/EWCS facilities use `coveredPercentage` (string number).
+ * - BSS/EWCS facilities use `coveredPercentage` (number string).
  * @param {GetCoverPercentageParams} params - Inputs required to determine which source field to use.
  * @param {TfmFacilitySnapshot} params.facilitySnapshot - Facility snapshot containing cover percentage fields.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if deal is BSS/EWCS.


### PR DESCRIPTION
# Introduction :pencil2:

An `amount` field in the payload was always being sent as null, due to a missing cover percentage.

## Resolution :heavy_check_mark:

- Create new helper functions:
  - `parseCoverPercentage`
  - `enrichAmendmentForApimGift`
- Update `updateFacilityAmendment` and `sendFacilityAmendment` to consume new helper functions.

## Miscellaneous :heavy_plus_sign:

- Minor readability improvements.
- Fix a couple of typos.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
