### PR TITLE
chore(DTFS2-8365): handle new credit rating format for ACBS mapping

### DIFF
--- a/azure-functions/acbs/constants/deal.js
+++ b/azure-functions/acbs/constants/deal.js
@@ -36,6 +36,11 @@ const EXPORTER_CREDIT_RATING = {
   BB_MINUS: 'Good (BB-)',
 };
 
+const CREDIT_RATING = {
+  B_PLUS: 'B+',
+  BB_MINUS: 'BB-',
+};
+
 const UKEF_ID = {
   PENDING: 'PENDING',
   TEST: '100000',
@@ -50,5 +55,6 @@ module.exports = {
   COUNTRY,
   UNITED_KINGDOM,
   EXPORTER_CREDIT_RATING,
+  CREDIT_RATING,
   UKEF_ID,
 };

--- a/azure-functions/acbs/mappings/facility/helpers/get-credit-rating-code.js
+++ b/azure-functions/acbs/mappings/facility/helpers/get-credit-rating-code.js
@@ -1,9 +1,12 @@
 const CONSTANTS = require('../../../constants');
 
+const { EXPORTER_CREDIT_RATING, CREDIT_RATING } = CONSTANTS.DEAL;
+
 /**
  * Returns ACBS credit rating code based on deal's exporter credit rating.
  * `AIN` = B+(14)
  * `MIN` = TFM value
+ * Handles both the old and new style of credit rating values
  * @param {object} deal Deal object
  * @returns {string} ACBS credit rating code, defaults to `B+(14)`
  */
@@ -16,12 +19,20 @@ const getCreditRatingCode = (deal) => {
   // `MIN` = TFM value
   if (deal.tfm) {
     switch (deal.tfm.exporterCreditRating) {
-      // BB- (13)
-      case CONSTANTS.DEAL.EXPORTER_CREDIT_RATING.BB_MINUS:
+      // BB- (13) for Good (BB-)
+      case EXPORTER_CREDIT_RATING.BB_MINUS:
         return CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS;
 
-      // B+ (14)
-      case CONSTANTS.DEAL.EXPORTER_CREDIT_RATING.B_PLUS:
+      // BB- (13) for BB-
+      case CREDIT_RATING.BB_MINUS:
+        return CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS;
+
+      // B+ (14) for Acceptable (B+)
+      case EXPORTER_CREDIT_RATING.B_PLUS:
+        return CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS;
+
+      // B+ (14) for B+
+      case CREDIT_RATING.B_PLUS:
         return CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS;
 
       // Not know (98)

--- a/azure-functions/acbs/mappings/facility/helpers/get-credit-rating-code.js
+++ b/azure-functions/acbs/mappings/facility/helpers/get-credit-rating-code.js
@@ -5,10 +5,10 @@ const { EXPORTER_CREDIT_RATING, CREDIT_RATING } = CONSTANTS.DEAL;
 /**
  * Returns ACBS credit rating code based on deal's exporter credit rating.
  * `AIN` = B+(14)
- * `MIN` = TFM value
- * Handles both the old and new style of credit rating values
+ * `MIN` = TFM value if BB- or B+, otherwise Not known (98)
+ * Handles both the old and new style of stored credit rating values
  * @param {object} deal Deal object
- * @returns {string} ACBS credit rating code, defaults to `B+(14)`
+ * @returns {string} ACBS credit rating code`
  */
 const getCreditRatingCode = (deal) => {
   // `AIN` = B+(14)
@@ -19,19 +19,13 @@ const getCreditRatingCode = (deal) => {
   // `MIN` = TFM value
   if (deal.tfm) {
     switch (deal.tfm.exporterCreditRating) {
-      // BB- (13) for Good (BB-)
+      // BB- (13) for Good (BB-) or BB-
       case EXPORTER_CREDIT_RATING.BB_MINUS:
-        return CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS;
-
-      // BB- (13) for BB-
       case CREDIT_RATING.BB_MINUS:
         return CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS;
 
-      // B+ (14) for Acceptable (B+)
+      // B+ (14) for Acceptable (B+) or B+
       case EXPORTER_CREDIT_RATING.B_PLUS:
-        return CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS;
-
-      // B+ (14) for B+
       case CREDIT_RATING.B_PLUS:
         return CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS;
 

--- a/azure-functions/acbs/mappings/facility/helpers/get-credit-rating-code.test.js
+++ b/azure-functions/acbs/mappings/facility/helpers/get-credit-rating-code.test.js
@@ -1,0 +1,108 @@
+const getCreditRatingCode = require('./get-credit-rating-code');
+const CONSTANTS = require('../../../constants');
+
+const { EXPORTER_CREDIT_RATING, CREDIT_RATING } = CONSTANTS.DEAL;
+
+describe('getCreditRatingCode', () => {
+  it(`should return ${CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS} for AIN submission type`, () => {
+    const deal = {
+      dealSnapshot: {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.AIN,
+      },
+    };
+
+    const result = getCreditRatingCode(deal);
+
+    expect(result).toEqual(CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS);
+  });
+
+  it(`should return ${CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS} for AIN submission type even when credit rating is different`, () => {
+    const deal = {
+      dealSnapshot: {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.AIN,
+      },
+      fm: {
+        exporterCreditRating: EXPORTER_CREDIT_RATING.BB_MINUS,
+      },
+    };
+
+    const result = getCreditRatingCode(deal);
+
+    expect(result).toEqual(CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS);
+  });
+
+  it(`should return ${CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS} for MIN submission type with ${EXPORTER_CREDIT_RATING.BB_MINUS} exporter credit rating`, () => {
+    const deal = {
+      dealSnapshot: {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIN,
+      },
+      tfm: {
+        exporterCreditRating: EXPORTER_CREDIT_RATING.BB_MINUS,
+      },
+    };
+
+    const result = getCreditRatingCode(deal);
+
+    expect(result).toEqual(CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS);
+  });
+
+  it(`should return ${CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS} for MIN submission type with ${CREDIT_RATING.BB_MINUS} exporter credit rating`, () => {
+    const deal = {
+      dealSnapshot: {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIN,
+      },
+      tfm: {
+        exporterCreditRating: CREDIT_RATING.BB_MINUS,
+      },
+    };
+
+    const result = getCreditRatingCode(deal);
+
+    expect(result).toEqual(CONSTANTS.FACILITY.CREDIT_RATING.BB_MINUS);
+  });
+
+  it(`should return ${CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS} for MIN submission type with ${EXPORTER_CREDIT_RATING.B_PLUS} exporter credit rating`, () => {
+    const deal = {
+      dealSnapshot: {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIN,
+      },
+      tfm: {
+        exporterCreditRating: EXPORTER_CREDIT_RATING.B_PLUS,
+      },
+    };
+
+    const result = getCreditRatingCode(deal);
+
+    expect(result).toEqual(CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS);
+  });
+
+  it(`should return ${CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS} for MIN submission type with ${CREDIT_RATING.B_PLUS} exporter credit rating`, () => {
+    const deal = {
+      dealSnapshot: {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIN,
+      },
+      tfm: {
+        exporterCreditRating: CREDIT_RATING.B_PLUS,
+      },
+    };
+
+    const result = getCreditRatingCode(deal);
+
+    expect(result).toEqual(CONSTANTS.FACILITY.CREDIT_RATING.B_PLUS);
+  });
+
+  it(`should return ${CONSTANTS.FACILITY.CREDIT_RATING.NOT_KNOWN} for MIN submission type with unknown exporter credit rating`, () => {
+    const deal = {
+      dealSnapshot: {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIN,
+      },
+      tfm: {
+        exporterCreditRating: 'AAA',
+      },
+    };
+
+    const result = getCreditRatingCode(deal);
+
+    expect(result).toEqual(CONSTANTS.FACILITY.CREDIT_RATING.NOT_KNOWN);
+  });
+});


### PR DESCRIPTION
# Introduction :pencil2:

Handle new credit rating storage of B+ and BB- in ACBS credit rating mapping

## Resolution :heavy_check_mark:

* Add to case statement to handle new credit rating storage
* added test

