### PR TITLE
fix(DTFS2-8432): amend a facility - apim/gift - manual amendment

### DIFF
--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -437,7 +437,10 @@ describe('updated facility amendment API call', () => {
             api.getAmendmentById = jest.fn().mockResolvedValue({
               ...MOCK_AMENDMENT,
               requireUkefApproval: true,
-              // bankDecision not yet recorded
+              changeFacilityValue: true,
+              changeCoverEndDate: false,
+              currentValue: 100,
+              value: 130,
             });
 
             // Act
@@ -474,7 +477,10 @@ describe('updated facility amendment API call', () => {
               submitted: true,
               effectiveDate: bankDecisionEffectiveDate,
             },
-            tfm: { ...MOCK_AMENDMENT.tfm, coverEndDate: 1706745600000 },
+            tfm: {
+              ...MOCK_AMENDMENT.tfm,
+              coverEndDate: 1706745600000,
+            },
           });
 
           // Act

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-updateFacilityAmendment.test.js
@@ -421,6 +421,69 @@ describe('updated facility amendment API call', () => {
             expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
           });
         });
+
+        describe('when the amendment is manual (requireUkefApproval) and bank decision has not yet been submitted', () => {
+          it('should not call APIM GIFT', async () => {
+            // Arrange
+            const updateAmendmentBody = {
+              status: TFM_AMENDMENT_STATUS.IN_PROGRESS,
+              submittedByPim: true,
+            };
+
+            const { req } = createMocks({ params: { amendmentId, facilityId }, user: underwriter, body: updateAmendmentBody });
+
+            mockIsTfmApimGiftIntegrationEnabled.mockReturnValue(true);
+
+            api.getAmendmentById = jest.fn().mockResolvedValue({
+              ...MOCK_AMENDMENT,
+              requireUkefApproval: true,
+              // bankDecision not yet recorded
+            });
+
+            // Act
+            await amendmentController.updateFacilityAmendment(req, res);
+
+            // Assert
+            expect(submitFacilityAmendmentsToApimGift).not.toHaveBeenCalled();
+            expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+          });
+        });
+      });
+
+      describe('when the amendment is manual (requireUkefApproval) and bank decision has been submitted', () => {
+        it('should call APIM GIFT with the bank decision effective date', async () => {
+          // Arrange
+          const bankDecisionEffectiveDate = 1704067200;
+          const updateAmendmentBody = {
+            status: TFM_AMENDMENT_STATUS.COMPLETED,
+            submittedByPim: true,
+          };
+
+          const { req } = createMocks({ params: { amendmentId, facilityId }, user: underwriter, body: updateAmendmentBody });
+
+          mockIsTfmApimGiftIntegrationEnabled.mockReturnValue(true);
+
+          api.getAmendmentById = jest.fn().mockResolvedValue({
+            ...MOCK_AMENDMENT,
+            requireUkefApproval: true,
+            changeFacilityValue: false,
+            changeCoverEndDate: true,
+            effectiveDate: bankDecisionEffectiveDate,
+            bankDecision: {
+              decision: 'Proceed',
+              submitted: true,
+              effectiveDate: bankDecisionEffectiveDate,
+            },
+            tfm: { ...MOCK_AMENDMENT.tfm, coverEndDate: 1706745600000 },
+          });
+
+          // Act
+          await amendmentController.updateFacilityAmendment(req, res);
+
+          // Assert
+          expect(submitFacilityAmendmentsToApimGift).toHaveBeenCalledTimes(1);
+          expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+        });
       });
     });
   });

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -494,8 +494,20 @@ const updateFacilityAmendment = async (req, res) => {
         // Amend facility TFM properties
         await amendIssuedFacility(amendment, facility, tfmDeal, generateTfmAuditDetails(req.user._id));
 
+        // Manual amendments must wait until the bank decision is submitted before APIM GIFT receives the effective date
+        /**
+         * Amendments that require UKEF approval are considered manual amendments.
+         * The bank decision must be submitted before sending to APIM GIFT to ensure the effective date is available for the amendment payload.
+         */
+        const isManualAmendment = Boolean(amendment?.requireUkefApproval);
+        const bankDecisionIsSubmitted = Boolean(amendment?.bankDecision?.submitted);
+
         const couldSendToApimGift =
-          isTfmApimGiftIntegrationEnabled() && !isTaskUpdate && isSubmittedByPim && !hasFacilityAmendmentBeenSentToApimGift(amendment);
+          isTfmApimGiftIntegrationEnabled() &&
+          !isTaskUpdate &&
+          isSubmittedByPim &&
+          !hasFacilityAmendmentBeenSentToApimGift(amendment) &&
+          (!isManualAmendment || bankDecisionIsSubmitted);
 
         if (couldSendToApimGift) {
           console.info('TFM facility %s updateFacilityAmendment - calling canSendAmendmentsToApimGift', facilityId);


### PR DESCRIPTION
# Introduction :pencil2:

Manual amendments (amendments that require UKEF and bank approval), were being sent to APIM before the bank decision was submitted. Therefore, for facility amount amendments, the date would not be populated.

## Resolution :heavy_check_mark:

- Update amendment controller to use `isManualAmendment` and `bankDecisionIsSubmitted` flags.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
