### PR TITLE
fix(DTFS2-8558): amend a gift facility - amount mapping

### DIFF
--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
@@ -91,7 +91,7 @@ describe('mapAmount', () => {
       expect(result).toEqual(24);
     });
 
-    it('should round decimal adjusted amount up to the nearest integer when .5 or above', () => {
+    it('should round decimal adjusted amount up to the nearest integer when above .5', () => {
       // Arrange
       const params = {
         coveredPercentage: 80,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.test.ts
@@ -75,6 +75,36 @@ describe('mapAmount', () => {
       // Assert
       expect(result).toEqual(32);
     });
+
+    it('should round decimal adjusted amount down to the nearest integer when below .5', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: 80,
+        newAmount: 130.25,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      expect(result).toEqual(24);
+    });
+
+    it('should round decimal adjusted amount up to the nearest integer when .5 or above', () => {
+      // Arrange
+      const params = {
+        coveredPercentage: 80,
+        newAmount: 130.75,
+        previousAmount: 100,
+      };
+
+      // Act
+      const result = mapAmount(params);
+
+      // Assert
+      expect(result).toEqual(25);
+    });
   });
 
   describe('when coveredPercentage is null', () => {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
@@ -20,7 +20,7 @@ export const mapAmount = ({ coveredPercentage, newAmount, previousAmount }: MapA
   const amountDifference = getAmountDifference(previousAmount, newAmount);
 
   /**
-   * Calculate newAmount adjusted by the covered percentage.
+   * Calculate the amount adjusted by the covered percentage.
    * Use Math.round to round to the nearest integer and avoid floating point precision issues.
    * For example, 232000.2 becomes 232000 and 232000.6 becomes 232001.
    */

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/index.ts
@@ -19,8 +19,12 @@ const {
 export const mapAmount = ({ coveredPercentage, newAmount, previousAmount }: MapAmountParams): number | null => {
   const amountDifference = getAmountDifference(previousAmount, newAmount);
 
-  // calculate newAmount adjusted by the covered percentage
-  const amount = coveredPercentage ? amountDifference * (coveredPercentage / 100) : null;
+  /**
+   * Calculate newAmount adjusted by the covered percentage.
+   * Use Math.round to round to the nearest integer and avoid floating point precision issues.
+   * For example, 232000.2 becomes 232000 and 232000.6 becomes 232001.
+   */
+  const amount = coveredPercentage ? Math.round(amountDifference * (coveredPercentage / 100)) : null;
 
   return amount;
 };


### PR DESCRIPTION
# Introduction :pencil2:

DTFS amendment payloads to APIM could generate an amount such as `232000.2`, which would fail in APIM TFS.

## Resolution :heavy_check_mark:

- Update `mapAmount` to use `Math.round`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
