### PR TITLE
fix(DTFS2-8561): fixed portal amendments sending amount in GBP to ACBS when foreign currency

### DIFF
--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller-submitToAcbs.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller-submitToAcbs.test.js
@@ -13,6 +13,7 @@ jest.mock('./acbs.controller', () => ({
 }));
 
 jest.mock('../helpers/amendment.helpers', () => ({
+  ...jest.requireActual('../helpers/amendment.helpers'),
   internalAmendmentEmail: jest.fn(),
 }));
 
@@ -28,15 +29,19 @@ describe('submitToAcbs', () => {
     amendmentId: '1234',
     dealId: '00345678910',
     changeFacilityValue: true,
+    value: 3450,
     tfm: {
       exposure: {
-        ukefExposureValue: 2760,
+        ukefExposureValue: 3500,
       },
     },
   };
 
   const facility = {
     _id: 'mock-facility-id',
+    facilitySnapshot: {
+      coverPercentage: 80,
+    },
   };
 
   const tfmDeal = {
@@ -50,6 +55,8 @@ describe('submitToAcbs', () => {
       },
     },
   };
+
+  const expectedUkefExposure = amendment.value * (facility.facilitySnapshot.coverPercentage / 100);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -85,7 +92,7 @@ describe('submitToAcbs', () => {
       },
     });
 
-    expect(result.ukefExposure).toEqual(amendment.tfm.exposure.ukefExposureValue);
+    expect(result.ukefExposure).toEqual(expectedUkefExposure);
   });
 
   describe('when amendment cannot be sent to ACBS', () => {
@@ -106,7 +113,7 @@ describe('submitToAcbs', () => {
       expect(internalAmendmentEmail).not.toHaveBeenCalled();
       expect(acbs.amendAcbsFacility).not.toHaveBeenCalled();
 
-      expect(result.ukefExposure).toEqual(amendment.tfm.exposure.ukefExposureValue);
+      expect(result.ukefExposure).toEqual(expectedUkefExposure);
     });
   });
 

--- a/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/amendment.controller.js
@@ -16,6 +16,7 @@ const {
   sendManualBankDecisionEmail,
   sendFirstTaskEmail,
   internalAmendmentEmail,
+  calculateAcbsUkefExposureValue,
   calculateAcbsUkefExposure,
   addLatestAmendmentValue,
   addLatestAmendmentCoverEndDate,
@@ -461,7 +462,8 @@ const submitToAcbs = async (amendment, facility, ukefFacilityId) => {
     const amendmentWithUkefExposure = amendment;
 
     if (amendment.changeFacilityValue) {
-      amendmentWithUkefExposure.ukefExposure = amendment.tfm.exposure.ukefExposureValue;
+      // Calculate UKEF exposure for ACBS from the amendment value and facility coverPercentage
+      amendmentWithUkefExposure.ukefExposure = calculateAcbsUkefExposureValue(amendment.value, facility.facilitySnapshot.coverPercentage);
     }
 
     if (facility._id && amendmentWithUkefExposure && tfmDeal?.tfm) {

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
@@ -465,12 +465,12 @@ const addLatestAmendmentFacilityEndDate = async (tfmObject, latestFacilityEndDat
 };
 
 /**
- * calculates the ukef exposure for ACBS from the provided value and coveredPercentage
- * @param {Number} value
+ * calculates the ukef exposure for ACBS from the provided newAmount and coveredPercentage
+ * @param {Number} newAmount
  * @param {Number} coveredPercentage
  * @returns {Number} calculated ukef exposure value
  */
-const calculateAcbsUkefExposureValue = (value, coveredPercentage) => value * (coveredPercentage / 100);
+const calculateAcbsUkefExposureValue = (newAmount, coveredPercentage) => newAmount * (coveredPercentage / 100);
 
 /**
  * Calculates UKEF Exposure for the defined facility

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
@@ -465,6 +465,14 @@ const addLatestAmendmentFacilityEndDate = async (tfmObject, latestFacilityEndDat
 };
 
 /**
+ * calculates the ukef exposure for ACBS from the provided value and coveredPercentage
+ * @param {Number} value
+ * @param {Number} coveredPercentage
+ * @returns {Number} calculated ukef exposure value
+ */
+const calculateAcbsUkefExposureValue = (value, coveredPercentage) => value * (coveredPercentage / 100);
+
+/**
  * Calculates UKEF Exposure for the defined facility
  * based on updated facility amount and original cover percentage.
  * @param {object} payload Amendment payload
@@ -474,7 +482,7 @@ const calculateAcbsUkefExposure = (payload) => {
   if (payload?.value && payload?.coveredPercentage) {
     return {
       ...payload,
-      ukefExposure: payload.value * (payload.coveredPercentage / 100),
+      ukefExposure: calculateAcbsUkefExposureValue(payload.value, payload.coveredPercentage),
     };
   }
 
@@ -513,4 +521,5 @@ module.exports = {
   calculateAmendmentDateTenor,
   calculateAmendmentExposure,
   calculateAcbsUkefExposure,
+  calculateAcbsUkefExposureValue,
 };

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -1080,15 +1080,15 @@ describe('formatAmendmentDates', () => {
       coverEndDate: 1761087600000,
     });
   });
+});
 
-  describe('calculateAcbsUkefExposureValue', () => {
-    it('should calculate UKEF exposure correctly', () => {
-      const value = 5000;
-      const coveredPercentage = 12;
+describe('calculateAcbsUkefExposureValue', () => {
+  it('should calculate UKEF exposure correctly', () => {
+    const value = 5000;
+    const coveredPercentage = 12;
 
-      const result = calculateAcbsUkefExposureValue(value, coveredPercentage);
+    const result = calculateAcbsUkefExposureValue(value, coveredPercentage);
 
-      expect(result).toBe(600);
-    });
+    expect(result).toBe(600);
   });
 });

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -11,6 +11,7 @@ const {
   internalAmendmentEmail,
   addLatestAmendmentFacilityEndDate,
   formatAmendmentDates,
+  calculateAcbsUkefExposureValue,
 } = require('./amendment.helpers');
 const CONSTANTS = require('../../constants');
 const { AMENDMENT_UW_DECISION } = require('../../constants/deals');
@@ -1077,6 +1078,17 @@ describe('formatAmendmentDates', () => {
     expect(response).toEqual({
       effectiveDate: 1761087600000,
       coverEndDate: 1761087600000,
+    });
+  });
+
+  describe('calculateAcbsUkefExposureValue', () => {
+    it('should calculate UKEF exposure correctly', () => {
+      const value = 5000;
+      const coveredPercentage = 12;
+
+      const result = calculateAcbsUkefExposureValue(value, coveredPercentage);
+
+      expect(result).toBe(600);
     });
   });
 });


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes an issue with Portal amendments where when a facility has a foreign currency - the amount sent to ACBS was the exposure in GBP rather than the value of the amendment * coverPercentage

## Resolution :heavy_check_mark:

* Changed mapping for portal amendments to send value * coverPercentage to ACBS
* Updated tests

