### PR TITLE
fix(DTFS2-8564): amend a gift facility - date/timezone issue

### DIFF
--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.test.ts
@@ -1,4 +1,4 @@
-import { getFormattedDateStringInTimeZone, getFormattedUTCDateString, TIMEZONE } from '@ukef/dtfs2-common';
+import { getFormattedDateStringInTimeZone, TIMEZONE } from '@ukef/dtfs2-common';
 import { TfmFacilityAmendmentData } from '../../types';
 import { getAmendmentFields } from '.';
 
@@ -25,7 +25,7 @@ describe('getAmendmentFields', () => {
       newAmount: amendment.value,
       previousAmount: amendment.currentValue,
       coverEndDate: getFormattedDateStringInTimeZone(Number(amendment.coverEndDate), TIMEZONE.DEFAULT),
-      effectiveDate: getFormattedUTCDateString(Number(amendment.effectiveDate)),
+      effectiveDate: getFormattedDateStringInTimeZone(Number(amendment.effectiveDate), TIMEZONE.DEFAULT),
       coveredPercentage: null,
     };
 
@@ -46,6 +46,24 @@ describe('getAmendmentFields', () => {
     const expected = '2028-06-21';
 
     expect(result.coverEndDate).toEqual(expected);
+  });
+
+  describe('when the timestamp is UK midnight during BST', () => {
+    it('should not shift effectiveDate by one day', () => {
+      // Arrange
+      const amendment: TfmFacilityAmendmentData = {
+        ...mockBaseAmendment,
+        effectiveDate: new Date('2026-08-11T00:00:00+01:00').getTime() / 1000,
+      };
+
+      // Act
+      const result = getAmendmentFields(amendment);
+
+      // Assert
+      const expected = '2026-08-11';
+
+      expect(result.effectiveDate).toEqual(expected);
+    });
   });
 
   describe('when coverEndDate is not provided', () => {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/amend-facility/get-amendment-fields/index.ts
@@ -1,4 +1,4 @@
-import { getFormattedDateStringInTimeZone, getFormattedUTCDateString, TIMEZONE } from '@ukef/dtfs2-common';
+import { getFormattedDateStringInTimeZone, TIMEZONE } from '@ukef/dtfs2-common';
 import { TfmFacilityAmendmentData } from '../../types';
 
 type AmendmentFields = {
@@ -29,7 +29,7 @@ export const getAmendmentFields = (amendment: TfmFacilityAmendmentData): Amendme
 
   const effectiveDateValue = Number(amendment.effectiveDate);
 
-  const effectiveDate = hasEffectiveDate ? getFormattedUTCDateString(effectiveDateValue) : '';
+  const effectiveDate = hasEffectiveDate ? getFormattedDateStringInTimeZone(effectiveDateValue, TIMEZONE.DEFAULT) : '';
 
   const coveredPercentage = typeof amendment.coveredPercentage === 'number' ? amendment.coveredPercentage : null;
 


### PR DESCRIPTION
# Introduction :pencil2:

- The amendment effective date was being formatted as UTC.
- A stored value of e.g `1786402800` equals `2026-08-10T23:00:00Z`, which is 2026-08-11 in Europe/London.
- UTC formatting therefore produced 2026-08-10 in the payload instead of 2026-08-11.

## Resolution :heavy_check_mark:

- Update `getAmendmentFields` to use `getFormattedDateStringInTimeZone` instead of `getFormattedUTCDateString`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
