### PR TITLE
chore(DTFS2-8565): apim gift integration - facility boolean flags

### DIFF
--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.test.ts
@@ -13,9 +13,9 @@ describe('getFacilityTypeFlags', () => {
       // Assert
       const expected = {
         isBssFacility: true,
+        isCashFacility: false,
+        isContingentFacility: false,
         isEwcsFacility: false,
-        isGefFacility: false,
-        facilityType: mockFacilityType,
       };
 
       expect(result).toEqual(expected);
@@ -33,9 +33,9 @@ describe('getFacilityTypeFlags', () => {
       // Assert
       const expected = {
         isBssFacility: false,
+        isCashFacility: false,
+        isContingentFacility: false,
         isEwcsFacility: true,
-        isGefFacility: false,
-        facilityType: mockFacilityType,
       };
 
       expect(result).toEqual(expected);
@@ -43,7 +43,7 @@ describe('getFacilityTypeFlags', () => {
   });
 
   describe(`when facilityType is ${FACILITY_TYPE.CASH}`, () => {
-    it('should return an object with isGefFacility as true', () => {
+    it('should return an object with isCashFacility as true', () => {
       // Arrange
       const mockFacilityType = FACILITY_TYPE.CASH;
 
@@ -53,9 +53,9 @@ describe('getFacilityTypeFlags', () => {
       // Assert
       const expected = {
         isBssFacility: false,
+        isCashFacility: true,
+        isContingentFacility: false,
         isEwcsFacility: false,
-        isGefFacility: true,
-        facilityType: mockFacilityType,
       };
 
       expect(result).toEqual(expected);
@@ -63,7 +63,7 @@ describe('getFacilityTypeFlags', () => {
   });
 
   describe(`when facilityType is ${FACILITY_TYPE.CONTINGENT}`, () => {
-    it('should return an object with isGefFacility as true', () => {
+    it('should return an object with isContingentFacility as true', () => {
       // Arrange
       const mockFacilityType = FACILITY_TYPE.CONTINGENT;
 
@@ -73,9 +73,9 @@ describe('getFacilityTypeFlags', () => {
       // Assert
       const expected = {
         isBssFacility: false,
+        isCashFacility: false,
+        isContingentFacility: true,
         isEwcsFacility: false,
-        isGefFacility: true,
-        facilityType: mockFacilityType,
       };
 
       expect(result).toEqual(expected);

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.test.ts
@@ -1,0 +1,84 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
+import { getFacilityTypeFlags } from '.';
+
+describe('getFacilityTypeFlags', () => {
+  describe(`when facilityType is ${FACILITY_TYPE.BOND}`, () => {
+    it('should return an object with isBssFacility as true', () => {
+      // Arrange
+      const mockFacilityType = FACILITY_TYPE.BOND;
+
+      // Act
+      const result = getFacilityTypeFlags(mockFacilityType);
+
+      // Assert
+      const expected = {
+        isBssFacility: true,
+        isEwcsFacility: false,
+        isGefFacility: false,
+        facilityType: mockFacilityType,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when facilityType is ${FACILITY_TYPE.LOAN}`, () => {
+    it('should return an object with isEwcsFacility as true', () => {
+      // Arrange
+      const mockFacilityType = FACILITY_TYPE.LOAN;
+
+      // Act
+      const result = getFacilityTypeFlags(mockFacilityType);
+
+      // Assert
+      const expected = {
+        isBssFacility: false,
+        isEwcsFacility: true,
+        isGefFacility: false,
+        facilityType: mockFacilityType,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when facilityType is ${FACILITY_TYPE.CASH}`, () => {
+    it('should return an object with isGefFacility as true', () => {
+      // Arrange
+      const mockFacilityType = FACILITY_TYPE.CASH;
+
+      // Act
+      const result = getFacilityTypeFlags(mockFacilityType);
+
+      // Assert
+      const expected = {
+        isBssFacility: false,
+        isEwcsFacility: false,
+        isGefFacility: true,
+        facilityType: mockFacilityType,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe(`when facilityType is ${FACILITY_TYPE.CONTINGENT}`, () => {
+    it('should return an object with isGefFacility as true', () => {
+      // Arrange
+      const mockFacilityType = FACILITY_TYPE.CONTINGENT;
+
+      // Act
+      const result = getFacilityTypeFlags(mockFacilityType);
+
+      // Assert
+      const expected = {
+        isBssFacility: false,
+        isEwcsFacility: false,
+        isGefFacility: true,
+        facilityType: mockFacilityType,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.ts
@@ -1,0 +1,23 @@
+import { FACILITY_TYPE, FacilityType } from '@ukef/dtfs2-common';
+
+type GetFacilityTypeFlagsReturnShape = {
+  isBssFacility: boolean;
+  isCashFacility: boolean;
+  isContingentFacility: boolean;
+  isEwcsFacility: boolean;
+  facilityType: string;
+};
+
+/**
+ * Return an object with BSS/EWCS/GEF facility flags.
+ * Avoids doing the same checks in other functions.
+ * @param {FacilityType} facilityType - The deal type
+ * @returns {GetFacilityTypeFlagsReturnShape} BSS/EWCS/GEF facility booleans
+ */
+export const getFacilityTypeFlags = (facilityType: FacilityType): GetFacilityTypeFlagsReturnShape => ({
+  isBssFacility: facilityType === FACILITY_TYPE.BOND,
+  isCashFacility: facilityType === FACILITY_TYPE.CASH,
+  isContingentFacility: facilityType === FACILITY_TYPE.CONTINGENT,
+  isEwcsFacility: facilityType === FACILITY_TYPE.LOAN,
+  facilityType,
+});

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/get-facility-type-flags/index.ts
@@ -5,13 +5,12 @@ type GetFacilityTypeFlagsReturnShape = {
   isCashFacility: boolean;
   isContingentFacility: boolean;
   isEwcsFacility: boolean;
-  facilityType: string;
 };
 
 /**
  * Return an object with BSS/EWCS/GEF facility flags.
  * Avoids doing the same checks in other functions.
- * @param {FacilityType} facilityType - The deal type
+ * @param {FacilityType} facilityType - The facility type
  * @returns {GetFacilityTypeFlagsReturnShape} BSS/EWCS/GEF facility booleans
  */
 export const getFacilityTypeFlags = (facilityType: FacilityType): GetFacilityTypeFlagsReturnShape => ({
@@ -19,5 +18,4 @@ export const getFacilityTypeFlags = (facilityType: FacilityType): GetFacilityTyp
   isCashFacility: facilityType === FACILITY_TYPE.CASH,
   isContingentFacility: facilityType === FACILITY_TYPE.CONTINGENT,
   isEwcsFacility: facilityType === FACILITY_TYPE.LOAN,
-  facilityType,
 });

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
@@ -45,13 +45,15 @@ describe('createFacility', () => {
 
   const { facilitySnapshot, tfm } = mockFacility;
 
+  const { type: facilityType } = facilitySnapshot;
+
   const mockUkefIndustryCode = '1003';
 
   const mockNewPartyUrnCreated = true;
 
   const { isBssEwcsDeal, isGefDeal } = getDealTypeFlags(mockDeal.dealSnapshot.dealType);
 
-  const { isBssFacility, isCashFacility, isContingentFacility, isEwcsFacility, facilityType } = getFacilityTypeFlags(mockFacility.facilitySnapshot.type);
+  const { isBssFacility, isCashFacility, isContingentFacility, isEwcsFacility } = getFacilityTypeFlags(facilityType);
 
   const productTypeCode = mapProductTypeCode({ isBssFacility, isGefDeal });
 
@@ -135,7 +137,6 @@ describe('createFacility', () => {
         bssSubtypeName: isBssEwcsDeal ? String(facilitySnapshot.bondType) : undefined,
         currency: facilitySnapshot.currency.id,
         facilityAmount,
-        facilityType,
         isBssFacility,
         isCashFacility,
         isContingentFacility,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
@@ -6,6 +6,7 @@ import { MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS } from '../../../__mocks__/mock-c
 import { MOCK_FACILITY_CATEGORIES } from '../../../__mocks__/mock-facility-categories';
 import { APIM_GIFT_INTEGRATION } from '../constants';
 import { getDealTypeFlags } from './get-deal-type-flags';
+import { getFacilityTypeFlags } from './get-facility-type-flags';
 import { getGuaranteeFeePayableToUkef } from './get-guarantee-fee-payable-to-ukef';
 import { mapCoverPercentage } from './map-cover-percentage';
 import { mapProductTypeCode } from './map-product-type-code';
@@ -50,11 +51,9 @@ describe('createFacility', () => {
 
   const { isBssEwcsDeal, isGefDeal } = getDealTypeFlags(mockDeal.dealSnapshot.dealType);
 
-  const productTypeCode = mapProductTypeCode({
-    isBssEwcsDeal,
-    isGefDeal,
-    facilityCategoryCode: facilitySnapshot.type,
-  });
+  const { isBssFacility, isCashFacility, isContingentFacility, isEwcsFacility, facilityType } = getFacilityTypeFlags(mockFacility.facilitySnapshot.type);
+
+  const productTypeCode = mapProductTypeCode({ isBssFacility, isGefDeal });
 
   const guaranteeFeePayableToUkef = getGuaranteeFeePayableToUkef({
     facilitySnapshot,
@@ -109,7 +108,7 @@ describe('createFacility', () => {
         expiryDate,
         exporterPartyUrn: mockDeal.tfm.parties.exporter.partyUrn,
         facilityAmount,
-        facilityType: facilitySnapshot.type,
+        facilityType,
         isGefDeal,
         monthsOfCover: tfm.exposurePeriodInMonths,
         productTypeCode,
@@ -123,8 +122,9 @@ describe('createFacility', () => {
         guaranteeFeePayableToUkef,
       }),
       counterparties: mapCounterparties({
-        isBssEwcsDeal,
-        isGefDeal,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
         partyUrns: mapPartyUrns({
           deal: mockDeal,
           isBssEwcsDeal,
@@ -135,15 +135,17 @@ describe('createFacility', () => {
         bssSubtypeName: isBssEwcsDeal ? String(facilitySnapshot.bondType) : undefined,
         currency: facilitySnapshot.currency.id,
         facilityAmount,
-        facilityType: facilitySnapshot.type,
-        isBssEwcsDeal,
-        isGefDeal,
+        facilityType,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
+        isEwcsFacility,
       }),
       riskDetails: await mapRiskDetails({
         creditRiskRatings: MOCK_CREDIT_RISK_RATINGS_DESCRIPTIONS,
         dealId: getTfmUkefDealId(mockDeal),
         exporterCreditRating: mockDeal.tfm.exporterCreditRating,
-        facilityType: facilitySnapshot.type,
+        facilityType,
         facilityCategories: MOCK_FACILITY_CATEGORIES,
         industryCode: getIndustryCode(mockDeal),
         isGefDeal,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
@@ -2,6 +2,7 @@ import { TfmDeal, TfmFacility, getTfmUkefDealId } from '@ukef/dtfs2-common';
 import { FacilityCategory } from '../../../api-response-types';
 import { APIM_GIFT_INTEGRATION } from '../constants';
 import { ApimGiftFacilityCreationPayload } from '../types';
+import { getFacilityTypeFlags } from './get-facility-type-flags';
 import { mapPartyUrns } from './map-party-urns';
 import { getIndustryCode } from '../get-industry-code';
 import { mapOverview } from './map-overview';
@@ -62,13 +63,15 @@ export const createFacility = async ({
   const effectiveDate = String(facilityGuaranteeDates?.guaranteeCommencementDate);
   const expiryDate = String(facilityGuaranteeDates?.guaranteeExpiryDate);
 
+  const { isBssFacility, isCashFacility, isContingentFacility, isEwcsFacility, facilityType } = getFacilityTypeFlags(facilitySnapshot.type);
+
   const coverPercentage = mapCoverPercentage({
     facilitySnapshot,
     isBssEwcsDeal,
     isGefDeal,
   });
 
-  const { feeFrequency, feeType, type: facilityType } = facilitySnapshot;
+  const { feeFrequency, feeType } = facilitySnapshot;
 
   const facilityAmount = mapFacilityAmount({
     facilityAmount: facilitySnapshot.value,
@@ -84,11 +87,7 @@ export const createFacility = async ({
    */
   const dayCountBasis = Number(facilitySnapshot.dayCountBasis);
 
-  const productTypeCode = mapProductTypeCode({
-    isBssEwcsDeal,
-    isGefDeal,
-    facilityCategoryCode: facilityType,
-  });
+  const productTypeCode = mapProductTypeCode({ isBssFacility, isGefDeal });
 
   const { exporterCreditRating } = deal.tfm;
 
@@ -144,17 +143,19 @@ export const createFacility = async ({
       guaranteeFeePayableToUkef,
     }),
     counterparties: mapCounterparties({
-      isBssEwcsDeal,
-      isGefDeal,
+      isBssFacility,
+      isCashFacility,
+      isContingentFacility,
       partyUrns,
     }),
     obligations: mapObligations({
       bssSubtypeName,
       currency,
       facilityAmount,
-      facilityType,
-      isBssEwcsDeal,
-      isGefDeal,
+      isBssFacility,
+      isCashFacility,
+      isContingentFacility,
+      isEwcsFacility,
     }),
     riskDetails: await mapRiskDetails({
       creditRiskRatings,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
@@ -63,7 +63,9 @@ export const createFacility = async ({
   const effectiveDate = String(facilityGuaranteeDates?.guaranteeCommencementDate);
   const expiryDate = String(facilityGuaranteeDates?.guaranteeExpiryDate);
 
-  const { isBssFacility, isCashFacility, isContingentFacility, isEwcsFacility, facilityType } = getFacilityTypeFlags(facilitySnapshot.type);
+  const { type: facilityType } = facilitySnapshot;
+
+  const { isBssFacility, isCashFacility, isContingentFacility, isEwcsFacility } = getFacilityTypeFlags(facilityType);
 
   const coverPercentage = mapCoverPercentage({
     facilitySnapshot,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.test.ts
@@ -4,9 +4,10 @@ import { mapCounterparties } from '.';
 const { DEFAULTS } = APIM_GIFT_INTEGRATION;
 
 describe('mapCounterparties', () => {
-  describe('when isBssEwcsDeal is true', () => {
-    const isBssEwcsDeal = true;
-    const isGefDeal = false;
+  describe('when isBssFacility is true', () => {
+    const isBssFacility = true;
+    const isCashFacility = false;
+    const isContingentFacility = false;
 
     describe(`when partyUrns.bondGiver exists`, () => {
       it('should return an array with a "BOND_GIVER" counterparty', () => {
@@ -17,8 +18,9 @@ describe('mapCounterparties', () => {
 
         // Act
         const result = mapCounterparties({
-          isBssEwcsDeal,
-          isGefDeal,
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
           partyUrns: mockPartyUrns,
         });
 
@@ -43,8 +45,9 @@ describe('mapCounterparties', () => {
 
         // Act
         const result = mapCounterparties({
-          isBssEwcsDeal,
-          isGefDeal,
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
           partyUrns: mockPartyUrns,
         });
 
@@ -70,8 +73,9 @@ describe('mapCounterparties', () => {
 
         // Act
         const result = mapCounterparties({
-          isBssEwcsDeal,
-          isGefDeal,
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
           partyUrns: mockPartyUrns,
         });
 
@@ -98,8 +102,9 @@ describe('mapCounterparties', () => {
 
         // Act
         const result = mapCounterparties({
-          isBssEwcsDeal,
-          isGefDeal,
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
           partyUrns: mockPartyUrns,
         });
 
@@ -109,9 +114,10 @@ describe('mapCounterparties', () => {
     });
   });
 
-  describe('when isGefDeal is true', () => {
-    const isGefDeal = true;
-    const isBssEwcsDeal = false;
+  describe('when isCashFacility is true', () => {
+    const isBssFacility = false;
+    const isCashFacility = true;
+    const isContingentFacility = false;
 
     describe(`when partyUrns.issuingBank exists`, () => {
       it('should return an array with an "ISSUING_BANK" counterparty', () => {
@@ -122,8 +128,9 @@ describe('mapCounterparties', () => {
 
         // Act
         const result = mapCounterparties({
-          isBssEwcsDeal,
-          isGefDeal,
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
           partyUrns: mockPartyUrns,
         });
 
@@ -146,8 +153,9 @@ describe('mapCounterparties', () => {
 
         // Act
         const result = mapCounterparties({
-          isBssEwcsDeal,
-          isGefDeal,
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
           partyUrns: mockPartyUrns,
         });
 
@@ -157,15 +165,68 @@ describe('mapCounterparties', () => {
     });
   });
 
-  describe('when isBssEwcsDeal and isGefDeal are both false', () => {
-    const isGefDeal = false;
-    const isBssEwcsDeal = false;
+  describe('when isContingentFacility is true', () => {
+    const isBssFacility = false;
+    const isCashFacility = false;
+    const isContingentFacility = true;
+
+    describe(`when partyUrns.issuingBank exists`, () => {
+      it('should return an array with an "ISSUING_BANK" counterparty', () => {
+        // Arrange
+        const mockPartyUrns = {
+          issuingBank: '00318345',
+        };
+
+        // Act
+        const result = mapCounterparties({
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
+          partyUrns: mockPartyUrns,
+        });
+
+        // Assert
+        const expected = [
+          {
+            counterpartyUrn: mockPartyUrns.issuingBank,
+            roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.GEF.ISSUING_BANK,
+          },
+        ];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe(`when partyUrns.issuingBank does NOT exist`, () => {
+      it('should return an empty array', () => {
+        // Arrange
+        const mockPartyUrns = {};
+
+        // Act
+        const result = mapCounterparties({
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
+          partyUrns: mockPartyUrns,
+        });
+
+        // Assert
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe('when all flags are false', () => {
+    const isCashFacility = false;
+    const isBssFacility = false;
+    const isContingentFacility = false;
 
     it('should return an empty array', () => {
       // Act
       const result = mapCounterparties({
-        isBssEwcsDeal,
-        isGefDeal,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
         partyUrns: {},
       });
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.ts
@@ -11,9 +11,9 @@ type MapCounterpartiesParams = {
 };
 
 /**
- * Maps the counterparties for a given deal type and party URNs.
- * BSS/EWCS - If available, create a "Bond giver" counterparty (from the bank party URN) and a "Bond beneficiary" counterparty (from the buyer party URN).
- * GEF - If available, create an "Issuing bank" counterparty (from the bank party URN).
+ * Maps the counterparties depending on the type of facility and party URNs.
+ * BSS - If available, create a "Bond giver" counterparty (from the bank party URN) and a "Bond beneficiary" counterparty (from the buyer party URN).
+ * Cash, Contingent - If available, create an "Issuing bank" counterparty (from the bank party URN).
  * @param {MapCounterpartiesParams} params - Data required to build the APIM GIFT "counterparties" data.
  * @param {boolean} params.isBssFacility - If the facility is a BSS facility.
  * @param {boolean} params.isCashFacility - If the facility is a Cash facility.

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-counterparties/index.ts
@@ -4,8 +4,9 @@ import { ApimGiftCounterparty, PartyUrns } from '../../types';
 const { DEFAULTS } = APIM_GIFT_INTEGRATION;
 
 type MapCounterpartiesParams = {
-  isBssEwcsDeal: boolean;
-  isGefDeal: boolean;
+  isBssFacility: boolean;
+  isCashFacility: boolean;
+  isContingentFacility: boolean;
   partyUrns: PartyUrns;
 };
 
@@ -14,15 +15,17 @@ type MapCounterpartiesParams = {
  * BSS/EWCS - If available, create a "Bond giver" counterparty (from the bank party URN) and a "Bond beneficiary" counterparty (from the buyer party URN).
  * GEF - If available, create an "Issuing bank" counterparty (from the bank party URN).
  * @param {MapCounterpartiesParams} params - Data required to build the APIM GIFT "counterparties" data.
- * @param {boolean} params.isBssEwcsDeal - If the deal is a BSS/EWCS deal.
- * @param {boolean} params.isGefDeal - If the deal is a GEF deal.
+ * @param {boolean} params.isBssFacility - If the facility is a BSS facility.
+ * @param {boolean} params.isCashFacility - If the facility is a Cash facility.
+ * @param {boolean} params.isContingentFacility - If the facility is a Contingent facility.
  * @param {PartyUrns} params.partyUrns - The party URNs.
  * @returns {ApimGiftCounterparty[]} Mapped counterparties array for the APIM GIFT payload.
  */
-export const mapCounterparties = ({ isBssEwcsDeal, isGefDeal, partyUrns }: MapCounterpartiesParams): ApimGiftCounterparty[] => {
+
+export const mapCounterparties = ({ isBssFacility, isCashFacility, isContingentFacility, partyUrns }: MapCounterpartiesParams): ApimGiftCounterparty[] => {
   const counterparties: ApimGiftCounterparty[] = [];
 
-  if (isBssEwcsDeal) {
+  if (isBssFacility) {
     if (partyUrns.bondGiver) {
       counterparties.push({
         counterpartyUrn: partyUrns.bondGiver,
@@ -40,7 +43,7 @@ export const mapCounterparties = ({ isBssEwcsDeal, isGefDeal, partyUrns }: MapCo
     return counterparties;
   }
 
-  if (isGefDeal && partyUrns.issuingBank) {
+  if ((isCashFacility || isContingentFacility) && partyUrns.issuingBank) {
     counterparties.push({
       counterpartyUrn: partyUrns.issuingBank,
       roleCode: DEFAULTS.COUNTERPARTY_ROLE_CODE.GEF.ISSUING_BANK,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.test.ts
@@ -1,4 +1,3 @@
-import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { APIM_GIFT_INTEGRATION } from '../../constants';
 import { mapObligations } from '.';
 import { mapObligationAmount } from './map-obligation-amount';
@@ -9,31 +8,35 @@ describe('mapObligations', () => {
   const bssSubtypeName = 'Performance bond';
   const currency = 'GBP';
   const facilityAmount = 1500;
-  const facilityType = FACILITY_TYPE.CASH;
 
-  describe('when isBssEwcsDeal is true', () => {
+  describe('when isBssFacility is true', () => {
     it('should return an array with one obligation and mapped subtypeCode', () => {
       // Arrange
-      const isBssEwcsDeal = true;
-      const isGefDeal = false;
+      const isBssFacility = true;
+      const isCashFacility = false;
+      const isContingentFacility = false;
+      const isEwcsFacility = false;
 
       // Act
       const result = mapObligations({
-        currency,
-        facilityAmount,
-        isBssEwcsDeal,
-        isGefDeal,
         bssSubtypeName,
+        currency,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
+        isEwcsFacility,
+        facilityAmount,
       });
 
       // Assert
       const expected = [
         {
           amount: mapObligationAmount({
-            isBssEwcsDeal,
-            isGefDeal,
+            isBssFacility,
+            isCashFacility,
+            isContingentFacility,
+            isEwcsFacility,
             facilityAmount,
-            facilityType,
           }),
           currency,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
@@ -47,27 +50,32 @@ describe('mapObligations', () => {
     describe('when bssSubtypeName is not mapped to an obligation subtype code', () => {
       it('should return an array with the subtypeCode as null', () => {
         // Arrange
-        const isBssEwcsDeal = true;
-        const isGefDeal = false;
+        const isBssFacility = true;
+        const isCashFacility = false;
+        const isContingentFacility = false;
+        const isEwcsFacility = false;
         const unmappedBssSubtypeName = 'Unmapped BSS subtype';
 
         // Act
         const result = mapObligations({
+          bssSubtypeName: unmappedBssSubtypeName,
           currency,
           facilityAmount,
-          isBssEwcsDeal,
-          isGefDeal,
-          bssSubtypeName: unmappedBssSubtypeName,
+          isBssFacility,
+          isCashFacility,
+          isContingentFacility,
+          isEwcsFacility,
         });
 
         // Assert
         const expected = [
           {
             amount: mapObligationAmount({
-              isBssEwcsDeal,
-              isGefDeal,
               facilityAmount,
-              facilityType,
+              isBssFacility,
+              isCashFacility,
+              isContingentFacility,
+              isEwcsFacility,
             }),
             currency,
             repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
@@ -80,29 +88,33 @@ describe('mapObligations', () => {
     });
   });
 
-  describe('when isBssEwcsDeal is false', () => {
+  describe('when isBssFacility is false', () => {
     it('should return an array with one obligation and subtypeCode as null', () => {
       // Arrange
-      const isBssEwcsDeal = false;
-      const isGefDeal = true;
+      const isBssFacility = false;
+      const isCashFacility = true;
+      const isContingentFacility = false;
+      const isEwcsFacility = false;
 
       // Act
       const result = mapObligations({
         currency,
         facilityAmount,
-        isBssEwcsDeal,
-        isGefDeal,
-        facilityType,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
+        isEwcsFacility,
       });
 
       // Assert
       const expected = [
         {
           amount: mapObligationAmount({
-            isBssEwcsDeal,
-            isGefDeal,
             facilityAmount,
-            facilityType,
+            isBssFacility,
+            isCashFacility,
+            isContingentFacility,
+            isEwcsFacility,
           }),
           currency,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,
@@ -114,28 +126,33 @@ describe('mapObligations', () => {
     });
   });
 
-  describe('when isBssEwcsDeal is true and bssSubtypeName is not provided', () => {
+  describe('when isBssFacility is true and bssSubtypeName is not provided', () => {
     it('should return an array with the subtypeCode as null', () => {
       // Arrange
-      const isBssEwcsDeal = true;
-      const isGefDeal = false;
+      const isBssFacility = true;
+      const isCashFacility = false;
+      const isContingentFacility = false;
+      const isEwcsFacility = false;
 
       // Act
       const result = mapObligations({
         currency,
         facilityAmount,
-        isBssEwcsDeal,
-        isGefDeal,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
+        isEwcsFacility,
       });
 
       // Assert
       const expected = [
         {
           amount: mapObligationAmount({
-            isBssEwcsDeal,
-            isGefDeal,
             facilityAmount,
-            facilityType,
+            isBssFacility,
+            isCashFacility,
+            isContingentFacility,
+            isEwcsFacility,
           }),
           currency,
           repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
@@ -13,7 +13,6 @@ type MapObligationsParams = {
   isContingentFacility: boolean;
   isEwcsFacility: boolean;
   facilityAmount: number | null;
-  facilityType?: string;
 };
 
 /**
@@ -23,9 +22,10 @@ type MapObligationsParams = {
  * @param {MapObligationsParams} params - Data required to build the APIM GIFT "obligations" data.
  * @param {string} [params.bssSubtypeName] - The BSS facility's subtype name. Only used when `isBssEwcsDeal` is true.
  * @param {Currency} params.currency - The facility currency code to use for the obligation amount.
- * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
+ * @param {boolean} params.isBssFacility - Flag indicating if the facility is a BSS facility.
  * @param {boolean} params.isCashFacility - Flag indicating if the facility is a cash facility.
  * @param {boolean} params.isContingentFacility - Flag indicating if the facility is a contingent facility.
+ * @param {boolean} params.isEwcsFacility - Flag indicating if the facility is an EWCS facility.
  * @param {number | null} params.facilityAmount - The facility amount (required for BSS/EWCS; used for GEF obligation calculation).
  * @returns {ApimGiftObligation[]} Mapped obligations array for the APIM GIFT payload.
  */

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/index.ts
@@ -8,10 +8,12 @@ const { DEFAULTS, OBLIGATION_SUBTYPE_MAP } = APIM_GIFT_INTEGRATION;
 type MapObligationsParams = {
   bssSubtypeName?: string;
   currency: Currency;
-  isBssEwcsDeal: boolean;
+  isBssFacility: boolean;
+  isCashFacility: boolean;
+  isContingentFacility: boolean;
+  isEwcsFacility: boolean;
   facilityAmount: number | null;
   facilityType?: string;
-  isGefDeal: boolean;
 };
 
 /**
@@ -22,22 +24,23 @@ type MapObligationsParams = {
  * @param {string} [params.bssSubtypeName] - The BSS facility's subtype name. Only used when `isBssEwcsDeal` is true.
  * @param {Currency} params.currency - The facility currency code to use for the obligation amount.
  * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
- * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
+ * @param {boolean} params.isCashFacility - Flag indicating if the facility is a cash facility.
+ * @param {boolean} params.isContingentFacility - Flag indicating if the facility is a contingent facility.
  * @param {number | null} params.facilityAmount - The facility amount (required for BSS/EWCS; used for GEF obligation calculation).
- * @param {string} [params.facilityType] - The facility type (e.g. "Bond", "Cash", "Contingent", "Loan"). Only required for GEF facilities.
  * @returns {ApimGiftObligation[]} Mapped obligations array for the APIM GIFT payload.
  */
 export const mapObligations = ({
   bssSubtypeName,
   currency,
-  isBssEwcsDeal,
-  isGefDeal,
+  isBssFacility,
+  isCashFacility,
+  isContingentFacility,
+  isEwcsFacility,
   facilityAmount,
-  facilityType,
 }: MapObligationsParams): ApimGiftObligation[] => {
   let subtypeCode = null;
 
-  if (isBssEwcsDeal && bssSubtypeName) {
+  if (isBssFacility && bssSubtypeName) {
     const mappedSubtypeCode = OBLIGATION_SUBTYPE_MAP.BSS[bssSubtypeName as keyof typeof OBLIGATION_SUBTYPE_MAP.BSS];
 
     /**
@@ -55,10 +58,11 @@ export const mapObligations = ({
   const obligations = [
     {
       amount: mapObligationAmount({
-        isBssEwcsDeal,
-        isGefDeal,
         facilityAmount,
-        facilityType,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
+        isEwcsFacility,
       }),
       currency,
       repaymentType: DEFAULTS.REPAYMENT_TYPE.BULLET,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.test.ts
@@ -7,56 +7,66 @@ const { UKEF_EXPOSURE_PERCENTAGE } = OBLIGATION_AMOUNT;
 const facilityAmount = 1000;
 
 describe('mapGefObligationAmount', () => {
-  describe(`when facilityType is ${FACILITY_TYPE.CASH}`, () => {
-    it(`should return the facilityAmount multiplied by the ${FACILITY_TYPE.CASH} percentage with decimals`, () => {
-      // Arrange
-      const facilityType = FACILITY_TYPE.CASH;
+  describe('when isCashFacility is true', () => {
+    // Arrange
+    const isCashFacility = true;
+    const isContingentFacility = false;
 
+    it(`should return the facilityAmount multiplied by the ${FACILITY_TYPE.CASH} percentage with decimals`, () => {
       // Act
-      const result = mapGefObligationAmount({ facilityType, facilityAmount });
+      const result = mapGefObligationAmount({ facilityAmount, isCashFacility, isContingentFacility });
 
       // Assert
       const expected = Number((facilityAmount * UKEF_EXPOSURE_PERCENTAGE.CASH).toFixed(2));
 
       expect(result).toEqual(expected);
     });
-  });
 
-  describe('when facilityAmount is null', () => {
-    it('should return null', () => {
-      // Arrange
-      const facilityType = FACILITY_TYPE.CASH;
+    describe('when facilityAmount is null', () => {
+      it('should return null', () => {
+        // Act
+        const result = mapGefObligationAmount({ facilityAmount: null, isCashFacility, isContingentFacility });
 
-      // Act
-      const result = mapGefObligationAmount({ facilityType, facilityAmount: null });
-
-      // Assert
-      expect(result).toBeNull();
+        // Assert
+        expect(result).toBeNull();
+      });
     });
   });
 
-  describe(`when facilityType is ${FACILITY_TYPE.CONTINGENT}`, () => {
-    it(`should return the facilityAmount multiplied by the ${FACILITY_TYPE.CONTINGENT} percentage with decimals`, () => {
-      // Arrange
-      const facilityType = FACILITY_TYPE.CONTINGENT;
+  describe('when isContingentFacility is true', () => {
+    // Arrange
+    const isCashFacility = false;
+    const isContingentFacility = true;
 
+    it(`should return the facilityAmount multiplied by the ${FACILITY_TYPE.CONTINGENT} percentage with decimals`, () => {
       // Act
-      const result = mapGefObligationAmount({ facilityType, facilityAmount });
+      const result = mapGefObligationAmount({ facilityAmount, isCashFacility, isContingentFacility });
 
       // Assert
       const expected = Number((facilityAmount * UKEF_EXPOSURE_PERCENTAGE.CONTINGENT).toFixed(2));
 
       expect(result).toEqual(expected);
     });
+
+    describe('when facilityAmount is null', () => {
+      it('should return null', () => {
+        // Act
+        const result = mapGefObligationAmount({ facilityAmount: null, isCashFacility, isContingentFacility });
+
+        // Assert
+        expect(result).toBeNull();
+      });
+    });
   });
 
-  describe(`when facilityType is not ${FACILITY_TYPE.CASH} or ${FACILITY_TYPE.CONTINGENT}`, () => {
+  describe('when isCashFacility and isContingentFacility are both false', () => {
     it('should return null', () => {
       // Arrange
-      const facilityType = FACILITY_TYPE.BOND;
+      const isCashFacility = false;
+      const isContingentFacility = false;
 
       // Act
-      const result = mapGefObligationAmount({ facilityType, facilityAmount });
+      const result = mapGefObligationAmount({ facilityAmount, isCashFacility, isContingentFacility });
 
       // Assert
       expect(result).toBeNull();
@@ -65,37 +75,21 @@ describe('mapGefObligationAmount', () => {
 });
 
 describe('mapObligationAmount', () => {
-  describe('when isGefDeal is true', () => {
-    it('should return the the result of mapGefObligationAmount', () => {
-      // Arrange
-      const facilityType = FACILITY_TYPE.CASH;
-      const isBssEwcsDeal = false;
+  describe('when isBssFacility is true', () => {
+    // Arrange
+    const isBssFacility = true;
+    const isEwcsFacility = false;
+    const isCashFacility = false;
+    const isContingentFacility = false;
 
-      // Act
-      const result = mapObligationAmount({
-        isBssEwcsDeal,
-        isGefDeal: true,
-        facilityAmount,
-        facilityType,
-      });
-
-      // Assert
-      const expected = mapGefObligationAmount({ facilityType, facilityAmount });
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when isBssEwcsDeal is true and isGefDeal is false', () => {
     it('should return facilityAmount', () => {
-      // Arrange
-      const isBssEwcsDeal = true;
-
       // Act
       const result = mapObligationAmount({
-        isBssEwcsDeal,
-        isGefDeal: false,
         facilityAmount,
+        isBssFacility,
+        isEwcsFacility,
+        isCashFacility,
+        isContingentFacility,
       });
 
       // Assert
@@ -105,14 +99,13 @@ describe('mapObligationAmount', () => {
     });
 
     it('should return null when facilityAmount is null', () => {
-      // Arrange
-      const isBssEwcsDeal = true;
-
       // Act
       const result = mapObligationAmount({
-        isBssEwcsDeal,
-        isGefDeal: false,
         facilityAmount: null,
+        isBssFacility,
+        isEwcsFacility,
+        isCashFacility,
+        isContingentFacility,
       });
 
       // Assert
@@ -120,16 +113,69 @@ describe('mapObligationAmount', () => {
     });
   });
 
-  describe('when isGefDeal is false and isBssEwcsDeal is false', () => {
-    it('should return null', () => {
+  describe('when isCashFacility is true', () => {
+    it('should return the the result of mapGefObligationAmount', () => {
       // Arrange
-      const isBssEwcsDeal = false;
+      const isBssFacility = false;
+      const isEwcsFacility = false;
+      const isCashFacility = true;
+      const isContingentFacility = false;
 
       // Act
       const result = mapObligationAmount({
-        isBssEwcsDeal,
-        isGefDeal: false,
         facilityAmount,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
+        isEwcsFacility,
+      });
+
+      // Assert
+      const expected = mapGefObligationAmount({ facilityAmount, isCashFacility, isContingentFacility });
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when isContingentFacility is true', () => {
+    it('should return the the result of mapGefObligationAmount', () => {
+      // Arrange
+      const isBssFacility = false;
+      const isEwcsFacility = false;
+      const isCashFacility = false;
+      const isContingentFacility = true;
+
+      // Act
+      const result = mapObligationAmount({
+        facilityAmount,
+        isBssFacility,
+        isCashFacility,
+        isContingentFacility,
+        isEwcsFacility,
+      });
+
+      // Assert
+      const expected = mapGefObligationAmount({ facilityAmount, isCashFacility, isContingentFacility });
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when all provided flags are false', () => {
+    it('should return null', () => {
+      // Arrange
+      const isBssFacility = false;
+      const isEwcsFacility = false;
+      const isCashFacility = false;
+      const isContingentFacility = false;
+
+      // Act
+      const result = mapObligationAmount({
+        facilityAmount,
+        isBssFacility,
+        isEwcsFacility,
+        isCashFacility,
+        isContingentFacility,
       });
 
       // Assert

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-obligations/map-obligation-amount/index.ts
@@ -1,40 +1,40 @@
-import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { OBLIGATION_AMOUNT } from '../../../constants';
 import { roundTo2Decimals } from '../../../helpers/round-to-2-decimals';
 
 const { UKEF_EXPOSURE_PERCENTAGE } = OBLIGATION_AMOUNT;
 
 type MapGefObligationAmountParams = {
-  facilityType?: string;
   facilityAmount: number | null;
+  isCashFacility: boolean;
+  isContingentFacility: boolean;
 };
 
 type MapObligationAmountParams = MapGefObligationAmountParams & {
-  isBssEwcsDeal: boolean;
-  isGefDeal: boolean;
-  facilityAmount: number | null;
+  isBssFacility: boolean;
+  isEwcsFacility: boolean;
 };
 
 /**
  * Maps the obligation amount for a GEF facility.
  * @param {MapGefObligationAmountParams} params - Data required to calculate the obligation amount.
- * @param {string} params.facilityType - The facility type (e.g. "Cash", "Contingent").
  * @param {number | null} params.facilityAmount - The facility amount
+ * @param {boolean} params.isCashFacility - Flag indicating if the facility is a cash facility.
+ * @param {boolean} params.isContingentFacility - Flag indicating if the facility is a contingent facility.
  * @example
- * const obligationAmount = mapGefObligationAmount({ facilityType: 'Contingent', facilityAmount: 128.518888 }); => 89.96
- * const obligationAmount = mapGefObligationAmount({ facilityType: 'Cash', facilityAmount: 128.518888 }); => 109.24
- * const obligationAmount = mapGefObligationAmount({ facilityType: 'Unknown', facilityAmount: 128.518888 }); => null
+ * const obligationAmount = mapGefObligationAmount({ isContingentFacility: true, facilityAmount: 128.518888 }); => 89.96
+ * const obligationAmount = mapGefObligationAmount({ isCashFacility: true, facilityAmount: 128.518888 }); => 109.24
+ * const obligationAmount = mapGefObligationAmount({ isCashFacility: false, isContingentFacility: false, facilityAmount: 128.518888 }); => null
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */
-export const mapGefObligationAmount = ({ facilityType, facilityAmount }: MapGefObligationAmountParams): number | null => {
+export const mapGefObligationAmount = ({ facilityAmount, isCashFacility, isContingentFacility }: MapGefObligationAmountParams): number | null => {
   if (facilityAmount) {
-    if (facilityType === FACILITY_TYPE.CASH) {
+    if (isCashFacility) {
       const multiplier = UKEF_EXPOSURE_PERCENTAGE.CASH;
 
       return roundTo2Decimals(facilityAmount * multiplier);
     }
 
-    if (facilityType === FACILITY_TYPE.CONTINGENT) {
+    if (isContingentFacility) {
       const multiplier = UKEF_EXPOSURE_PERCENTAGE.CONTINGENT;
 
       return roundTo2Decimals(facilityAmount * multiplier);
@@ -47,19 +47,30 @@ export const mapGefObligationAmount = ({ facilityType, facilityAmount }: MapGefO
 /**
  * Maps the obligation amount for a facility.
  * @param {MapObligationAmountParams} params - Data required to calculate the obligation amount.
- * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
- * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
  * @param {number | null} params.facilityAmount - The facility amount (required for BSS/EWCS; used for GEF obligation calculation).
- * @param {string} [params.facilityType] - The facility type (e.g. "Cash", "Contingent"). Only required for GEF deals.
+ * @param {boolean} params.isBssFacility - Flag indicating if the facility is a BSS facility.
+ * @param {boolean} params.isCashFacility - Flag indicating if the facility is a cash facility.
+ * @param {boolean} params.isContingentFacility - Flag indicating if the facility is a contingent facility.
+ * @param {boolean} params.isEwcsFacility - Flag indicating if the facility is an EWCS facility.
  * @returns {number | null} The calculated obligation amount, or null if the facility type is not recognized for a GEF deal.
  */
-export const mapObligationAmount = ({ isBssEwcsDeal, isGefDeal, facilityAmount, facilityType }: MapObligationAmountParams): number | null => {
-  if (isBssEwcsDeal) {
+export const mapObligationAmount = ({
+  facilityAmount,
+  isBssFacility,
+  isCashFacility,
+  isContingentFacility,
+  isEwcsFacility,
+}: MapObligationAmountParams): number | null => {
+  if (isBssFacility || isEwcsFacility) {
     return facilityAmount;
   }
 
-  if (isGefDeal) {
-    return mapGefObligationAmount({ facilityType, facilityAmount });
+  if (isCashFacility || isContingentFacility) {
+    return mapGefObligationAmount({
+      isCashFacility,
+      isContingentFacility,
+      facilityAmount,
+    });
   }
 
   return null;

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.test.ts
@@ -1,15 +1,13 @@
-import { BSS_EWCS_FACILITY_TYPE, GEF_FACILITY_TYPE } from '@ukef/dtfs2-common';
-import { mapProductTypeCode } from '.';
 import { PRODUCT_TYPE_CODES } from '../../constants';
+import { mapProductTypeCode } from '.';
 
 describe('mapProductTypeCode', () => {
-  describe(`when isBssEwcsDeal is true and facilityCategoryCode is ${BSS_EWCS_FACILITY_TYPE.BOND}`, () => {
+  describe('when isBssFacility is true', () => {
     it('should return the correct product type code', () => {
       // Arrange & Act
       const result = mapProductTypeCode({
-        isBssEwcsDeal: true,
+        isBssFacility: true,
         isGefDeal: false,
-        facilityCategoryCode: BSS_EWCS_FACILITY_TYPE.BOND,
       });
 
       // Assert
@@ -19,29 +17,12 @@ describe('mapProductTypeCode', () => {
     });
   });
 
-  describe(`when isBssEwcsDeal is true and facilityCategoryCode is NOT ${BSS_EWCS_FACILITY_TYPE.BOND}`, () => {
-    it('should return the correct product type code', () => {
-      // Arrange & Act
-      const result = mapProductTypeCode({
-        isBssEwcsDeal: true,
-        isGefDeal: false,
-        facilityCategoryCode: BSS_EWCS_FACILITY_TYPE.LOAN,
-      });
-
-      // Assert
-      const expected = PRODUCT_TYPE_CODES.UNKNOWN;
-
-      expect(result).toEqual(expected);
-    });
-  });
-
   describe('when isGefDeal is true', () => {
     it('should return the correct product type code', () => {
       // Arrange & Act
       const result = mapProductTypeCode({
-        isBssEwcsDeal: false,
+        isBssFacility: false,
         isGefDeal: true,
-        facilityCategoryCode: GEF_FACILITY_TYPE.CASH,
       });
 
       // Assert

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.test.ts
@@ -31,4 +31,19 @@ describe('mapProductTypeCode', () => {
       expect(result).toEqual(expected);
     });
   });
+
+  describe('when isBssFacility and isGefDeal are false', () => {
+    it(`should return ${PRODUCT_TYPE_CODES.UNKNOWN}`, () => {
+      // Arrange & Act
+      const result = mapProductTypeCode({
+        isBssFacility: false,
+        isGefDeal: false,
+      });
+
+      // Assert
+      const expected = PRODUCT_TYPE_CODES.UNKNOWN;
+
+      expect(result).toEqual(expected);
+    });
+  });
 });

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.ts
@@ -13,7 +13,7 @@ type MapProductTypeCodeParams = {
  * GEF deal type "GEF" => GIFT product type code "GEF"
  * NOTE: V1 integration only supports BSS Bond facilities and GEF facilities.
  * @param {MapProductTypeCodeParams} params - Object containing flags indicating the deal
- * @param {boolean} params.isBssFacility - The facility category code (e.g. "Bond", "Cash", "Contingent", "Loan").
+ * @param {boolean} params.isBssFacility - Flag indicating if the facility is a BSS (Bond) facility.
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
  * @returns {ApimGiftProductTypeCode} The APIM/GIFT product type code for the facility.
  */

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-product-type-code/index.ts
@@ -1,11 +1,9 @@
-import { BSS_EWCS_FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { PRODUCT_TYPE_CODES } from '../../constants';
 import { ApimGiftProductTypeCode } from '../../types';
 
 type MapProductTypeCodeParams = {
-  isBssEwcsDeal: boolean;
+  isBssFacility: boolean;
   isGefDeal: boolean;
-  facilityCategoryCode: string;
 };
 
 /**
@@ -14,14 +12,13 @@ type MapProductTypeCodeParams = {
  * BSS/EWCS deal type "BSS/EWCS" => GIFT product type code "BSS"
  * GEF deal type "GEF" => GIFT product type code "GEF"
  * NOTE: V1 integration only supports BSS Bond facilities and GEF facilities.
- * @param {MapProductTypeCodeParams} params - Object containing flags indicating the deal type.
- * @param {boolean} params.isBssEwcsDeal - Flag indicating if the deal is a BSS/EWCS deal.
+ * @param {MapProductTypeCodeParams} params - Object containing flags indicating the deal
+ * @param {boolean} params.isBssFacility - The facility category code (e.g. "Bond", "Cash", "Contingent", "Loan").
  * @param {boolean} params.isGefDeal - Flag indicating if the deal is a GEF deal.
- * @param {string} params.facilityCategoryCode - The facility category code (e.g. "Bond", "Cash", "Contingent", "Loan").
  * @returns {ApimGiftProductTypeCode} The APIM/GIFT product type code for the facility.
  */
-export const mapProductTypeCode = ({ isBssEwcsDeal, isGefDeal, facilityCategoryCode }: MapProductTypeCodeParams): ApimGiftProductTypeCode => {
-  if (isBssEwcsDeal && facilityCategoryCode === BSS_EWCS_FACILITY_TYPE.BOND) {
+export const mapProductTypeCode = ({ isBssFacility, isGefDeal }: MapProductTypeCodeParams): ApimGiftProductTypeCode => {
+  if (isBssFacility) {
     return PRODUCT_TYPE_CODES.BSS;
   }
 


### PR DESCRIPTION
# Introduction :pencil2:

Some mapping functions for APIM/GIFT rely on `isBssEwcsDeal` and `isGefDeal` for some conditions.

This will not work for EWCS integration as there are EWCS specific conditions to introduce.

Additionally, the concept of "is X deal", when in a facility, could be confusing. Sticking in the realm of a facility makes more sense, and to future proof.

## Resolution :heavy_check_mark:

- Create new mapping function, `getFacilityTypeFlags`.
- Update `createFacility` to use the new facility flags, instead of `facilitySnapshot.type`, `isBssEwcsDeal`, `isGefDeal`.
- Update the following to use new facility flags:
  - `mapCounterparties`
  - mapObligations`
  - `mapObligationAmount`
  - `mapProductTypeCode`.

## Miscellaneous :heavy_plus_sign:

- Minor param ordering improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
