### PR TITLE
feat(DTFS2-8553): create an ewcs gift facility - accrual schedule

### DIFF
--- a/libs/common/src/constants/apim-gift-payloads/apim-gift-payloads.example.constants.ts
+++ b/libs/common/src/constants/apim-gift-payloads/apim-gift-payloads.example.constants.ts
@@ -16,15 +16,16 @@ export const APIM_GIFT_PAYLOADS_EXAMPLES = {
       },
       accrualSchedules: [
         {
-          accrualScheduleTypeCode: 'PAC01',
-          accrualEffectiveDate: '2025-01-13',
-          accrualMaturityDate: '2025-01-15',
-          accrualFrequencyCode: 'FREQ12MON',
-          firstCycleAccrualEndDate: '2025-01-15',
           accrualDayBasisCode: 'ACTUAL_365',
-          baseRate: 0,
-          spreadRate: 0,
+          accrualEffectiveDate: '2025-01-13',
+          accrualFrequencyCode: 'FREQ12MON',
+          accrualMaturityDate: '2025-01-15',
+          accrualScheduleTypeCode: 'PAC01',
           additionalRate: 0,
+          baseRate: 0,
+          firstCycleAccrualEndDate: '2025-01-15',
+          indexRateCode: 'USD003',
+          spreadRate: 0,
         },
       ],
       counterparties: [
@@ -37,10 +38,10 @@ export const APIM_GIFT_PAYLOADS_EXAMPLES = {
       ],
       fixedFees: [
         {
-          feeTypeCode: 'PLA',
-          effectiveDate: '2025-01-15',
-          currency: 'USD',
           amount: 5000,
+          currency: 'USD',
+          effectiveDate: '2025-01-15',
+          feeTypeCode: 'PLA',
         },
       ],
       obligations: [
@@ -54,8 +55,8 @@ export const APIM_GIFT_PAYLOADS_EXAMPLES = {
         },
       ],
       riskDetails: {
-        dealId: '0030000123',
         account: '2',
+        dealId: '0030000123',
         facilityCreditRating: 'AA',
         riskStatus: 'Corporate',
         ukefIndustryCode: '0101',

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/constants.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/constants.ts
@@ -118,6 +118,34 @@ export const ACCRUAL_FREQUENCY_CODE_MAP = {
   EVERY_BUSINESS_DAY: 'FREQEBD',
 } as const;
 
+/**
+ * APIM/GIFT index rate codes for EWCS facilities.
+ * These are required to map the facility's currency and accrual frequency code to the expected index rate code in APIM/GIFT when mapping the facility "accrual schedules" data for the APIM GIFT payload.
+ * If the currency is not recognized, the index rate code will default to "UNKNOWN_INDEX_RATE_CODE".
+ * If the frequency code is not quarterly, the index rate code will default to the "OTHER" index rate code for the given currency.
+ * This is required to ensure that the integration can handle unexpected currency and frequency code values without breaking, and to provide a fallback value for unrecognized values.
+ * If the "UNKNOWN_INDEX_RATE_CODE" is sent to APIM/GIFT, this will trigger an alert in APIM for the unexpected index rate code value, which can be investigated by the team.
+ */
+export const ACCRUAL_SCHEDULE_INDEX_RATE_CODES = {
+  GBP: {
+    QUARTERLY: 'GBP003',
+    OTHER: 'GBP004',
+  },
+  EUR: {
+    QUARTERLY: 'EUR003',
+    OTHER: 'EUR004',
+  },
+  USD: {
+    QUARTERLY: 'USD003',
+    OTHER: 'USD004',
+  },
+  JPY: {
+    QUARTERLY: 'JPY003',
+    OTHER: 'JPY004',
+  },
+  UNKNOWN: 'UNKNOWN_INDEX_RATE_CODE',
+} as const;
+
 export const ACCRUAL_SCHEDULE_TYPE_CODES = {
   PREMIUM: 'PAC01',
 } as const;

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.test.ts
@@ -117,11 +117,13 @@ describe('createFacility', () => {
         ukefFacilityId: String(facilitySnapshot.ukefFacilityId),
       }),
       accrualSchedules: mapAccrualSchedules({
+        currency: facilitySnapshot.currency.id,
         dayCountBasis: Number(facilitySnapshot.dayCountBasis),
         expiryDate,
         feeFrequency: facilitySnapshot.feeFrequency,
         feeType: facilitySnapshot.feeType,
         guaranteeFeePayableToUkef,
+        isEwcsFacility,
       }),
       counterparties: mapCounterparties({
         isBssFacility,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/index.ts
@@ -140,11 +140,13 @@ export const createFacility = async ({
       ukefFacilityId,
     }),
     accrualSchedules: mapAccrualSchedules({
+      currency,
       dayCountBasis,
       expiryDate,
       feeFrequency,
       feeType,
       guaranteeFeePayableToUkef,
+      isEwcsFacility,
     }),
     counterparties: mapCounterparties({
       isBssFacility,

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.test.ts
@@ -49,7 +49,7 @@ describe('mapAccrualSchedules', () => {
   });
 
   describe('when isEwcsFacility is true', () => {
-    it('should return an array with a accrual schedule containing indexRateCode', () => {
+    it('should return an array with an accrual schedule containing indexRateCode', () => {
       // Arrange
       const isEwcsFacility = true;
 

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.test.ts
@@ -1,27 +1,35 @@
+import { CURRENCY } from '@ukef/dtfs2-common';
 import { APIM_GIFT_INTEGRATION } from '../../constants';
 import { mapDayBasisCode } from './map-day-basis-code';
 import { mapFrequencyCode } from './map-frequency-code';
 import { mapSpreadRate } from './map-spread-rate';
 import { mapAccrualSchedules } from '.';
+import { mapEwcsIndexRateCode } from './map-ewcs-index-rate-code';
 
 const { DEFAULTS } = APIM_GIFT_INTEGRATION;
 
 describe('mapAccrualSchedules', () => {
+  // Arrange
+  const currency = CURRENCY.GBP;
+  const dayCountBasis = 360;
+  const expiryDate = '2026-12-31';
+  const feeFrequency = 'Monthly';
+  const feeType = 'At maturity';
+  const guaranteeFeePayableToUkef = '7.0200%';
+
   it('should return an array with a mapped accrual schedule', () => {
     // Arrange
-    const dayCountBasis = 360;
-    const expiryDate = '2026-12-31';
-    const feeFrequency = 'Monthly';
-    const feeType = 'At maturity';
-    const guaranteeFeePayableToUkef = '7.0200%';
+    const isEwcsFacility = false;
 
     // Act
     const result = mapAccrualSchedules({
+      currency,
       dayCountBasis,
       expiryDate,
       feeFrequency,
       feeType,
       guaranteeFeePayableToUkef,
+      isEwcsFacility,
     });
 
     // Assert
@@ -38,5 +46,30 @@ describe('mapAccrualSchedules', () => {
     ];
 
     expect(result).toEqual(expected);
+  });
+
+  describe('when isEwcsFacility is true', () => {
+    it('should return an array with a accrual schedule containing indexRateCode', () => {
+      // Arrange
+      const isEwcsFacility = true;
+
+      // Act
+      const result = mapAccrualSchedules({
+        currency,
+        dayCountBasis,
+        expiryDate,
+        feeFrequency,
+        feeType,
+        guaranteeFeePayableToUkef,
+        isEwcsFacility,
+      });
+
+      // Assert
+      const frequencyCode = mapFrequencyCode(feeFrequency, feeType);
+
+      const expected = mapEwcsIndexRateCode({ currency, frequencyCode });
+
+      expect(result[0].indexRateCode).toEqual(expected);
+    });
   });
 });

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/index.ts
@@ -1,40 +1,50 @@
+import type { Currency } from '@ukef/dtfs2-common';
 import { APIM_GIFT_INTEGRATION } from '../../constants';
 import { ApimAccrualSchedule } from '../../types';
 import { mapDayBasisCode } from './map-day-basis-code';
 import { mapFrequencyCode } from './map-frequency-code';
 import { mapSpreadRate } from './map-spread-rate';
+import { mapEwcsIndexRateCode } from './map-ewcs-index-rate-code';
 
 const { DEFAULTS } = APIM_GIFT_INTEGRATION;
 
 type MapAccrualSchedulesParams = {
   dayCountBasis: number;
+  currency: Currency;
   expiryDate: string;
   feeFrequency: string;
   feeType: string;
   guaranteeFeePayableToUkef: string | null;
+  isEwcsFacility: boolean;
 };
 
 /**
  * Maps the facility "accrual schedules"
  * @param params - The parameters required to map the accrual schedules, including:
+ * @param {Currency} params.currency - The facility currency code, used for EWCS index rate mapping.
  * @param {number} params.dayCountBasis - The facility's day count basis, used to map to GIFT day basis code.
  * @param {string} params.expiryDate - The facility guarantee expiry date.
  * @param {string} params.feeFrequency - The facility's fee frequency, used to map to GIFT accrual frequency code.
  * @param {string} params.feeType - The facility's fee type, used to determine special handling for "At maturity" option.
- * @param {string | null} params.guaranteeFeePayableToUkef - The guarantee fee payable to UKEF, used as the spread rate in the accrual schedule.
+ * @param {string | null} params.guaranteeFeePayableToUkef - The guarantee fee payable to UKEF, used as the spread rate in the accrual schedule
+ * @param {boolean} params.isEwcsFacility - Flag indicating if the facility is an EWCS facility.
  * @returns {ApimAccrualSchedule[]} - Mapped accrual schedules for the APIM GIFT payload.
  */
 export const mapAccrualSchedules = ({
+  currency,
   dayCountBasis,
   expiryDate,
   feeFrequency,
   feeType,
   guaranteeFeePayableToUkef,
+  isEwcsFacility,
 }: MapAccrualSchedulesParams): ApimAccrualSchedule[] => {
-  const accrualSchedules = [
+  const frequencyCode = mapFrequencyCode(feeFrequency, feeType);
+
+  const accrualSchedules: ApimAccrualSchedule[] = [
     {
       accrualScheduleTypeCode: DEFAULTS.ACCRUAL_SCHEDULE.TYPE_CODE,
-      accrualFrequencyCode: mapFrequencyCode(feeFrequency, feeType),
+      accrualFrequencyCode: frequencyCode,
       accrualDayBasisCode: mapDayBasisCode(dayCountBasis),
       additionalRate: DEFAULTS.ACCRUAL_SCHEDULE.ADDITIONAL_RATE,
       baseRate: DEFAULTS.ACCRUAL_SCHEDULE.BASE_RATE,
@@ -42,6 +52,10 @@ export const mapAccrualSchedules = ({
       spreadRate: mapSpreadRate(guaranteeFeePayableToUkef),
     },
   ];
+
+  if (isEwcsFacility) {
+    accrualSchedules[0].indexRateCode = mapEwcsIndexRateCode({ currency, frequencyCode });
+  }
 
   return accrualSchedules;
 };

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/map-ewcs-index-rate-code/index.test.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/map-ewcs-index-rate-code/index.test.ts
@@ -1,0 +1,120 @@
+import type { Currency } from '@ukef/dtfs2-common';
+import { CURRENCY } from '@ukef/dtfs2-common';
+import { ACCRUAL_FREQUENCY_CODE_MAP, ACCRUAL_SCHEDULE_INDEX_RATE_CODES } from '../../../constants';
+import { mapEwcsIndexRateCode } from '.';
+
+const { QUARTERLY } = ACCRUAL_FREQUENCY_CODE_MAP;
+const { EUR, GBP, JPY, USD, UNKNOWN } = ACCRUAL_SCHEDULE_INDEX_RATE_CODES;
+
+describe('mapEwcsIndexRateCode', () => {
+  describe(`when currency is ${CURRENCY.EUR}`, () => {
+    it(`should return ${EUR.QUARTERLY} when frequencyCode is ${QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.EUR,
+        frequencyCode: QUARTERLY,
+      });
+
+      // Assert
+      expect(result).toEqual(EUR.QUARTERLY);
+    });
+
+    it(`should return ${EUR.OTHER} when frequencyCode is not ${EUR.QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.EUR,
+        frequencyCode: 'UNRECOGNISED',
+      });
+
+      // Assert
+      expect(result).toEqual(EUR.OTHER);
+    });
+  });
+
+  describe(`when currency is ${CURRENCY.GBP}`, () => {
+    it(`should return ${GBP.QUARTERLY} when frequencyCode is ${QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.GBP,
+        frequencyCode: QUARTERLY,
+      });
+
+      // Assert
+      expect(result).toEqual(GBP.QUARTERLY);
+    });
+
+    it(`should return ${GBP.OTHER} when frequencyCode is not ${GBP.QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.GBP,
+        frequencyCode: 'UNRECOGNISED',
+      });
+
+      // Assert
+      expect(result).toEqual(GBP.OTHER);
+    });
+  });
+
+  describe(`when currency is ${CURRENCY.JPY}`, () => {
+    it(`should return ${JPY.QUARTERLY} when frequencyCode is ${QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.JPY,
+        frequencyCode: QUARTERLY,
+      });
+
+      // Assert
+      expect(result).toEqual(JPY.QUARTERLY);
+    });
+
+    it(`should return ${JPY.OTHER} when frequencyCode is not ${JPY.QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.JPY,
+        frequencyCode: 'UNRECOGNISED',
+      });
+
+      // Assert
+      expect(result).toEqual(JPY.OTHER);
+    });
+  });
+
+  describe(`when currency is ${CURRENCY.USD}`, () => {
+    it(`should return ${USD.QUARTERLY} when frequencyCode is ${QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.USD,
+        frequencyCode: QUARTERLY,
+      });
+
+      // Assert
+      expect(result).toEqual(USD.QUARTERLY);
+    });
+
+    it(`should return ${USD.OTHER} when frequencyCode is not ${USD.QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency: CURRENCY.USD,
+        frequencyCode: 'UNRECOGNISED',
+      });
+
+      // Assert
+      expect(result).toEqual(USD.OTHER);
+    });
+  });
+
+  describe('when currency is not recognised', () => {
+    const currency = 'UNRECOGNISED' as Currency;
+
+    it(`should return ${UNKNOWN} when frequencyCode is ${QUARTERLY}`, () => {
+      // Arrange & Act
+      const result = mapEwcsIndexRateCode({
+        currency,
+        frequencyCode: QUARTERLY,
+      });
+
+      // Assert
+      expect(result).toEqual(UNKNOWN);
+    });
+  });
+});

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/map-ewcs-index-rate-code/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/map-ewcs-index-rate-code/index.ts
@@ -1,0 +1,57 @@
+import type { Currency } from '@ukef/dtfs2-common';
+import { CURRENCY } from '@ukef/dtfs2-common';
+import { ACCRUAL_FREQUENCY_CODE_MAP, ACCRUAL_SCHEDULE_INDEX_RATE_CODES } from '../../../constants';
+
+const { QUARTERLY } = ACCRUAL_FREQUENCY_CODE_MAP;
+const { EUR, GBP, JPY, USD, UNKNOWN } = ACCRUAL_SCHEDULE_INDEX_RATE_CODES;
+
+type MapEwcsIndexRateCodeParams = {
+  currency: Currency;
+  frequencyCode: string | null;
+};
+
+/**
+ * Maps the facility's currency and accrual frequency code to the corresponding APIM/GIFT index rate code for EWCS facilities.
+ * @param params - The parameters required to map the EWCS index rate code, including:
+ * @param {Currency} params.currency - The facility currency code.
+ * @param {string | null} params.frequencyCode - The facility's accrual frequency code.
+ * @returns {string} - The corresponding GIFT index rate code for EWCS facilities, or 'UNKNOWN_INDEX_RATE_CODE' if not found.
+ */
+export const mapEwcsIndexRateCode = ({ currency, frequencyCode }: MapEwcsIndexRateCodeParams) => {
+  switch (currency) {
+    case CURRENCY.EUR:
+      switch (frequencyCode) {
+        case QUARTERLY:
+          return EUR.QUARTERLY;
+        default:
+          return EUR.OTHER;
+      }
+
+    case CURRENCY.GBP:
+      switch (frequencyCode) {
+        case QUARTERLY:
+          return GBP.QUARTERLY;
+        default:
+          return GBP.OTHER;
+      }
+
+    case CURRENCY.JPY:
+      switch (frequencyCode) {
+        case QUARTERLY:
+          return JPY.QUARTERLY;
+        default:
+          return JPY.OTHER;
+      }
+
+    case CURRENCY.USD:
+      switch (frequencyCode) {
+        case QUARTERLY:
+          return USD.QUARTERLY;
+        default:
+          return USD.OTHER;
+      }
+
+    default:
+      return UNKNOWN;
+  }
+};

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/map-ewcs-index-rate-code/index.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/create-facility/map-accrual-schedules/map-ewcs-index-rate-code/index.ts
@@ -3,6 +3,7 @@ import { CURRENCY } from '@ukef/dtfs2-common';
 import { ACCRUAL_FREQUENCY_CODE_MAP, ACCRUAL_SCHEDULE_INDEX_RATE_CODES } from '../../../constants';
 
 const { QUARTERLY } = ACCRUAL_FREQUENCY_CODE_MAP;
+
 const { EUR, GBP, JPY, USD, UNKNOWN } = ACCRUAL_SCHEDULE_INDEX_RATE_CODES;
 
 type MapEwcsIndexRateCodeParams = {

--- a/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/apim-gift.ts
+++ b/trade-finance-manager-api/server/v1/mappings/apim-gift-payloads/types/apim-gift.ts
@@ -40,6 +40,7 @@ export type ApimAccrualSchedule = {
   additionalRate: number;
   baseRate: number;
   firstCycleAccrualEndDate: string;
+  indexRateCode?: string;
   spreadRate: number | null;
 };
 


### PR DESCRIPTION
# Introduction :pencil2:

This PR updates the APIM/GIFT integration to include an "index rate code" for GIFT accrual schedules.

## Resolution :heavy_check_mark:

- Update constants.
- Update `mapAccrualSchedules` to require `currency` and `isEwcsFacility` params.
- Update `mapAccrualSchedules` to map an index rate code for EWCS facilities.
- Create new mapping function, `mapEwcsIndexRateCode`.

## Miscellaneous :heavy_plus_sign:

- Update example payload.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```json

```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.

</details>
