### PR TITLE
fix(DTFS2-8570): fix passwords showing in error messages

### DIFF
--- a/libs/common/src/helpers/errors/index.ts
+++ b/libs/common/src/helpers/errors/index.ts
@@ -1,1 +1,2 @@
 export * from './global-handlers';
+export * from './log-user-auth-error';

--- a/libs/common/src/helpers/errors/log-user-auth-error.test.ts
+++ b/libs/common/src/helpers/errors/log-user-auth-error.test.ts
@@ -10,6 +10,7 @@ describe('logUserAuthError', () => {
   });
 
   it('should log the error with the provided message', () => {
+    // Arrange
     const error = {
       message: 'Test error message',
       code: 'TEST_CODE',
@@ -20,24 +21,26 @@ describe('logUserAuthError', () => {
     };
     const message = 'Custom log message';
 
+    // Act
     logUserAuthError(error, message);
 
-    expect(console.error).toHaveBeenCalledWith(
-      '%s: %s (status: %s, code: %s) %o',
-      message,
-      error.message,
-      error.response.status,
-      error.code,
-      error.response.data,
-    );
+    // Assert
+    const expected = ['%s: %s (status: %s, code: %s) %o', message, error.message, error.response.status, error.code, error.response.data];
+
+    expect(console.error).toHaveBeenNthCalledWith(1, ...expected);
   });
 
   it('should handle missing properties gracefully', () => {
+    // Arrange
     const error = {};
     const message = 'Custom log message';
 
+    // Act
     logUserAuthError(error, message);
 
-    expect(console.error).toHaveBeenCalledWith('%s: %s (status: %s, code: %s) %o', message, 'Unknown error', undefined, 'UNKNOWN', 'Unknown error');
+    // Assert
+    const expected = ['%s: %s (status: %s, code: %s) %o', message, 'Unknown error', undefined, 'UNKNOWN', 'Unknown error'];
+
+    expect(console.error).toHaveBeenNthCalledWith(1, ...expected);
   });
 });

--- a/libs/common/src/helpers/errors/log-user-auth-error.test.ts
+++ b/libs/common/src/helpers/errors/log-user-auth-error.test.ts
@@ -1,0 +1,43 @@
+import { logUserAuthError } from './log-user-auth-error';
+
+describe('logUserAuthError', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should log the error with the provided message', () => {
+    const error = {
+      message: 'Test error message',
+      code: 'TEST_CODE',
+      response: {
+        status: 400,
+        data: { detail: 'Test error detail' },
+      },
+    };
+    const message = 'Custom log message';
+
+    logUserAuthError(error, message);
+
+    expect(console.error).toHaveBeenCalledWith(
+      '%s: %s (status: %s, code: %s) %o',
+      message,
+      error.message,
+      error.response.status,
+      error.code,
+      error.response.data,
+    );
+  });
+
+  it('should handle missing properties gracefully', () => {
+    const error = {};
+    const message = 'Custom log message';
+
+    logUserAuthError(error, message);
+
+    expect(console.error).toHaveBeenCalledWith('%s: %s (status: %s, code: %s) %o', message, 'Unknown error', undefined, 'UNKNOWN', 'Unknown error');
+  });
+});

--- a/libs/common/src/helpers/errors/log-user-auth-error.ts
+++ b/libs/common/src/helpers/errors/log-user-auth-error.ts
@@ -7,6 +7,12 @@ export type AuthErrorObject = {
   };
 };
 
+/**
+ * Logs user authentication errors to the console with a custom message.
+ * If certain properties of the error object are missing, it will log default values instead.
+ * @param error The error object containing details about the authentication error.
+ * @param message A custom message to provide context for the error.
+ */
 export const logUserAuthError = (error: AuthErrorObject, message: string) => {
   const status = error?.response?.status;
   const errorMessage = error?.message ?? 'Unknown error';

--- a/libs/common/src/helpers/errors/log-user-auth-error.ts
+++ b/libs/common/src/helpers/errors/log-user-auth-error.ts
@@ -1,0 +1,17 @@
+export type AuthErrorObject = {
+  message?: string;
+  code?: string;
+  response?: {
+    status?: number | string;
+    data?: unknown;
+  };
+};
+
+export const logUserAuthError = (error: AuthErrorObject, message: string) => {
+  const status = error?.response?.status;
+  const errorMessage = error?.message ?? 'Unknown error';
+  const errorCode = error?.code ?? 'UNKNOWN';
+  const specificError = error?.response?.data ?? 'Unknown error';
+
+  console.error('%s: %s (status: %s, code: %s) %o', message, errorMessage, status, errorCode, specificError);
+};

--- a/portal-ui/server/controllers/login/post-login.js
+++ b/portal-ui/server/controllers/login/post-login.js
@@ -96,7 +96,7 @@ export const postLogin = async (req, res) => {
         return res.redirect('/login/temporarily-suspended-access-code');
       }
 
-      const generalErrorMessage = 'Failed to send sign in OTP, rendering problem with service page. The error was ';
+      const generalErrorMessage = 'Failed to send sign in OTP, rendering problem with service page. The error was';
       logUserAuthError(error, generalErrorMessage);
 
       return res.render('_partials/problem-with-service.njk');
@@ -151,7 +151,7 @@ export const postLogin = async (req, res) => {
         return res.status(HttpStatusCode.Forbidden).render('login/temporarily-suspended.njk');
       }
 
-      const generalErrorMessage = 'Failed to send sign in link. The login flow will continue as the user can retry on the next page. The error was ';
+      const generalErrorMessage = 'Failed to send sign in link. The login flow will continue as the user can retry on the next page. The error was';
       logUserAuthError(error, generalErrorMessage);
 
       // Continue login flow so the user can retry sending sign-in link

--- a/portal-ui/server/controllers/login/post-login.js
+++ b/portal-ui/server/controllers/login/post-login.js
@@ -96,8 +96,8 @@ export const postLogin = async (req, res) => {
         return res.redirect('/login/temporarily-suspended-access-code');
       }
 
-      const generalErrorMessage = 'Failed to send sign in OTP, rendering problem with service page. The error was';
-      logUserAuthError(error, generalErrorMessage);
+      const message = 'Failed to send sign in OTP, rendering problem with service page. The error was';
+      logUserAuthError(error, message);
 
       return res.render('_partials/problem-with-service.njk');
     }
@@ -151,8 +151,8 @@ export const postLogin = async (req, res) => {
         return res.status(HttpStatusCode.Forbidden).render('login/temporarily-suspended.njk');
       }
 
-      const generalErrorMessage = 'Failed to send sign in link. The login flow will continue as the user can retry on the next page. The error was';
-      logUserAuthError(error, generalErrorMessage);
+      const message = 'Failed to send sign in link. The login flow will continue as the user can retry on the next page. The error was';
+      logUserAuthError(error, message);
 
       // Continue login flow so the user can retry sending sign-in link
       return res.redirect('/login/check-your-email');

--- a/portal-ui/server/controllers/login/post-login.js
+++ b/portal-ui/server/controllers/login/post-login.js
@@ -71,9 +71,13 @@ export const postLogin = async (req, res) => {
       return res.redirect(nextAccessCodePage);
     } catch (error) {
       const status = error.response?.status;
+      const errorMessage = error?.message ?? 'Unknown error';
+      const errorCode = error?.code ?? 'UNKNOWN';
+      const message = 'Failed to login';
+      const specificError = error.response?.data ?? 'Unknown error';
 
       if (!loginApiOtpSucceeded) {
-        console.error('Failed to login %o', error);
+        console.error('%s: %s (status: %s, code: %s) %o', message, errorMessage, status, errorCode, specificError);
 
         if (status === HttpStatusCode.Forbidden) {
           console.error('Access temporarily suspended for user %s', email);
@@ -95,7 +99,8 @@ export const postLogin = async (req, res) => {
         return res.redirect('/login/temporarily-suspended-access-code');
       }
 
-      console.error('Failed to send sign in OTP, rendering problem with service page. The error was %o', error);
+      const generalErrorMessage = 'Failed to send sign in OTP, rendering problem with service page. The error was ';
+      console.error('%s %s: %s (status: %s, code: %s)', generalErrorMessage, message, errorMessage, status, errorCode);
 
       return res.render('_partials/problem-with-service.njk');
     }
@@ -126,9 +131,13 @@ export const postLogin = async (req, res) => {
       return res.redirect('/login/check-your-email');
     } catch (error) {
       const status = error.response?.status;
+      const errorMessage = error?.message ?? 'Unknown error';
+      const errorCode = error?.code ?? 'UNKNOWN';
+      const message = 'Failed to login';
+      const specificError = error.response?.data ?? 'Unknown error';
 
       if (!loginApiLinkSucceeded) {
-        console.error('Failed to login %o', error);
+        console.error('%s: %s (status: %s, code: %s) %o', message, errorMessage, status, errorCode, specificError);
 
         if (status === HttpStatusCode.Forbidden) {
           console.error('Access temporarily suspended for user');
@@ -148,8 +157,8 @@ export const postLogin = async (req, res) => {
         return res.status(HttpStatusCode.Forbidden).render('login/temporarily-suspended.njk');
       }
 
-      const message = 'Failed to send sign in link. The login flow will continue as the user can retry on the next page. The error was ';
-      console.error('%s %o', message, error);
+      const generalErrorMessage = 'Failed to send sign in link. The login flow will continue as the user can retry on the next page. The error was ';
+      console.error('%s %s: %s (status: %s, code: %s)', generalErrorMessage, message, errorMessage, status, errorCode);
 
       // Continue login flow so the user can retry sending sign-in link
       return res.redirect('/login/check-your-email');

--- a/portal-ui/server/controllers/login/post-login.js
+++ b/portal-ui/server/controllers/login/post-login.js
@@ -1,5 +1,5 @@
 import { HttpStatusCode } from 'axios';
-import { isPortal2FAFeatureFlagEnabled } from '@ukef/dtfs2-common';
+import { isPortal2FAFeatureFlagEnabled, logUserAuthError } from '@ukef/dtfs2-common';
 
 import { validationErrorHandler, getNextAccessCodePage } from '../../helpers';
 import api from '../../api';
@@ -71,13 +71,10 @@ export const postLogin = async (req, res) => {
       return res.redirect(nextAccessCodePage);
     } catch (error) {
       const status = error.response?.status;
-      const errorMessage = error?.message ?? 'Unknown error';
-      const errorCode = error?.code ?? 'UNKNOWN';
-      const message = 'Failed to login';
-      const specificError = error.response?.data ?? 'Unknown error';
 
       if (!loginApiOtpSucceeded) {
-        console.error('%s: %s (status: %s, code: %s) %o', message, errorMessage, status, errorCode, specificError);
+        const message = 'Failed to login';
+        logUserAuthError(error, message);
 
         if (status === HttpStatusCode.Forbidden) {
           console.error('Access temporarily suspended for user %s', email);
@@ -100,7 +97,7 @@ export const postLogin = async (req, res) => {
       }
 
       const generalErrorMessage = 'Failed to send sign in OTP, rendering problem with service page. The error was ';
-      console.error('%s %s: %s (status: %s, code: %s)', generalErrorMessage, message, errorMessage, status, errorCode);
+      logUserAuthError(error, generalErrorMessage);
 
       return res.render('_partials/problem-with-service.njk');
     }
@@ -131,13 +128,10 @@ export const postLogin = async (req, res) => {
       return res.redirect('/login/check-your-email');
     } catch (error) {
       const status = error.response?.status;
-      const errorMessage = error?.message ?? 'Unknown error';
-      const errorCode = error?.code ?? 'UNKNOWN';
-      const message = 'Failed to login';
-      const specificError = error.response?.data ?? 'Unknown error';
 
       if (!loginApiLinkSucceeded) {
-        console.error('%s: %s (status: %s, code: %s) %o', message, errorMessage, status, errorCode, specificError);
+        const message = 'Failed to login';
+        logUserAuthError(error, message);
 
         if (status === HttpStatusCode.Forbidden) {
           console.error('Access temporarily suspended for user');
@@ -158,7 +152,7 @@ export const postLogin = async (req, res) => {
       }
 
       const generalErrorMessage = 'Failed to send sign in link. The login flow will continue as the user can retry on the next page. The error was ';
-      console.error('%s %s: %s (status: %s, code: %s)', generalErrorMessage, message, errorMessage, status, errorCode);
+      logUserAuthError(error, generalErrorMessage);
 
       // Continue login flow so the user can retry sending sign-in link
       return res.redirect('/login/check-your-email');

--- a/portal-ui/server/controllers/login/post-login.test.js
+++ b/portal-ui/server/controllers/login/post-login.test.js
@@ -210,7 +210,15 @@ describe('postLogin', () => {
         it('should log the error and render the problem with service page', async () => {
           await postLogin(req, res);
 
-          expect(console.error).toHaveBeenNthCalledWith(1, 'Failed to send sign in OTP, rendering problem with service page. The error was %o', error);
+          expect(console.error).toHaveBeenNthCalledWith(
+            1,
+            '%s %s: %s (status: %s, code: %s)',
+            'Failed to send sign in OTP, rendering problem with service page. The error was ',
+            'Failed to login',
+            'OTP sending failed',
+            undefined,
+            'UNKNOWN',
+          );
 
           expect(res.render).toHaveBeenNthCalledWith(1, '_partials/problem-with-service.njk');
           expect(res.redirect).not.toHaveBeenCalled();
@@ -249,7 +257,15 @@ describe('postLogin', () => {
         it('should log the error and render the login page with errors', async () => {
           await postLogin(req, res);
 
-          expect(console.error).toHaveBeenNthCalledWith(1, 'Failed to login %o', error);
+          expect(console.error).toHaveBeenNthCalledWith(
+            1,
+            '%s: %s (status: %s, code: %s) %o',
+            'Failed to login',
+            'Login failed',
+            undefined,
+            'UNKNOWN',
+            'Unknown error',
+          );
 
           const expectedErrors = [
             {

--- a/portal-ui/server/controllers/login/post-login.test.js
+++ b/portal-ui/server/controllers/login/post-login.test.js
@@ -213,7 +213,7 @@ describe('postLogin', () => {
           expect(console.error).toHaveBeenNthCalledWith(
             1,
             '%s: %s (status: %s, code: %s) %o',
-            'Failed to send sign in OTP, rendering problem with service page',
+            'Failed to send sign in OTP, rendering problem with service page. The error was',
             'OTP sending failed',
             undefined,
             'UNKNOWN',

--- a/portal-ui/server/controllers/login/post-login.test.js
+++ b/portal-ui/server/controllers/login/post-login.test.js
@@ -212,12 +212,12 @@ describe('postLogin', () => {
 
           expect(console.error).toHaveBeenNthCalledWith(
             1,
-            '%s %s: %s (status: %s, code: %s)',
-            'Failed to send sign in OTP, rendering problem with service page. The error was ',
-            'Failed to login',
+            '%s: %s (status: %s, code: %s) %o',
+            'Failed to send sign in OTP, rendering problem with service page',
             'OTP sending failed',
             undefined,
             'UNKNOWN',
+            'Unknown error',
           );
 
           expect(res.render).toHaveBeenNthCalledWith(1, '_partials/problem-with-service.njk');

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1,6 +1,6 @@
 const { HANDLE_SSO_REDIRECT_FORM_RESPONSE_SCHEMA } = require('@ukef/dtfs2-common/schemas');
 const axios = require('axios');
-const { HttpStatusCode } = require('axios');
+const { HttpStatusCode, logUserAuthError } = require('axios');
 const { HEADERS } = require('@ukef/dtfs2-common');
 const { isValidMongoId, isValidPartyUrn, isValidGroupId, isValidTaskId, isValidBankId } = require('./helpers/validateIds');
 const { assertValidIsoMonth, assertValidIsoYear } = require('./helpers/date');
@@ -489,13 +489,10 @@ const updateUserPassword = async (userId, update, token) => {
       headers: generateHeadersWithToken(token),
       data: update,
     }).catch((error) => {
-      const status = error.response?.status;
-      const errorMessage = error?.message ?? 'Unknown error';
-      const errorCode = error?.code ?? 'UNKNOWN';
       const message = 'Unable to update user password in axios request';
-      const specificError = error.response?.data ?? 'Unknown error';
 
-      console.error('%s: %s (status: %s, code: %s) %o', message, errorMessage, status, errorCode, specificError);
+      logUserAuthError(error, message);
+
       return { status: error?.response?.status || 500, data: 'Failed to update user password' };
     });
 

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -498,7 +498,9 @@ const updateUserPassword = async (userId, update, token) => {
 
     return response;
   } catch (error) {
-    console.error('Unable to update user details %o', error);
+    const message = 'Unable to update user password';
+    logUserAuthError(error, message);
+
     return { status: error?.response?.status || 500, data: 'Failed to update user password' };
   }
 };

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -489,7 +489,13 @@ const updateUserPassword = async (userId, update, token) => {
       headers: generateHeadersWithToken(token),
       data: update,
     }).catch((error) => {
-      console.error('Unable to update user details in axios request %o', error);
+      const status = error.response?.status;
+      const errorMessage = error?.message ?? 'Unknown error';
+      const errorCode = error?.code ?? 'UNKNOWN';
+      const message = 'Unable to update user password in axios request';
+      const specificError = error.response?.data ?? 'Unknown error';
+
+      console.error('%s: %s (status: %s, code: %s) %o', message, errorMessage, status, errorCode, specificError);
       return { status: error?.response?.status || 500, data: 'Failed to update user password' };
     });
 

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1,7 +1,7 @@
 const { HANDLE_SSO_REDIRECT_FORM_RESPONSE_SCHEMA } = require('@ukef/dtfs2-common/schemas');
 const axios = require('axios');
-const { HttpStatusCode, logUserAuthError } = require('axios');
-const { HEADERS } = require('@ukef/dtfs2-common');
+const { HttpStatusCode } = require('axios');
+const { HEADERS, logUserAuthError } = require('@ukef/dtfs2-common');
 const { isValidMongoId, isValidPartyUrn, isValidGroupId, isValidTaskId, isValidBankId } = require('./helpers/validateIds');
 const { assertValidIsoMonth, assertValidIsoYear } = require('./helpers/date');
 const PageOutOfBoundsError = require('./errors/page-out-of-bounds.error');


### PR DESCRIPTION
# Introduction :pencil2:

This PR stops passwords being shown in console.errors

## Resolution :heavy_check_mark:

* helper to get relevant details from error object and console.error those
* Update portal-ui controller and tfm-ui api file to use this helper