### PR TITLE
fix(DTFS2-8576): reset otp send count when user reactivated

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/activate-user-reset-otp-send-count.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/activate-user-reset-otp-send-count.spec.js
@@ -25,6 +25,8 @@ context('Admin re-activating a user should reset the sign-in OTP send count', ()
     editUser.Activate().click();
     editUser.save().click();
 
+    cy.clearSessionCookies();
+
     // log back in as the user
     cy.enterUsernameAndPassword(BANK1_MAKER1);
     cy.url().should('eq', relative('/login/check-your-email-access-code'));

--- a/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/activate-user-reset-otp-send-count.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/activate-user-reset-otp-send-count.spec.js
@@ -1,0 +1,33 @@
+const { header, users, editUser, checkYourEmailAccessCode } = require('../../../../../pages');
+const MOCK_USERS = require('../../../../../../../../e2e-fixtures');
+const relative = require('../../../../../relativeURL');
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+const { ADMIN } = MOCK_USERS;
+
+context('Admin re-activating a user should reset the sign-in OTP send count', () => {
+  beforeEach(() => {
+    cy.task('updatePortalUserByUsername', {
+      username: BANK1_MAKER1.username,
+      update: { 'user-status': 'blocked', signInOTPSendCount: 3 },
+    });
+
+    cy.enterUsernameAndPassword(BANK1_MAKER1);
+  });
+
+  it('should show the correct remaining OTP attempts after re-activating a user', () => {
+    // reactivate the user
+    cy.login(ADMIN);
+    header.users().click();
+
+    users.row(BANK1_MAKER1).username().click();
+    editUser.Activate().click();
+    editUser.save().click();
+
+    // log back in as the user
+    cy.enterUsernameAndPassword(BANK1_MAKER1);
+    cy.url().should('eq', relative('/login/check-your-email-access-code'));
+    cy.assertText(checkYourEmailAccessCode.attemptsInfo(), 'You have 2 attempts remaining.');
+  });
+});

--- a/portal-api/server/v1/users/controller.js
+++ b/portal-api/server/v1/users/controller.js
@@ -1,4 +1,4 @@
-const { MONGO_DB_COLLECTIONS, DocumentNotDeletedError, TIMEZONE, generatePasswordHash } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, DocumentNotDeletedError, TIMEZONE, generatePasswordHash, isPortal2FAFeatureFlagEnabled } = require('@ukef/dtfs2-common');
 const { PORTAL_USER } = require('@ukef/dtfs2-common/schemas');
 const { isVerifiedPayload } = require('@ukef/dtfs2-common/payload-verification');
 const { ObjectId } = require('mongodb');
@@ -189,11 +189,20 @@ exports.update = async (_id, update, auditDetails, callback) => {
     if (existingUser['user-status'] === USER.STATUS.BLOCKED && userSetUpdate['user-status'] === USER.STATUS.ACTIVE) {
       // User is being re-activated.
       userSetUpdate.loginFailureCount = 0;
-      userUnsetUpdate = {
-        signInLinkSendDate: '',
-        signInLinkSendCount: '',
-        blockedStatusReason: '',
-      };
+
+      if (isPortal2FAFeatureFlagEnabled()) {
+        userUnsetUpdate = {
+          signInOTPSendDate: 0,
+          signInOTPSendCount: 0,
+          blockedStatusReason: '',
+        };
+      } else {
+        userUnsetUpdate = {
+          signInLinkSendDate: '',
+          signInLinkSendCount: '',
+          blockedStatusReason: '',
+        };
+      }
 
       await sendUnblockedEmail(existingUser.email);
     }

--- a/portal-api/server/v1/users/controller.js
+++ b/portal-api/server/v1/users/controller.js
@@ -190,6 +190,13 @@ exports.update = async (_id, update, auditDetails, callback) => {
       // User is being re-activated.
       userSetUpdate.loginFailureCount = 0;
 
+      /**
+       * if 2FA is enabled,
+       * reset the signInOTPSendCount and signInOTPSendDate to 0
+       * if 2FA is not enabled,
+       * reset the signInLinkSendCount and signInLinkSendDate to ''
+       * reset the blockedStatusReason to ''
+       */
       if (isPortal2FAFeatureFlagEnabled()) {
         userUnsetUpdate = {
           signInOTPSendDate: 0,

--- a/portal-api/server/v1/users/controller.test.js
+++ b/portal-api/server/v1/users/controller.test.js
@@ -10,12 +10,12 @@ jest.mock('@ukef/dtfs2-common', () => ({
 
 const { ObjectId } = require('mongodb');
 const { when, resetAllWhenMocks } = require('jest-when');
+const { isPortal2FAFeatureFlagEnabled } = require('@ukef/dtfs2-common');
 const { generateNoUserLoggedInAuditDetails, generatePortalAuditDetails } = require('@ukef/dtfs2-common/change-stream');
 const { generateMockNoUserLoggedInAuditDatabaseRecord } = require('@ukef/dtfs2-common/change-stream/test-helpers');
 const { isVerifiedPayload } = require('@ukef/dtfs2-common/payload-verification');
 const { mongoDbClient: db } = require('../../drivers/db-client');
 const { updateSessionIdentifier, createPasswordToken, create, update } = require('./controller');
-const { isPortal2FAFeatureFlagEnabled } = require('@ukef/dtfs2-common');
 const { TEST_USER, TEST_DATABASE_USER, TEST_USER_SANITISED_FOR_FRONTEND } = require('../../../test-helpers/unit-test-mocks/mock-user');
 const { STATUS } = require('../../constants/user');
 const { InvalidUserIdError } = require('../errors');
@@ -144,7 +144,12 @@ describe('user controller', () => {
     }
 
     describe('when reactivating a blocked user', () => {
-      const BLOCKED_DATABASE_USER = { ...TEST_DATABASE_USER, 'user-status': STATUS.BLOCKED, blockedStatusReason: 'Too many invalid password entries', loginFailureCount: 3 };
+      const BLOCKED_DATABASE_USER = {
+        ...TEST_DATABASE_USER,
+        'user-status': STATUS.BLOCKED,
+        blockedStatusReason: 'Too many invalid password entries',
+        loginFailureCount: 3,
+      };
       const reactivationUpdate = { 'user-status': STATUS.ACTIVE };
       let mockFindOneAndUpdate;
 
@@ -165,7 +170,9 @@ describe('user controller', () => {
         isVerifiedPayload.mockReturnValue(true);
 
         // Act
-        await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
+        await new Promise((resolve) => {
+          update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve);
+        });
 
         // Assert
         expect(sendEmail).toHaveBeenCalledWith(CONSTANTS.EMAIL_TEMPLATE_IDS.UNBLOCKED, BLOCKED_DATABASE_USER.email, {});
@@ -176,7 +183,9 @@ describe('user controller', () => {
         isVerifiedPayload.mockReturnValue(true);
 
         // Act
-        await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
+        await new Promise((resolve) => {
+          update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve);
+        });
 
         // Assert
         expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
@@ -196,10 +205,13 @@ describe('user controller', () => {
           isVerifiedPayload.mockReturnValue(true);
 
           // Act
-          await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
-          
+          await new Promise((resolve) => {
+            update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve);
+          });
+
           // Assert
-          const expected = [expect.anything(),
+          const expected = [
+            expect.anything(),
             expect.objectContaining({
               $unset: {
                 signInLinkSendDate: '',
@@ -207,7 +219,8 @@ describe('user controller', () => {
                 blockedStatusReason: '',
               },
             }),
-            expect.anything(),]
+            expect.anything(),
+          ];
 
           expect(mockFindOneAndUpdate).toHaveBeenCalledWith(...expected);
         });
@@ -223,10 +236,13 @@ describe('user controller', () => {
           isVerifiedPayload.mockReturnValue(true);
 
           // Act
-          await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
+          await new Promise((resolve) => {
+            update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve);
+          });
 
           // Assert
-          const expected = [expect.anything(),
+          const expected = [
+            expect.anything(),
             expect.objectContaining({
               $unset: {
                 signInOTPSendDate: 0,
@@ -234,7 +250,8 @@ describe('user controller', () => {
                 blockedStatusReason: '',
               },
             }),
-            expect.anything(),];
+            expect.anything(),
+          ];
 
           expect(mockFindOneAndUpdate).toHaveBeenCalledWith(...expected);
         });

--- a/portal-api/server/v1/users/controller.test.js
+++ b/portal-api/server/v1/users/controller.test.js
@@ -3,6 +3,10 @@ jest.mock('./sanitizeUserData');
 jest.mock('../email');
 jest.mock('@ukef/dtfs2-common/payload-verification');
 jest.mock('../../crypto/utils');
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  isPortal2FAFeatureFlagEnabled: jest.fn(),
+}));
 
 const { ObjectId } = require('mongodb');
 const { when, resetAllWhenMocks } = require('jest-when');
@@ -11,11 +15,14 @@ const { generateMockNoUserLoggedInAuditDatabaseRecord } = require('@ukef/dtfs2-c
 const { isVerifiedPayload } = require('@ukef/dtfs2-common/payload-verification');
 const { mongoDbClient: db } = require('../../drivers/db-client');
 const { updateSessionIdentifier, createPasswordToken, create, update } = require('./controller');
+const { isPortal2FAFeatureFlagEnabled } = require('@ukef/dtfs2-common');
 const { TEST_USER, TEST_DATABASE_USER, TEST_USER_SANITISED_FOR_FRONTEND } = require('../../../test-helpers/unit-test-mocks/mock-user');
+const { STATUS } = require('../../constants/user');
 const { InvalidUserIdError } = require('../errors');
 const InvalidSessionIdentifierError = require('../errors/invalid-session-identifier.error');
 const { sanitizeUser } = require('./sanitizeUserData');
 const sendEmail = require('../email');
+const CONSTANTS = require('../../constants');
 
 const MOCK_EMAIL = 'mockEmail';
 const utils = require('../../crypto/utils');
@@ -126,6 +133,7 @@ describe('user controller', () => {
 
     function givenEverythingElseSucceeds() {
       sendEmail.mockResolvedValue({});
+      isPortal2FAFeatureFlagEnabled.mockReturnValue(false);
       when(db.getCollection)
         .calledWith('users')
         .mockResolvedValue({
@@ -134,6 +142,104 @@ describe('user controller', () => {
           findOneAndUpdate: jest.fn().mockResolvedValue(TEST_DATABASE_USER),
         });
     }
+
+    describe('when reactivating a blocked user', () => {
+      const BLOCKED_DATABASE_USER = { ...TEST_DATABASE_USER, 'user-status': STATUS.BLOCKED, blockedStatusReason: 'Too many invalid password entries', loginFailureCount: 3 };
+      const reactivationUpdate = { 'user-status': STATUS.ACTIVE };
+      let mockFindOneAndUpdate;
+
+      beforeEach(() => {
+        jest.resetAllMocks();
+        resetAllWhenMocks();
+        sendEmail.mockResolvedValue({});
+        isPortal2FAFeatureFlagEnabled.mockReturnValue(false);
+        mockFindOneAndUpdate = jest.fn().mockResolvedValue(BLOCKED_DATABASE_USER);
+        db.getCollection.mockResolvedValue({
+          findOne: jest.fn().mockImplementation(async (id, findOneCallback) => await findOneCallback(null, BLOCKED_DATABASE_USER)),
+          findOneAndUpdate: mockFindOneAndUpdate,
+        });
+      });
+
+      it('should send an unblocked email to the user', async () => {
+        // Arrange
+        isVerifiedPayload.mockReturnValue(true);
+
+        // Act
+        await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
+
+        // Assert
+        expect(sendEmail).toHaveBeenCalledWith(CONSTANTS.EMAIL_TEMPLATE_IDS.UNBLOCKED, BLOCKED_DATABASE_USER.email, {});
+      });
+
+      it('should reset loginFailureCount to 0', async () => {
+        // Arrange
+        isVerifiedPayload.mockReturnValue(true);
+
+        // Act
+        await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
+
+        // Assert
+        expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ $set: expect.objectContaining({ loginFailureCount: 0 }) }),
+          expect.anything(),
+        );
+      });
+
+      describe('when the portal 2FA feature flag is disabled', () => {
+        beforeEach(() => {
+          isPortal2FAFeatureFlagEnabled.mockReturnValue(false);
+        });
+
+        it('should unset signInLinkSendDate, signInLinkSendCount, and blockedStatusReason', async () => {
+          // Arrange
+          isVerifiedPayload.mockReturnValue(true);
+
+          // Act
+          await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
+          
+          // Assert
+          const expected = [expect.anything(),
+            expect.objectContaining({
+              $unset: {
+                signInLinkSendDate: '',
+                signInLinkSendCount: '',
+                blockedStatusReason: '',
+              },
+            }),
+            expect.anything(),]
+
+          expect(mockFindOneAndUpdate).toHaveBeenCalledWith(...expected);
+        });
+      });
+
+      describe('when the portal 2FA feature flag is enabled', () => {
+        beforeEach(() => {
+          isPortal2FAFeatureFlagEnabled.mockReturnValue(true);
+        });
+
+        it('should unset signInOTPSendDate, signInOTPSendCount, and blockedStatusReason', async () => {
+          // Arrange
+          isVerifiedPayload.mockReturnValue(true);
+
+          // Act
+          await new Promise((resolve) => update(TEST_DATABASE_USER._id, reactivationUpdate, generatePortalAuditDetails(new ObjectId()), resolve));
+
+          // Assert
+          const expected = [expect.anything(),
+            expect.objectContaining({
+              $unset: {
+                signInOTPSendDate: 0,
+                signInOTPSendCount: 0,
+                blockedStatusReason: '',
+              },
+            }),
+            expect.anything(),];
+
+          expect(mockFindOneAndUpdate).toHaveBeenCalledWith(...expected);
+        });
+      });
+    });
   });
 
   function withValidationTests({ givenEverythingElseSucceeds, makeRequest, successResult }) {


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes an issue where a user's sign in OTP send count is not reset when user is reactivated by an admin

## Resolution :heavy_check_mark:

* Added to update users controller in portal-api to reset otp send count if FF is set
* Added unit test
* Added e2e test
