### PR TITLE
fix(DTFS2-8578): fix account not being blocked when otp send count is above 3

### DIFF
--- a/dtfs-central-api/server/helpers/portal-2fa/increment-sign-in-otp-sent-count.test.ts
+++ b/dtfs-central-api/server/helpers/portal-2fa/increment-sign-in-otp-sent-count.test.ts
@@ -1,0 +1,441 @@
+import { OTP, AuditDetails, STATUS_BLOCKED_REASON } from '@ukef/dtfs2-common';
+import { incrementSignInOTPSendCount } from './increment-sign-in-otp-sent-count';
+import { PortalUsersRepo } from '../../repositories/users-repo';
+
+jest.mock('@ukef/dtfs2-common/change-stream');
+
+const { generateSystemAuditDetails } = jest.requireActual<{ generateSystemAuditDetails: () => AuditDetails }>('@ukef/dtfs2-common/change-stream');
+
+jest.mock('../../repositories/users-repo');
+
+describe('incrementSignInOTPSendCount', () => {
+  const mockResetSignInData = jest.fn();
+  const mockIncrementSignInOTPSendCount = jest.fn();
+  const mockSetSignInOTPSendDate = jest.fn();
+  const mockBlockUser = jest.fn();
+
+  beforeEach(() => {
+    mockResetSignInData.mockReset();
+    mockIncrementSignInOTPSendCount.mockReset();
+    mockSetSignInOTPSendDate.mockReset();
+    mockBlockUser.mockReset();
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    PortalUsersRepo.resetSignInData = mockResetSignInData;
+    PortalUsersRepo.incrementSignInOTPSendCount = mockIncrementSignInOTPSendCount;
+    PortalUsersRepo.setSignInOTPSendDate = mockSetSignInOTPSendDate;
+    PortalUsersRepo.blockUser = mockBlockUser;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('when sign in data is stale and incrementSignInOTPSendCount returns 1', () => {
+    beforeEach(() => {
+      mockResetSignInData.mockResolvedValue(null);
+      mockIncrementSignInOTPSendCount.mockResolvedValue(1);
+      mockSetSignInOTPSendDate.mockResolvedValue(null);
+    });
+
+    const variables = {
+      userId: 'user-id',
+      signInOTPSendDate: new Date(Date.now() - OTP.TIME_TO_RESET_SIGN_IN_OTP_SEND_COUNT_IN_MILLISECONDS - 1000),
+      auditDetails: generateSystemAuditDetails(),
+    };
+
+    it('should call PortalUsersRepo.resetSignInData', async () => {
+      // Act
+      await incrementSignInOTPSendCount(variables);
+
+      // Assert
+      expect(mockResetSignInData).toHaveBeenCalledTimes(1);
+      expect(mockResetSignInData).toHaveBeenCalledWith(variables);
+    });
+
+    it('should call PortalUsersRepo.incrementSignInOTPSendCount', async () => {
+      // Act
+      await incrementSignInOTPSendCount(variables);
+
+      // Assert
+      expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
+      expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+    });
+
+    it('should call PortalUsersRepo.setSignInOTPSendDate', async () => {
+      // Act
+      await incrementSignInOTPSendCount(variables);
+
+      // Assert
+      expect(mockSetSignInOTPSendDate).toHaveBeenCalledTimes(1);
+      expect(mockSetSignInOTPSendDate).toHaveBeenCalledWith({ userId: variables.userId, auditDetails: variables.auditDetails });
+    });
+
+    it('should return the correct number of remaining attempts', async () => {
+      // Act
+      const remainingAttempts = await incrementSignInOTPSendCount(variables);
+
+      // Assert
+      expect(remainingAttempts).toEqual(OTP.MAX_SIGN_IN_ATTEMPTS - 1);
+    });
+
+    it('should not call PortalUsersRepo.blockUser', async () => {
+      // Act
+      await incrementSignInOTPSendCount(variables);
+
+      // Assert
+      expect(mockBlockUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when sign in data is not stale', () => {
+    describe('when incrementSignInOTPSendCount returns 1', () => {
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(1);
+        mockSetSignInOTPSendDate.mockResolvedValue(null);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should not call PortalUsersRepo.resetSignInData', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockResetSignInData).not.toHaveBeenCalled();
+      });
+
+      it('should call PortalUsersRepo.incrementSignInOTPSendCount', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+      });
+
+      it('should call PortalUsersRepo.setSignInOTPSendDate', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockSetSignInOTPSendDate).toHaveBeenCalledTimes(1);
+        expect(mockSetSignInOTPSendDate).toHaveBeenCalledWith({ userId: variables.userId, auditDetails: variables.auditDetails });
+      });
+
+      it('should return the correct number of remaining attempts', async () => {
+        // Act
+        const remainingAttempts = await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(remainingAttempts).toEqual(OTP.MAX_SIGN_IN_ATTEMPTS - 1);
+      });
+
+      it('should not call PortalUsersRepo.blockUser', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockBlockUser).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when incrementSignInOTPSendCount returns 2', () => {
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(2);
+        mockSetSignInOTPSendDate.mockResolvedValue(null);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should not call PortalUsersRepo.resetSignInData', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockResetSignInData).not.toHaveBeenCalled();
+      });
+
+      it('should call PortalUsersRepo.incrementSignInOTPSendCount', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+      });
+
+      it('should not call PortalUsersRepo.setSignInOTPSendDate', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockSetSignInOTPSendDate).not.toHaveBeenCalled();
+      });
+
+      it('should return the correct number of remaining attempts', async () => {
+        // Act
+        const remainingAttempts = await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(remainingAttempts).toEqual(OTP.MAX_SIGN_IN_ATTEMPTS - 2);
+      });
+
+      it('should not call PortalUsersRepo.blockUser', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockBlockUser).not.toHaveBeenCalled();
+      });
+    });
+
+    const remainingAttemptsCount = 3;
+
+    describe(`when incrementSignInOTPSendCount returns ${remainingAttemptsCount}`, () => {
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(remainingAttemptsCount);
+        mockSetSignInOTPSendDate.mockResolvedValue(null);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should not call PortalUsersRepo.resetSignInData', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockResetSignInData).not.toHaveBeenCalled();
+      });
+
+      it('should call PortalUsersRepo.incrementSignInOTPSendCount', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+      });
+
+      it('should not call PortalUsersRepo.setSignInOTPSendDate', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockSetSignInOTPSendDate).not.toHaveBeenCalled();
+      });
+
+      it('should return the correct number of remaining attempts', async () => {
+        // Act
+        const remainingAttempts = await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(remainingAttempts).toEqual(OTP.MAX_SIGN_IN_ATTEMPTS - remainingAttemptsCount);
+      });
+
+      it('should not call PortalUsersRepo.blockUser', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockBlockUser).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when incrementSignInOTPSendCount returns more than the maximum allowed attempts', () => {
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(OTP.MAX_SIGN_IN_ATTEMPTS + 1);
+        mockSetSignInOTPSendDate.mockResolvedValue(null);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should call PortalUsersRepo.blockUser', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockBlockUser).toHaveBeenCalledTimes(1);
+        expect(mockBlockUser).toHaveBeenCalledWith({
+          userId: variables.userId,
+          reason: STATUS_BLOCKED_REASON.EXCESSIVE_SIGN_IN_OTPS,
+          auditDetails: variables.auditDetails,
+        });
+      });
+    });
+
+    describe('when incrementSignInOTPSendCount returns a large number above the maximum allowed attempts', () => {
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(OTP.MAX_SIGN_IN_ATTEMPTS + 15);
+        mockSetSignInOTPSendDate.mockResolvedValue(null);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should call PortalUsersRepo.blockUser', async () => {
+        // Act
+        await incrementSignInOTPSendCount(variables);
+
+        // Assert
+        expect(mockBlockUser).toHaveBeenCalledTimes(1);
+        expect(mockBlockUser).toHaveBeenCalledWith({
+          userId: variables.userId,
+          reason: STATUS_BLOCKED_REASON.EXCESSIVE_SIGN_IN_OTPS,
+          auditDetails: variables.auditDetails,
+        });
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    describe('when PortalUsersRepo.incrementSignInOTPSendCount throws an error', () => {
+      const mockError = new Error('Database error');
+
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockRejectedValue(mockError);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should log the error and throw a new error', async () => {
+        // Act
+        await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
+
+        // Assert
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+      });
+    });
+
+    describe('when PortalUsersRepo.incrementSignInOTPSendCount returns null', () => {
+      const mockError = new Error('Failed to increment sign in OTP send count');
+
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(null);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should log the error and throw a new error', async () => {
+        // Act
+        await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
+
+        // Assert
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+      });
+    });
+
+    describe('when PortalUsersRepo.resetSignInData throws an error', () => {
+      const mockError = new Error('Database error');
+
+      beforeEach(() => {
+        mockResetSignInData.mockRejectedValue(mockError);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(Date.now() - OTP.TIME_TO_RESET_SIGN_IN_OTP_SEND_COUNT_IN_MILLISECONDS - 1000),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should log the error and throw a new error', async () => {
+        // Act
+        await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
+
+        // Assert
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+      });
+    });
+
+    describe('when PortalUsersRepo.setSignInOTPSendDate throws an error', () => {
+      const mockError = new Error('Database error');
+
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(1);
+        mockSetSignInOTPSendDate.mockRejectedValue(mockError);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should log the error and throw a new error', async () => {
+        // Act
+        await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
+
+        // Assert
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+      });
+    });
+
+    describe('when PortalUsersRepo.blockUser throws an error', () => {
+      const mockError = new Error('Database error');
+
+      beforeEach(() => {
+        mockResetSignInData.mockResolvedValue(null);
+        mockIncrementSignInOTPSendCount.mockResolvedValue(OTP.MAX_SIGN_IN_ATTEMPTS + 1);
+        mockSetSignInOTPSendDate.mockResolvedValue(null);
+        mockBlockUser.mockRejectedValue(mockError);
+      });
+
+      const variables = {
+        userId: 'user-id',
+        signInOTPSendDate: new Date(),
+        auditDetails: generateSystemAuditDetails(),
+      };
+
+      it('should log the error and throw a new error', async () => {
+        // Act
+        await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
+
+        // Assert
+        expect(console.error).toHaveBeenCalledTimes(1);
+        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+      });
+    });
+  });
+});

--- a/dtfs-central-api/server/helpers/portal-2fa/increment-sign-in-otp-sent-count.test.ts
+++ b/dtfs-central-api/server/helpers/portal-2fa/increment-sign-in-otp-sent-count.test.ts
@@ -52,8 +52,7 @@ describe('incrementSignInOTPSendCount', () => {
       await incrementSignInOTPSendCount(variables);
 
       // Assert
-      expect(mockResetSignInData).toHaveBeenCalledTimes(1);
-      expect(mockResetSignInData).toHaveBeenCalledWith(variables);
+      expect(mockResetSignInData).toHaveBeenNthCalledWith(1, variables);
     });
 
     it('should call PortalUsersRepo.incrementSignInOTPSendCount', async () => {
@@ -61,8 +60,7 @@ describe('incrementSignInOTPSendCount', () => {
       await incrementSignInOTPSendCount(variables);
 
       // Assert
-      expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
-      expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+      expect(mockIncrementSignInOTPSendCount).toHaveBeenNthCalledWith(1, variables.userId, variables.auditDetails);
     });
 
     it('should call PortalUsersRepo.setSignInOTPSendDate', async () => {
@@ -70,8 +68,7 @@ describe('incrementSignInOTPSendCount', () => {
       await incrementSignInOTPSendCount(variables);
 
       // Assert
-      expect(mockSetSignInOTPSendDate).toHaveBeenCalledTimes(1);
-      expect(mockSetSignInOTPSendDate).toHaveBeenCalledWith({ userId: variables.userId, auditDetails: variables.auditDetails });
+      expect(mockSetSignInOTPSendDate).toHaveBeenNthCalledWith(1, { userId: variables.userId, auditDetails: variables.auditDetails });
     });
 
     it('should return the correct number of remaining attempts', async () => {
@@ -118,8 +115,7 @@ describe('incrementSignInOTPSendCount', () => {
         await incrementSignInOTPSendCount(variables);
 
         // Assert
-        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
-        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenNthCalledWith(1, variables.userId, variables.auditDetails);
       });
 
       it('should call PortalUsersRepo.setSignInOTPSendDate', async () => {
@@ -127,8 +123,7 @@ describe('incrementSignInOTPSendCount', () => {
         await incrementSignInOTPSendCount(variables);
 
         // Assert
-        expect(mockSetSignInOTPSendDate).toHaveBeenCalledTimes(1);
-        expect(mockSetSignInOTPSendDate).toHaveBeenCalledWith({ userId: variables.userId, auditDetails: variables.auditDetails });
+        expect(mockSetSignInOTPSendDate).toHaveBeenNthCalledWith(1, { userId: variables.userId, auditDetails: variables.auditDetails });
       });
 
       it('should return the correct number of remaining attempts', async () => {
@@ -174,8 +169,7 @@ describe('incrementSignInOTPSendCount', () => {
         await incrementSignInOTPSendCount(variables);
 
         // Assert
-        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
-        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenNthCalledWith(1, variables.userId, variables.auditDetails);
       });
 
       it('should not call PortalUsersRepo.setSignInOTPSendDate', async () => {
@@ -231,8 +225,7 @@ describe('incrementSignInOTPSendCount', () => {
         await incrementSignInOTPSendCount(variables);
 
         // Assert
-        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledTimes(1);
-        expect(mockIncrementSignInOTPSendCount).toHaveBeenCalledWith(variables.userId, variables.auditDetails);
+        expect(mockIncrementSignInOTPSendCount).toHaveBeenNthCalledWith(1, variables.userId, variables.auditDetails);
       });
 
       it('should not call PortalUsersRepo.setSignInOTPSendDate', async () => {
@@ -278,8 +271,7 @@ describe('incrementSignInOTPSendCount', () => {
         await incrementSignInOTPSendCount(variables);
 
         // Assert
-        expect(mockBlockUser).toHaveBeenCalledTimes(1);
-        expect(mockBlockUser).toHaveBeenCalledWith({
+        expect(mockBlockUser).toHaveBeenNthCalledWith(1, {
           userId: variables.userId,
           reason: STATUS_BLOCKED_REASON.EXCESSIVE_SIGN_IN_OTPS,
           auditDetails: variables.auditDetails,
@@ -305,8 +297,7 @@ describe('incrementSignInOTPSendCount', () => {
         await incrementSignInOTPSendCount(variables);
 
         // Assert
-        expect(mockBlockUser).toHaveBeenCalledTimes(1);
-        expect(mockBlockUser).toHaveBeenCalledWith({
+        expect(mockBlockUser).toHaveBeenNthCalledWith(1, {
           userId: variables.userId,
           reason: STATUS_BLOCKED_REASON.EXCESSIVE_SIGN_IN_OTPS,
           auditDetails: variables.auditDetails,
@@ -335,8 +326,7 @@ describe('incrementSignInOTPSendCount', () => {
         await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
 
         // Assert
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+        expect(console.error).toHaveBeenNthCalledWith(1, 'Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
       });
     });
 
@@ -359,8 +349,7 @@ describe('incrementSignInOTPSendCount', () => {
         await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
 
         // Assert
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+        expect(console.error).toHaveBeenNthCalledWith(1, 'Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
       });
     });
 
@@ -382,8 +371,7 @@ describe('incrementSignInOTPSendCount', () => {
         await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
 
         // Assert
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+        expect(console.error).toHaveBeenNthCalledWith(1, 'Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
       });
     });
 
@@ -407,8 +395,7 @@ describe('incrementSignInOTPSendCount', () => {
         await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
 
         // Assert
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+        expect(console.error).toHaveBeenNthCalledWith(1, 'Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
       });
     });
 
@@ -433,8 +420,7 @@ describe('incrementSignInOTPSendCount', () => {
         await expect(incrementSignInOTPSendCount(variables)).rejects.toThrow('Error incrementing sign in OTP send count');
 
         // Assert
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
+        expect(console.error).toHaveBeenNthCalledWith(1, 'Error incrementing sign in OTP send count for user %s: %o', variables.userId, mockError);
       });
     });
   });

--- a/dtfs-central-api/server/helpers/portal-2fa/increment-sign-in-otp-sent-count.ts
+++ b/dtfs-central-api/server/helpers/portal-2fa/increment-sign-in-otp-sent-count.ts
@@ -50,9 +50,9 @@ export const incrementSignInOTPSendCount = async ({ userId, signInOTPSendDate, a
     /*
      * If the user is past their last attempt, block the user
      * This is because the signInOTPSendCount is greater than the max allowed attempts
-     * and hence the remaining attempts will be -1
+     * and hence the remaining attempts will be -1 or lower
      */
-    if (remainingAttempts === -1) {
+    if (remainingAttempts <= -1) {
       console.info('User %s has exceeded maximum sign in OTP send attempts, blocking user', userId);
       await PortalUsersRepo.blockUser({ userId, reason: STATUS_BLOCKED_REASON.EXCESSIVE_SIGN_IN_OTPS, auditDetails });
     }

--- a/dtfs-central-api/server/v1/controllers/portal/login/create-and-email-sign-in-otp.ts
+++ b/dtfs-central-api/server/v1/controllers/portal/login/create-and-email-sign-in-otp.ts
@@ -2,7 +2,7 @@ import { HttpStatusCode } from 'axios';
 import { Response } from 'express';
 import { CustomExpressRequest, AuditDetails, PortalUser, isProduction } from '@ukef/dtfs2-common';
 import { isUserBlockedOrDisabled } from '../../../../helpers/portal-2fa/is-user-blocked-or-disabled';
-import { incrementSignInOTPSendCount } from '../../../../helpers/portal-2fa/increment-sign-in-opt-sent-count';
+import { incrementSignInOTPSendCount } from '../../../../helpers/portal-2fa/increment-sign-in-otp-sent-count';
 import { generateOtp } from '../../../../helpers/portal-2fa/generate-otp';
 import { PortalUsersRepo } from '../../../../repositories/users-repo';
 import { sendSignInOtpEmail } from '../../../../helpers/portal-2fa/send-sign-in-otp-email';
@@ -45,7 +45,12 @@ export const createAndEmailSignInOTP = async (req: CustomExpressRequest<{ reqBod
 
     const signInOTPSendCount = await incrementSignInOTPSendCount({ userId, signInOTPSendDate, auditDetails });
 
-    if (signInOTPSendCount === -1) {
+    /**
+     * If the user has exceeded the maximum sign in OTP send attempts,
+     * then their signInOTPSendCount will be -1 or lower
+     * send an account suspension email and return a response indicating that the account is suspended.
+     */
+    if (signInOTPSendCount <= -1) {
       console.info('User %s account suspended due to excessive OTP requests, sending suspension email', sanitisedUserId);
       try {
         await sendAccountSuspensionEmail(user);

--- a/dtfs-central-api/server/v1/controllers/portal/login/create-and-email-sign-in-otp.ts
+++ b/dtfs-central-api/server/v1/controllers/portal/login/create-and-email-sign-in-otp.ts
@@ -47,8 +47,8 @@ export const createAndEmailSignInOTP = async (req: CustomExpressRequest<{ reqBod
 
     /**
      * If the user has exceeded the maximum sign in OTP send attempts,
-     * then their signInOTPSendCount will be -1 or lower
-     * send an account suspension email and return a response indicating that the account is suspended.
+     * then the remaining attempts returned here will be -1 or lower.
+     * Send an account suspension email and return a response indicating that the account is suspended.
      */
     if (signInOTPSendCount <= -1) {
       console.info('User %s account suspended due to excessive OTP requests, sending suspension email', sanitisedUserId);

--- a/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/account-suspension.journey.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/account-suspension.journey.spec.js
@@ -110,4 +110,20 @@ context('Portal 2FA Journey - Account suspension - too many access-code resend/r
       });
     });
   });
+
+  describe('when a user has more than the maximum allowed attempts', () => {
+    beforeEach(() => {
+      cy.task('updatePortalUserByUsername', {
+        username: BANK1_MAKER1.username,
+        update: { 'user-status': 'blocked', signInOTPSendCount: 15 },
+      });
+
+      cy.enterUsernameAndPassword(BANK1_MAKER1);
+    });
+
+    it('should show the suspension page when the user has more than the maximum allowed attempts', () => {
+      cy.url().should('eq', relative('/login/temporarily-suspended-access-code'));
+      cy.assertText(temporarilySuspendedAccessCode.heading(), 'This account has been temporarily suspended');
+    });
+  });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/activate-user-reset-otp-send-count.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/feature-flag-enabled/login/2fa/journeys/activate-user-reset-otp-send-count.spec.js
@@ -10,7 +10,7 @@ context('Admin re-activating a user should reset the sign-in OTP send count', ()
   beforeEach(() => {
     cy.task('updatePortalUserByUsername', {
       username: BANK1_MAKER1.username,
-      update: { 'user-status': 'blocked', signInOTPSendCount: 3 },
+      update: { 'user-status': 'active', signInOTPSendCount: 3 },
     });
 
     cy.enterUsernameAndPassword(BANK1_MAKER1);


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes an issue where if the otp send count is above 3, then the user is not blocked and redirected back to the login page

## Resolution :heavy_check_mark:

* Change signInOTPSendCount from === -1 to <= -1 so any number above 3 is caught
* Added tests
* Added e2e scenario

Tech debt to review signInOTPSendCount in https://ukef-dtfs.atlassian.net/browse/DTFS2-8582

